### PR TITLE
chore(quality): restore React Doctor to 100/100 (fix no-barrel-import)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project uses [CalVer](https://calver.org/) date-based versioning: `YYYY.MM.
 ### Changed
 
 - Coordinated TanStack Store/Form bump: upgraded `@tanstack/react-store` `^0.8.0` → `^0.11.0` and `@tanstack/react-form` `^1.27.7` → `^1.33.0` together so a single `@tanstack/store@0.11.0` resolves across both. The standalone Dependabot bump of `@tanstack/react-store` to 0.11 (PR #89) did not compile: 0.11 ships a newer `@tanstack/store` whose `Store`/`Derived` interface requires a `get()` method, while the older `@tanstack/react-form` pinned an older `@tanstack/store` whose `Derived` (e.g. `form.store`) lacked it — two incompatible `@tanstack/store` interfaces typed `useStore(form.store, selector)` state as `unknown` and produced ~40 build errors in the border-calculator components. `react-form@1.33.0` depends on `react-store@^0.11.0` and `form-core@1.33.0` (`@tanstack/store@^0.11.0`), so the coordinated bump resolves a single compatible store with no `overrides` and no consuming-code changes
+- Restored React Doctor health to 100/100 across all projects: replaced barrel-file imports with direct module imports in `film-filters-panel` (`../filters/*`) and `film-detail-panel` (`../detail-panel/detail-panel`) for better tree-shaking, and suppressed the `no-barrel-import` finding in `@dorkroom/api`'s `index.test.ts` (the barrel re-export is that suite's subject under test)
 
 ## [2026.05.28]
 

--- a/packages/api/src/__tests__/index.test.ts
+++ b/packages/api/src/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line react-doctor/no-barrel-import -- this suite verifies the package barrel ('../index.js') re-exports everything; importing from source modules would defeat its purpose
 import {
   apiClient,
   DorkroomApiClient,

--- a/packages/ui/src/components/films/film-detail-panel.tsx
+++ b/packages/ui/src/components/films/film-detail-panel.tsx
@@ -1,7 +1,7 @@
 import type { Film } from '@dorkroom/api';
 import { ExternalLink } from 'lucide-react';
 import type { FC } from 'react';
-import { DetailPanel } from '../detail-panel';
+import { DetailPanel } from '../detail-panel/detail-panel';
 import { Tag } from '../ui/tag';
 import { FilmImage } from './film-image';
 import { FilmRebrandInfo } from './film-rebrand-info';

--- a/packages/ui/src/components/films/film-filters-panel.tsx
+++ b/packages/ui/src/components/films/film-filters-panel.tsx
@@ -2,11 +2,9 @@ import type { SelectItem } from '@dorkroom/logic';
 import { Search } from 'lucide-react';
 import { type FC, useRef } from 'react';
 import { setStyles } from '../../lib/dom';
-import {
-  FilterPanelContainer,
-  FilterPanelHeader,
-  FilterPanelSection,
-} from '../filters';
+import { FilterPanelContainer } from '../filters/filter-panel-container';
+import { FilterPanelHeader } from '../filters/filter-panel-header';
+import { FilterPanelSection } from '../filters/filter-panel-section';
 import { SearchableSelect } from '../searchable-select';
 import { Select } from '../select';
 


### PR DESCRIPTION
## What

Brings React Doctor health back to **100/100/100** across `@dorkroom/source`, `@dorkroom/logic`, and `@dorkroom/ui` by resolving the three pre-existing `react-doctor/no-barrel-import` findings.

## Changes

- **`film-filters-panel.tsx`** — import `FilterPanelContainer`/`FilterPanelHeader`/`FilterPanelSection` directly from `../filters/*` source modules instead of the `../filters` barrel (better tree-shaking).
- **`film-detail-panel.tsx`** — import `DetailPanel` from `../detail-panel/detail-panel` instead of the `../detail-panel` barrel.
- **`packages/api/src/__tests__/index.test.ts`** — justified inline suppression of `no-barrel-import`. This suite (`describe('API Package Exports')`) exists specifically to verify the package barrel (`../index.js`) re-exports everything; importing from source modules would defeat its purpose.

No behavior change — import-path refactor + one test-only suppression.

## Verification

- `bun run test` (lint + test + build + typecheck): **exit 0**, 16/16 turbo tasks, 0 lint warnings
- `npx react-doctor@0.2.1 --score`: **100 / 100 / 100**
- `bun run format`: clean

Versions are already at CalVer `2026.06.11` (set by #94, same day); CHANGELOG entry added under that section.