### PR TITLE
Fix border calculator blade readings and rotation warning

### DIFF
--- a/apps/dorkroom/src/app/pages/border-calculator/border-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/border-calculator/border-calculator-page.tsx
@@ -534,7 +534,7 @@ export default function BorderCalculatorPage() {
                   Reset to defaults
                 </button>
 
-                {!isLandscape && (
+                {calculation.paperHeight > calculation.paperWidth && (
                   <div
                     className="mt-4 rounded-2xl px-4 py-3 text-center text-sm"
                     style={{
@@ -580,38 +580,22 @@ export default function BorderCalculatorPage() {
                 <div className="grid gap-3 sm:grid-cols-2">
                   <CalculatorStat
                     label="Left blade"
-                    value={formatWithUnit(
-                      !isLandscape
-                        ? calculation.topBladeReading
-                        : calculation.leftBladeReading
-                    )}
+                    value={formatWithUnit(calculation.leftBladeReading)}
                     className="p-4"
                   />
                   <CalculatorStat
                     label="Right blade"
-                    value={formatWithUnit(
-                      !isLandscape
-                        ? calculation.bottomBladeReading
-                        : calculation.rightBladeReading
-                    )}
+                    value={formatWithUnit(calculation.rightBladeReading)}
                     className="p-4"
                   />
                   <CalculatorStat
                     label="Top blade"
-                    value={formatWithUnit(
-                      !isLandscape
-                        ? calculation.leftBladeReading
-                        : calculation.topBladeReading
-                    )}
+                    value={formatWithUnit(calculation.topBladeReading)}
                     className="p-4"
                   />
                   <CalculatorStat
                     label="Bottom blade"
-                    value={formatWithUnit(
-                      !isLandscape
-                        ? calculation.rightBladeReading
-                        : calculation.bottomBladeReading
-                    )}
+                    value={formatWithUnit(calculation.bottomBladeReading)}
                     className="p-4"
                   />
                   <CalculatorStat


### PR DESCRIPTION
## Summary
- Fixed erroneous "rotate your easel" warning for custom paper sizes like 13x10in by checking actual paper dimensions instead of the landscape toggle
- Fixed reversed blade reading mappings that were incorrectly swapped based on orientation

## Test plan
- Set paper size to custom 13x10in and verify the "rotate your easel" warning does not appear
- Verify blade readings display correctly match the paper orientation
- Check that the preview correctly shows blade positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Border calculator now displays rotation guidance more intelligently, responding to paper dimensions rather than device orientation.
  * Blade reading displays have been streamlined to show consistent values regardless of device orientation or screen rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->