### PR TITLE
Fix mobile border calculator slider crash

### DIFF
--- a/apps/dorkroom/src/app/components/border-calculator/mobile-border-calculator.tsx
+++ b/apps/dorkroom/src/app/components/border-calculator/mobile-border-calculator.tsx
@@ -71,14 +71,17 @@ export function MobileBorderCalculator({
     setCustomPaperHeight,
     minBorder,
     setMinBorder,
+    setMinBorderSlider,
     enableOffset,
     setEnableOffset,
     ignoreMinBorder,
     setIgnoreMinBorder,
     horizontalOffset,
     setHorizontalOffset,
+    setHorizontalOffsetSlider,
     verticalOffset,
     setVerticalOffset,
+    setVerticalOffsetSlider,
     showBlades,
     setShowBlades,
     isLandscape,
@@ -303,6 +306,7 @@ export function MobileBorderCalculator({
                   onClose={closeDrawer}
                   minBorder={minBorder}
                   setMinBorder={setMinBorder}
+                  setMinBorderSlider={setMinBorderSlider}
                   minBorderWarning={minBorderWarning || undefined}
                 />
               )}
@@ -316,8 +320,10 @@ export function MobileBorderCalculator({
                   setIgnoreMinBorder={setIgnoreMinBorder}
                   horizontalOffset={horizontalOffset}
                   setHorizontalOffset={setHorizontalOffset}
+                  setHorizontalOffsetSlider={setHorizontalOffsetSlider}
                   verticalOffset={verticalOffset}
                   setVerticalOffset={setVerticalOffset}
+                  setVerticalOffsetSlider={setVerticalOffsetSlider}
                   offsetWarning={offsetWarning || undefined}
                 />
               )}

--- a/apps/dorkroom/src/app/components/border-calculator/sections/border-size-section.tsx
+++ b/apps/dorkroom/src/app/components/border-calculator/sections/border-size-section.tsx
@@ -12,6 +12,7 @@ interface BorderSizeSectionProps {
   onClose: () => void;
   minBorder: number;
   setMinBorder: (value: number) => void;
+  setMinBorderSlider: (value: number) => void;
   minBorderWarning?: string;
 }
 
@@ -19,6 +20,7 @@ export function BorderSizeSection({
   onClose,
   minBorder,
   setMinBorder,
+  setMinBorderSlider,
   minBorderWarning,
 }: BorderSizeSectionProps) {
   return (
@@ -38,7 +40,7 @@ export function BorderSizeSection({
           label="Minimum Border (inches):"
           value={minBorder}
           onChange={setMinBorder}
-          onSliderChange={setMinBorder}
+          onSliderChange={setMinBorderSlider}
           min={SLIDER_MIN_BORDER}
           max={SLIDER_MAX_BORDER}
           step={SLIDER_STEP_BORDER}

--- a/apps/dorkroom/src/app/components/border-calculator/sections/position-offsets-section.tsx
+++ b/apps/dorkroom/src/app/components/border-calculator/sections/position-offsets-section.tsx
@@ -17,8 +17,10 @@ interface PositionOffsetsSectionProps {
   setIgnoreMinBorder: (value: boolean) => void;
   horizontalOffset: number;
   setHorizontalOffset: (value: number) => void;
+  setHorizontalOffsetSlider: (value: number) => void;
   verticalOffset: number;
   setVerticalOffset: (value: number) => void;
+  setVerticalOffsetSlider: (value: number) => void;
   offsetWarning?: string;
 }
 
@@ -30,8 +32,10 @@ export function PositionOffsetsSection({
   setIgnoreMinBorder,
   horizontalOffset,
   setHorizontalOffset,
+  setHorizontalOffsetSlider,
   verticalOffset,
   setVerticalOffset,
+  setVerticalOffsetSlider,
   offsetWarning,
 }: PositionOffsetsSectionProps) {
   return (
@@ -72,7 +76,7 @@ export function PositionOffsetsSection({
                 label="Horizontal Offset:"
                 value={horizontalOffset}
                 onChange={setHorizontalOffset}
-                onSliderChange={setHorizontalOffset}
+                onSliderChange={setHorizontalOffsetSlider}
                 min={OFFSET_SLIDER_MIN}
                 max={OFFSET_SLIDER_MAX}
                 step={OFFSET_SLIDER_STEP}
@@ -85,7 +89,7 @@ export function PositionOffsetsSection({
                 label="Vertical Offset:"
                 value={verticalOffset}
                 onChange={setVerticalOffset}
-                onSliderChange={setVerticalOffset}
+                onSliderChange={setVerticalOffsetSlider}
                 min={OFFSET_SLIDER_MIN}
                 max={OFFSET_SLIDER_MAX}
                 step={OFFSET_SLIDER_STEP}

--- a/apps/dorkroom/src/app/components/ui/labeled-slider-input.tsx
+++ b/apps/dorkroom/src/app/components/ui/labeled-slider-input.tsx
@@ -29,10 +29,13 @@ export function LabeledSliderInput({
 }: LabeledSliderInputProps) {
   const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = parseFloat(e.target.value);
-    if (continuousUpdate) {
+    if (onSliderChange) {
+      // Prefer dedicated slider handler to avoid routing through text-input logic
+      onSliderChange(newValue);
+    } else {
+      // Fallback: if no slider-specific handler provided, use onChange
       onChange(newValue);
     }
-    onSliderChange?.(newValue);
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Fix mobile border calculator crashes by ensuring slider inputs directly update numeric state.

The previous implementation could pass transient string values from slider input events to numeric state setters, leading to crashes on mobile devices. This change introduces dedicated slider-specific handlers that bypass the general input change logic, ensuring only validated numeric values update the state during continuous slider interaction.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5dbb944-4a65-4e09-8498-c4d461301f0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e5dbb944-4a65-4e09-8498-c4d461301f0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

