### PR TITLE
chore(deps): coordinated bump @tanstack/react-store ^0.11 + react-form ^1.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Dorkroom.art are documented here.
 
 This project uses [CalVer](https://calver.org/) date-based versioning: `YYYY.MM.DD`.
 
+## [2026.06.11]
+
+### Changed
+
+- Coordinated TanStack Store/Form bump: upgraded `@tanstack/react-store` `^0.8.0` → `^0.11.0` and `@tanstack/react-form` `^1.27.7` → `^1.33.0` together so a single `@tanstack/store@0.11.0` resolves across both. The standalone Dependabot bump of `@tanstack/react-store` to 0.11 (PR #89) did not compile: 0.11 ships a newer `@tanstack/store` whose `Store`/`Derived` interface requires a `get()` method, while the older `@tanstack/react-form` pinned an older `@tanstack/store` whose `Derived` (e.g. `form.store`) lacked it — two incompatible `@tanstack/store` interfaces typed `useStore(form.store, selector)` state as `unknown` and produced ~40 build errors in the border-calculator components. `react-form@1.33.0` depends on `react-store@^0.11.0` and `form-core@1.33.0` (`@tanstack/store@^0.11.0`), so the coordinated bump resolves a single compatible store with no `overrides` and no consuming-code changes
+
 ## [2026.05.28]
 
 ### Added

--- a/apps/dorkroom/package.json
+++ b/apps/dorkroom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dorkroom/dorkroom",
-  "version": "2026.05.28",
+  "version": "2026.06.11",
   "private": true,
   "license": "AGPL-3.0-only",
   "scripts": {

--- a/bun.lock
+++ b/bun.lock
@@ -8,10 +8,10 @@
         "@fontsource-variable/montserrat": "^5.2.8",
         "@fontsource/vt323": "^5.2.7",
         "@tailwindcss/postcss": "4.3.0",
-        "@tanstack/react-form": "^1.27.7",
+        "@tanstack/react-form": "^1.33.0",
         "@tanstack/react-query": "^5.90.14",
         "@tanstack/react-router": "^1.144.0",
-        "@tanstack/react-store": "^0.8.0",
+        "@tanstack/react-store": "^0.11.0",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.13",
         "@tanstack/router-devtools": "^1.139.3",
@@ -694,9 +694,9 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.3.0", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "postcss": "^8.5.10", "tailwindcss": "4.3.0" } }, "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w=="],
 
-    "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.0", "", {}, "sha512-RPfGuk2bDZgcu9bAJodvO2lnZeHuz4/71HjZ0bGb/SPg8+lyTA+RLSKQvo7fSmPSi8/vcH3aKQ8EM9ywf1olaw=="],
+    "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.3", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw=="],
 
-    "@tanstack/form-core": ["@tanstack/form-core@1.28.2", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.0", "@tanstack/pacer-lite": "^0.1.1", "@tanstack/store": "^0.8.0" } }, "sha512-HghwxfvnQ0NlbKUWNTsQEVDC5RVn1ePqmb/t6RVhVVhv/KDKHIla7PSqrak4oSx6FaGK8NHIoRXjKupa2s7YpQ=="],
+    "@tanstack/form-core": ["@tanstack/form-core@1.33.0", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1", "@tanstack/pacer-lite": "^0.1.1", "@tanstack/store": "^0.11.0" } }, "sha512-AV4Pw9Dk4orFsuPBcDssfWMJFs+yMYBae7zZ4oTqrCf4ftNGQKxvrQRZeqKHG6A4TkiLeSvf2kzIjcVkrW7E6w=="],
 
     "@tanstack/history": ["@tanstack/history@1.141.0", "", {}, "sha512-LS54XNyxyTs5m/pl1lkwlg7uZM3lvsv2FIIV1rsJgnfwVCnI+n4ZGZ2CcjNT13BPu/3hPP+iHmliBSscJxW5FQ=="],
 
@@ -706,7 +706,7 @@
 
     "@tanstack/query-devtools": ["@tanstack/query-devtools@5.92.0", "", {}, "sha512-N8D27KH1vEpVacvZgJL27xC6yPFUy0Zkezn5gnB3L3gRCxlDeSuiya7fKge8Y91uMTnC8aSxBQhcK6ocY7alpQ=="],
 
-    "@tanstack/react-form": ["@tanstack/react-form@1.28.2", "", { "dependencies": { "@tanstack/form-core": "1.28.2", "@tanstack/react-store": "^0.8.0" }, "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-1x1Jcnu8sY03kI9LRNrD3euo+mnEdxFqZ0we98go84mew8fvgjiuNU62MiudMSEQ5tU0CcctRLWq3f3aT/yygw=="],
+    "@tanstack/react-form": ["@tanstack/react-form@1.33.0", "", { "dependencies": { "@tanstack/form-core": "1.33.0", "@tanstack/react-store": "^0.11.0" }, "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-unaee+VS4MvKo+s1dmgGUXI4902VeAhuaUbKsQbhFe3MceOpB3JpAUGCDpyzjQPXVFkFY0COKfLrUNX2XZYW4g=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
 
@@ -716,7 +716,7 @@
 
     "@tanstack/react-router-devtools": ["@tanstack/react-router-devtools@1.142.8", "", { "dependencies": { "@tanstack/router-devtools-core": "1.142.8" }, "peerDependencies": { "@tanstack/react-router": "^1.142.8", "@tanstack/router-core": "^1.142.8", "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" }, "optionalPeers": ["@tanstack/router-core"] }, "sha512-kOvJqPD86hR2Jw2SCq0sGgWCGX2yUPQ9t4sKUhapzayN0n6lrtUUwJ2qXaLcetINAyVVTLSHHVqD4b52SZXdxw=="],
 
-    "@tanstack/react-store": ["@tanstack/react-store@0.8.0", "", { "dependencies": { "@tanstack/store": "0.8.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-1vG9beLIuB7q69skxK9r5xiLN3ztzIPfSQSs0GfeqWGO2tGIyInZx0x1COhpx97RKaONSoAb8C3dxacWksm1ow=="],
+    "@tanstack/react-store": ["@tanstack/react-store@0.11.0", "", { "dependencies": { "@tanstack/store": "0.11.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tX4YXh3PDkmpvGQWkWqKpzs/MSqbtuwY9dWdWhtV9Q50PmO+jOkUKIWIX4G85dwt7lxdHLXsiaEKPdKmC8F41w=="],
 
     "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
 
@@ -736,7 +736,7 @@
 
     "@tanstack/router-vite-plugin": ["@tanstack/router-vite-plugin@1.142.8", "", { "dependencies": { "@tanstack/router-plugin": "1.142.8" } }, "sha512-uR+1KxPt4d8A2dJo8zqVrkppXpEF4+2q1u5BDpLcZLAe5GDKQpcmVK3f7zMBodj3DH3u8TQPEB18PmbEYYdvCA=="],
 
-    "@tanstack/store": ["@tanstack/store@0.8.0", "", {}, "sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ=="],
+    "@tanstack/store": ["@tanstack/store@0.11.0", "", {}, "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw=="],
 
     "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
@@ -1762,6 +1762,10 @@
 
     "@tailwindcss/postcss/postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
+    "@tanstack/react-router/@tanstack/react-store": ["@tanstack/react-store@0.8.0", "", { "dependencies": { "@tanstack/store": "0.8.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-1vG9beLIuB7q69skxK9r5xiLN3ztzIPfSQSs0GfeqWGO2tGIyInZx0x1COhpx97RKaONSoAb8C3dxacWksm1ow=="],
+
+    "@tanstack/router-core/@tanstack/store": ["@tanstack/store@0.8.0", "", {}, "sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ=="],
+
     "@tanstack/router-generator/@tanstack/router-core": ["@tanstack/router-core@1.142.8", "", { "dependencies": { "@tanstack/history": "1.141.0", "@tanstack/store": "^0.8.0", "cookie-es": "^2.0.0", "seroval": "^1.4.1", "seroval-plugins": "^1.4.0", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" } }, "sha512-eP36Kq3g7TRG+9yzgEtE5DNBXsnAwPkZWUmEjg5lqSOLZlZdhfxDngdXJqY98vEuogd2wkXmGlatxdatoYTjJA=="],
 
     "@tanstack/router-generator/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -1988,6 +1992,10 @@
 
     "@tailwindcss/postcss/postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
+    "@tanstack/react-router/@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.8.0", "", {}, "sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ=="],
+
+    "@tanstack/router-generator/@tanstack/router-core/@tanstack/store": ["@tanstack/store@0.8.0", "", {}, "sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ=="],
+
     "@tanstack/router-plugin/@babel/core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@tanstack/router-plugin/@babel/core/@babel/generator": ["@babel/generator@7.28.5", "", { "dependencies": { "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ=="],
@@ -2015,6 +2023,8 @@
     "@tanstack/router-plugin/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
     "@tanstack/router-plugin/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@tanstack/router-plugin/@tanstack/router-core/@tanstack/store": ["@tanstack/store@0.8.0", "", {}, "sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ=="],
 
     "@tanstack/router-utils/@babel/core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dorkroom/source",
-  "version": "2026.05.28",
+  "version": "2026.06.11",
   "license": "AGPL-3.0-only",
   "scripts": {
     "supabase:login": "bunx supabase login",
@@ -31,10 +31,10 @@
     "@fontsource-variable/montserrat": "^5.2.8",
     "@fontsource/vt323": "^5.2.7",
     "@tailwindcss/postcss": "4.3.0",
-    "@tanstack/react-form": "^1.27.7",
+    "@tanstack/react-form": "^1.33.0",
     "@tanstack/react-query": "^5.90.14",
     "@tanstack/react-router": "^1.144.0",
-    "@tanstack/react-store": "^0.8.0",
+    "@tanstack/react-store": "^0.11.0",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.13",
     "@tanstack/router-devtools": "^1.139.3",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dorkroom/api",
-  "version": "2026.05.28",
+  "version": "2026.06.11",
   "license": "AGPL-3.0-only",
   "description": "API client and type definitions for the Dorkroom analog photography calculator",
   "keywords": [

--- a/packages/logic/package.json
+++ b/packages/logic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dorkroom/logic",
-  "version": "2026.05.28",
+  "version": "2026.06.11",
   "license": "AGPL-3.0-only",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dorkroom/ui",
-  "version": "2026.05.28",
+  "version": "2026.06.11",
   "license": "AGPL-3.0-only",
   "main": "./src/index.ts",
   "types": "./src/index.ts",


### PR DESCRIPTION
## Summary

Coordinated bump of the TanStack Store/Form packages so a single `@tanstack/store@0.11.0` resolves across both, fixing the broken standalone `@tanstack/react-store` 0.11 upgrade.

- `@tanstack/react-store`: `^0.8.0` → `^0.11.0`
- `@tanstack/react-form`: `^1.27.7` → `^1.33.0`

**Supersedes #89. Closes #89.**

## Root cause

Dependabot PR #89 bumped only `@tanstack/react-store` to `^0.11.0`. That did **not** compile — `bun run test` failed in `@dorkroom/ui:build` (`tsgo --project tsconfig.lib.json`) with ~40 type errors of the shape:

```
error TS2741: Property 'get' is missing in type 'Derived<FormState<...>, readonly any[]>'
  but required in type '{ get: () => unknown; subscribe: (listener: ...) => ... }'.
error TS18046: 'state' is of type 'unknown'.
```

`@tanstack/react-store@0.11` ships `@tanstack/store@0.11.0`, whose `Store`/`Derived` interface now **requires a `get()` method**. But `@tanstack/react-form@1.27.7` (via `@tanstack/form-core@1.27.7`) pinned an **older** `@tanstack/store` whose `Derived` objects (e.g. `form.store`) lack `get()`. Two incompatible `@tanstack/store` interfaces in the tree caused `useStore(form.store, selector)` to mistype the selector `state` as `unknown`, cascading into `TS2339` errors for every field access in the border-calculator components.

## Version matrix

| Package | requires `@tanstack/store` |
| --- | --- |
| `@tanstack/react-store@0.11.0` | `0.11.0` |
| `@tanstack/react-form@1.27.7` (old) | older (via `form-core@1.27.7`) — lacks `get()` |
| `@tanstack/react-form@1.33.0` (new) | `^0.11.0` (via `react-store@^0.11.0` + `form-core@1.33.0` → `@tanstack/store@^0.11.0`) |

`react-form@1.33.0` is the first release that depends on `react-store@^0.11.0`, so bumping both together resolves a single compatible `@tanstack/store@0.11.0` for the form/store consumers.

## Why no `overrides`

Not needed. The coordinated dependency bump alone deduplicates `@tanstack/store@0.11.0` for the relevant consumers (`react-store` + `form-core`). A separate, older `@tanstack/store@0.8.0` remains in the tree purely as a transitive dep of `@tanstack/react-router`, which uses its own internal store and is unrelated to `form.store` typing — so no pin/override is warranted.

## Consuming code

No code changes required. `useStore(form.store, (state) => state.values.X)` in the border-calculator components now type-checks correctly under the single store resolution.

## Verification

- `bun run test` (lint + test + build + typecheck): **exit 0** — 16/16 turbo tasks, 73 test files / 1554 tests passing.
- `npx react-doctor@0.2.1 --score`: **95 / 100 / 95** across `@dorkroom/source` / `@dorkroom/logic` / `@dorkroom/ui` — unchanged from `main`. The two non-100 scores are a pre-existing `react-doctor/no-barrel-import` finding in `films/film-detail-panel.tsx`, `films/film-filters-panel.tsx`, and `packages/api/.../index.test.ts` (verified identical on a pristine `main` checkout); this deps-only PR neither introduces nor fixes them.
- `bun run format` applied.

## Versioning

CalVer bumped to `2026.06.11` across all `package.json` files; `CHANGELOG.md` updated.