### PR TITLE
Fix mobile border calculator slider crash

### DIFF
--- a/apps/dorkroom/src/app/components/border-calculator/mobile-border-calculator.tsx
+++ b/apps/dorkroom/src/app/components/border-calculator/mobile-border-calculator.tsx
@@ -71,14 +71,17 @@ export function MobileBorderCalculator({
     setCustomPaperHeight,
     minBorder,
     setMinBorder,
+    setMinBorderSlider,
     enableOffset,
     setEnableOffset,
     ignoreMinBorder,
     setIgnoreMinBorder,
     horizontalOffset,
     setHorizontalOffset,
+    setHorizontalOffsetSlider,
     verticalOffset,
     setVerticalOffset,
+    setVerticalOffsetSlider,
     showBlades,
     setShowBlades,
     isLandscape,
@@ -303,6 +306,7 @@ export function MobileBorderCalculator({
                   onClose={closeDrawer}
                   minBorder={minBorder}
                   setMinBorder={setMinBorder}
+                  setMinBorderSlider={setMinBorderSlider}
                   minBorderWarning={minBorderWarning || undefined}
                 />
               )}
@@ -316,8 +320,10 @@ export function MobileBorderCalculator({
                   setIgnoreMinBorder={setIgnoreMinBorder}
                   horizontalOffset={horizontalOffset}
                   setHorizontalOffset={setHorizontalOffset}
+                  setHorizontalOffsetSlider={setHorizontalOffsetSlider}
                   verticalOffset={verticalOffset}
                   setVerticalOffset={setVerticalOffset}
+                  setVerticalOffsetSlider={setVerticalOffsetSlider}
                   offsetWarning={offsetWarning || undefined}
                 />
               )}

--- a/apps/dorkroom/src/app/components/border-calculator/sections/border-size-section.tsx
+++ b/apps/dorkroom/src/app/components/border-calculator/sections/border-size-section.tsx
@@ -12,6 +12,7 @@ interface BorderSizeSectionProps {
   onClose: () => void;
   minBorder: number;
   setMinBorder: (value: number) => void;
+  setMinBorderSlider: (value: number) => void;
   minBorderWarning?: string;
 }
 
@@ -19,6 +20,7 @@ export function BorderSizeSection({
   onClose,
   minBorder,
   setMinBorder,
+  setMinBorderSlider,
   minBorderWarning,
 }: BorderSizeSectionProps) {
   return (
@@ -38,7 +40,7 @@ export function BorderSizeSection({
           label="Minimum Border (inches):"
           value={minBorder}
           onChange={setMinBorder}
-          onSliderChange={setMinBorder}
+          onSliderChange={setMinBorderSlider}
           min={SLIDER_MIN_BORDER}
           max={SLIDER_MAX_BORDER}
           step={SLIDER_STEP_BORDER}

--- a/apps/dorkroom/src/app/components/border-calculator/sections/position-offsets-section.tsx
+++ b/apps/dorkroom/src/app/components/border-calculator/sections/position-offsets-section.tsx
@@ -17,8 +17,10 @@ interface PositionOffsetsSectionProps {
   setIgnoreMinBorder: (value: boolean) => void;
   horizontalOffset: number;
   setHorizontalOffset: (value: number) => void;
+  setHorizontalOffsetSlider: (value: number) => void;
   verticalOffset: number;
   setVerticalOffset: (value: number) => void;
+  setVerticalOffsetSlider: (value: number) => void;
   offsetWarning?: string;
 }
 
@@ -30,8 +32,10 @@ export function PositionOffsetsSection({
   setIgnoreMinBorder,
   horizontalOffset,
   setHorizontalOffset,
+  setHorizontalOffsetSlider,
   verticalOffset,
   setVerticalOffset,
+  setVerticalOffsetSlider,
   offsetWarning,
 }: PositionOffsetsSectionProps) {
   return (
@@ -72,7 +76,7 @@ export function PositionOffsetsSection({
                 label="Horizontal Offset:"
                 value={horizontalOffset}
                 onChange={setHorizontalOffset}
-                onSliderChange={setHorizontalOffset}
+                onSliderChange={setHorizontalOffsetSlider}
                 min={OFFSET_SLIDER_MIN}
                 max={OFFSET_SLIDER_MAX}
                 step={OFFSET_SLIDER_STEP}
@@ -85,7 +89,7 @@ export function PositionOffsetsSection({
                 label="Vertical Offset:"
                 value={verticalOffset}
                 onChange={setVerticalOffset}
-                onSliderChange={setVerticalOffset}
+                onSliderChange={setVerticalOffsetSlider}
                 min={OFFSET_SLIDER_MIN}
                 max={OFFSET_SLIDER_MAX}
                 step={OFFSET_SLIDER_STEP}

--- a/apps/dorkroom/src/app/components/ui/labeled-slider-input.tsx
+++ b/apps/dorkroom/src/app/components/ui/labeled-slider-input.tsx
@@ -1,3 +1,4 @@
+import type { ChangeEvent } from 'react';
 import { cn } from '../../lib/cn';
 
 interface LabeledSliderInputProps {
@@ -27,15 +28,14 @@ export function LabeledSliderInput({
   warning = false,
   continuousUpdate = false,
 }: LabeledSliderInputProps) {
-  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSliderChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newValue = parseFloat(e.target.value);
-    if (continuousUpdate) {
-      onChange(newValue);
-    }
+    // For slider interactions, prefer the dedicated slider change handler
+    // to keep state strictly numeric during continuous updates.
     onSliderChange?.(newValue);
   };
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newValue = parseFloat(e.target.value) || 0;
     onChange(newValue);
   };


### PR DESCRIPTION
Separate slider and text input handlers to prevent `.toFixed` crashes on mobile when using the border calculator sliders.

The previous implementation allowed continuous slider updates to sometimes push string values into the state, which then caused methods like `.toFixed` to fail, leading to a page crash and black screen on mobile devices. This fix ensures that slider interactions always pass numeric values, resolving the crash.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc377f5d-de69-40ad-a337-301594ee2d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cc377f5d-de69-40ad-a337-301594ee2d45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

