### PR TITLE
fix(home): align tool category labels with navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project uses [CalVer](https://calver.org/) date-based versioning: `YYYY.MM.
 - Restored React Doctor health to 100/100 across all projects: replaced barrel-file imports with direct module imports in `film-filters-panel` (`../filters/*`) and `film-detail-panel` (`../detail-panel/detail-panel`) for better tree-shaking, and suppressed the `no-barrel-import` finding in `@dorkroom/api`'s `index.test.ts` (the barrel re-export is that suite's subject under test)
 - Bumped the TypeScript 7 native preview (`tsgo`) compiler from `7.0.0-dev.20260421.2` to `7.0.0-dev.20260604.1` (the typecheck/build toolchain). Chose a snapshot ≥7 days old so it clears the `bunfig.toml` `minimumReleaseAge` soak gate; full gate (typecheck + build + test) passes clean. Stable TypeScript 7 has not shipped yet, so the preview pin remains
 
+### Fixed
+
+- Print Resize Calculator (`/resize`) crashed on load with `useMeasurementConverter is not defined`: the hook was imported as `type`-only but called at runtime, so the import was erased from the compiled page. Made it a value import
+
 ## [2026.05.28]
 
 ### Added

--- a/apps/dorkroom/src/app/pages/camera-exposure-calculator/camera-exposure-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/camera-exposure-calculator/camera-exposure-calculator-page.tsx
@@ -667,34 +667,53 @@ export default function CameraExposureCalculatorPage() {
       sidebar={<CameraExposureSidebar />}
       results={
         <div className="space-y-6">
-          {/* EV Result - desktop only (mobile instance is in children) */}
+          {/* EV Result — desktop right column only */}
           <div className="hidden md:block">
             <EVResultCard form={form} formValues={formValues} />
           </div>
 
-          {/* Equivalent Exposures */}
-          <EquivalentExposuresCard form={form} />
+          {/* Equivalent Exposures — desktop right column only */}
+          <div className="hidden md:block">
+            <EquivalentExposuresCard form={form} />
+          </div>
+
+          {/* EV Presets — desktop right column only */}
+          <div className="hidden md:block">
+            <EVPresetsCard
+              form={form}
+              presetsOpen={presetsOpen}
+              onToggle={() => setPresetsOpen((prev) => !prev)}
+              onPresetClick={handlePresetClick}
+            />
+          </div>
         </div>
       }
     >
-      {/* Exposure Settings */}
+      {/* Exposure Settings — always visible */}
       <ExposureSettingsCard form={form} />
 
-      {/* Exposure Comparison */}
-      <ExposureComparisonCard form={form} />
-
-      {/* EV Result - mobile only (desktop instance is in results) */}
+      {/* EV Result — mobile only; on desktop this lives in the results column */}
       <div className="md:hidden">
         <EVResultCard form={form} formValues={formValues} />
       </div>
 
-      {/* EV Presets - collapsible */}
-      <EVPresetsCard
-        form={form}
-        presetsOpen={presetsOpen}
-        onToggle={() => setPresetsOpen((prev) => !prev)}
-        onPresetClick={handlePresetClick}
-      />
+      {/* Equivalent Exposures — mobile only; on desktop this lives in the results column */}
+      <div className="md:hidden">
+        <EquivalentExposuresCard form={form} />
+      </div>
+
+      {/* Exposure Comparison — always visible */}
+      <ExposureComparisonCard form={form} />
+
+      {/* EV Presets — mobile only; on desktop this lives in the results column */}
+      <div className="md:hidden">
+        <EVPresetsCard
+          form={form}
+          presetsOpen={presetsOpen}
+          onToggle={() => setPresetsOpen((prev) => !prev)}
+          onPresetClick={handlePresetClick}
+        />
+      </div>
     </CalculatorLayout>
   );
 }

--- a/apps/dorkroom/src/app/pages/camera-exposure-calculator/camera-exposure-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/camera-exposure-calculator/camera-exposure-calculator-page.tsx
@@ -29,7 +29,7 @@ import {
   solveForShutterSpeed,
   useLocalStorageFormPersistence,
 } from '@dorkroom/logic';
-import { ResultRow, Select, StatusAlert } from '@dorkroom/ui';
+import { getRouteIcon, ResultRow, Select, StatusAlert } from '@dorkroom/ui';
 import {
   CalculatorCard,
   CalculatorLayout,
@@ -135,7 +135,7 @@ function EVResultCard({
         <CalculatorCard
           title="Exposure value"
           description="Scene brightness at ISO 100"
-          accent="emerald"
+          accent="teal"
           padding="compact"
         >
           <div className="grid gap-4 sm:grid-cols-2">
@@ -143,7 +143,7 @@ function EVResultCard({
               label="EV"
               value={result.isValid ? `${result.ev}` : '—'}
               helperText={result.description || 'Enter valid settings'}
-              tone="emerald"
+              tone="teal"
             />
             <CalculatorStat
               label="Settings"
@@ -654,6 +654,8 @@ export default function CameraExposureCalculatorPage() {
   return (
     <CalculatorLayout
       title="Camera Exposure Calculator"
+      icon={getRouteIcon('/exposure')}
+      accentTone="teal"
       description={
         <>
           Balance aperture, shutter speed, and ISO for correct exposure.

--- a/apps/dorkroom/src/app/pages/camera-exposure-calculator/camera-exposure-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/camera-exposure-calculator/camera-exposure-calculator-page.tsx
@@ -271,13 +271,13 @@ function EquivalentExposuresCard({ form }: { form: CameraExposureForm }) {
                   >
                     <th
                       className="py-2 px-3 text-left font-medium"
-                      style={{ color: 'var(--color-text-tertiary)' }}
+                      style={{ color: 'var(--color-on-accent-muted)' }}
                     >
                       Aperture
                     </th>
                     <th
                       className="py-2 px-3 text-left font-medium"
-                      style={{ color: 'var(--color-text-tertiary)' }}
+                      style={{ color: 'var(--color-on-accent-muted)' }}
                     >
                       Shutter Speed
                     </th>
@@ -294,8 +294,8 @@ function EquivalentExposuresCard({ form }: { form: CameraExposureForm }) {
                           ? 'var(--color-surface-elevated)'
                           : undefined,
                         color: eq.isStandardShutterSpeed
-                          ? 'var(--color-text-primary)'
-                          : 'var(--color-text-tertiary)',
+                          ? 'var(--color-on-accent)'
+                          : 'var(--color-on-accent-muted)',
                       }}
                     >
                       <td className="py-2 px-3">{eq.apertureLabel}</td>
@@ -303,9 +303,9 @@ function EquivalentExposuresCard({ form }: { form: CameraExposureForm }) {
                         {eq.shutterSpeedLabel}
                         {eq.isCurrentSetting && (
                           <span
-                            className="ml-2 text-xs"
+                            className="ml-2 text-xs font-semibold"
                             style={{
-                              color: 'var(--color-primary)',
+                              color: 'var(--color-on-accent)',
                             }}
                           >
                             current
@@ -319,7 +319,7 @@ function EquivalentExposuresCard({ form }: { form: CameraExposureForm }) {
             </div>
             <p
               className="text-xs mt-2"
-              style={{ color: 'var(--color-text-tertiary)' }}
+              style={{ color: 'var(--color-on-accent-muted)' }}
             >
               Non-standard shutter speeds shown in muted text
             </p>
@@ -424,7 +424,7 @@ function ExposureComparisonCard({ form }: { form: CameraExposureForm }) {
           <div className="space-y-3">
             <h4
               className="text-xs font-semibold uppercase tracking-[0.25em]"
-              style={{ color: 'var(--color-text-muted)' }}
+              style={{ color: 'var(--color-on-accent-soft)' }}
             >
               Exposure B
             </h4>

--- a/apps/dorkroom/src/app/pages/development-recipes/components/recipe-results-section.tsx
+++ b/apps/dorkroom/src/app/pages/development-recipes/components/recipe-results-section.tsx
@@ -92,7 +92,7 @@ export const RecipeResultsSection: FC<RecipeResultsSectionProps> = (props) => {
               className={cn(
                 'grid gap-4',
                 isMobile
-                  ? 'grid-cols-2'
+                  ? 'grid-cols-1 min-[480px]:grid-cols-2'
                   : 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
               )}
             >

--- a/apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
+++ b/apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
@@ -443,6 +443,7 @@ export default function DevelopmentRecipesPage() {
           }}
           onRefresh={handleRefreshAll}
           isRefreshing={isRefreshingData}
+          isLoading={isLoading}
           showImportButton={flags.RECIPE_IMPORT}
           isMobile={isMobile}
         />

--- a/apps/dorkroom/src/app/pages/exposure-calculator/exposure-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/exposure-calculator/exposure-calculator-page.tsx
@@ -215,7 +215,7 @@ export default function ExposureCalculatorPage() {
 
               <div className="rounded-2xl p-4 font-mono text-sm border border-secondary bg-background/20 text-primary">
                 {`${formatExposureTime(calculation.originalTimeValue)} `}
-                <span className="align-super text-xs font-semibold text-[color:var(--color-primary)]">
+                <span className="align-super text-xs font-semibold text-[color:var(--color-on-accent)]">
                   ×2^
                   {calculation.stopsValue}
                 </span>

--- a/apps/dorkroom/src/app/pages/exposure-calculator/exposure-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/exposure-calculator/exposure-calculator-page.tsx
@@ -10,7 +10,7 @@ import {
   roundToStandardPrecision,
   useLocalStorageFormPersistence,
 } from '@dorkroom/logic';
-import { ResultRow } from '@dorkroom/ui';
+import { getRouteIcon, ResultRow } from '@dorkroom/ui';
 import {
   CalculatorCard,
   CalculatorLayout,
@@ -98,6 +98,8 @@ export default function ExposureCalculatorPage() {
   return (
     <CalculatorLayout
       title="Exposure Stop Calculator"
+      icon={getRouteIcon('/stops')}
+      accentTone="blue"
       description={
         <>
           Adjust exposure times by stops for darkroom printing.
@@ -188,7 +190,7 @@ export default function ExposureCalculatorPage() {
             <CalculatorCard
               title="Exposure results"
               description={`Adjusted exposure time for ${calculation.stopsValue >= 0 ? 'increased' : 'decreased'} amount of stops`}
-              accent="emerald"
+              accent="blue"
               padding="compact"
             >
               <div className="grid gap-4 sm:grid-cols-2">
@@ -198,7 +200,7 @@ export default function ExposureCalculatorPage() {
                   helperText={`${calculation.stopsValue > 0 ? '+' : ''}${
                     calculation.stopsValue
                   } stops`}
-                  tone="emerald"
+                  tone="blue"
                 />
                 <CalculatorStat
                   label={`${

--- a/apps/dorkroom/src/app/pages/films/films-page.tsx
+++ b/apps/dorkroom/src/app/pages/films/films-page.tsx
@@ -4,7 +4,7 @@ import {
   getBaseFilm,
   useFilmDatabase,
 } from '@dorkroom/logic';
-import { useIsMobile } from '@dorkroom/ui';
+import { getRouteIcon, useIsMobile } from '@dorkroom/ui';
 import { CalculatorPageHeader } from '@dorkroom/ui/calculator';
 import { VirtualizedErrorBoundary } from '@dorkroom/ui/development-recipes';
 import {
@@ -361,6 +361,8 @@ export default function FilmsPage() {
 
       <CalculatorPageHeader
         title="Film Database"
+        icon={getRouteIcon('/films')}
+        accentTone="cyan"
         description="Browse and search the complete film stock database"
       />
 

--- a/apps/dorkroom/src/app/pages/home-hero-preview.tsx
+++ b/apps/dorkroom/src/app/pages/home-hero-preview.tsx
@@ -1,0 +1,201 @@
+import {
+  bladeReadings,
+  calculateBladeThickness,
+  computePrintSize,
+} from '@dorkroom/logic';
+import { Link } from '@tanstack/react-router';
+import { ArrowRight } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+/* ------------------------------------------------------------------ *
+   Read-only border-calculator preview for the home hero.
+
+   Cycles through a few classic negative formats centered on 8x10 paper,
+   with the easel blades set by the same geometry helpers the border
+   calculator uses. All geometry is computed once at module level - no
+   data fetching, no per-frame math.
+\* ------------------------------------------------------------------ */
+
+const PAPER = { width: 10, height: 8 }; // 8x10 paper, landscape
+
+// calculateBladeThickness returns pixels for the calculator's 400px-wide
+// canvas; convert to inches so the blades scale with this fluid preview.
+const BLADE_IN =
+  (calculateBladeThickness(PAPER.width, PAPER.height) / 400) * PAPER.width;
+
+const pctX = (inches: number) => `${(inches / PAPER.width) * 100}%`;
+const pctY = (inches: number) => `${(inches / PAPER.height) * 100}%`;
+
+const FRACTION_GLYPHS: ReadonlyArray<readonly [number, string]> = [
+  [0.25, '¼'],
+  [0.5, '½'],
+  [0.75, '¾'],
+];
+
+/** Format inches with vulgar fractions: 8.25 -> "8 1/4". */
+function formatInches(value: number): string {
+  const whole = Math.trunc(value);
+  const rest = value - whole;
+  if (rest < 0.001) return `${whole}`;
+  const glyph = FRACTION_GLYPHS.find(
+    ([fraction]) => Math.abs(rest - fraction) < 0.001
+  )?.[1];
+  return glyph ? `${whole}${glyph}` : value.toFixed(2);
+}
+
+interface BorderSetup {
+  label: string;
+  printW: number;
+  printH: number;
+  borderX: number;
+  borderY: number;
+  readout: string;
+}
+
+// Min borders are chosen so every blade reading lands on a quarter inch.
+function makeSetup(
+  label: string,
+  ratioW: number,
+  ratioH: number,
+  minBorder: number
+): BorderSetup {
+  const { printW, printH } = computePrintSize(
+    PAPER.width,
+    PAPER.height,
+    ratioW,
+    ratioH,
+    minBorder
+  );
+  const readings = bladeReadings(printW, printH, 0, 0);
+  return {
+    label,
+    printW,
+    printH,
+    borderX: (PAPER.width - printW) / 2,
+    borderY: (PAPER.height - printH) / 2,
+    // Non-breaking spaces keep the readout on one line in the caption.
+    readout: `${formatInches(readings.left)} × ${formatInches(readings.top)}`,
+  };
+}
+
+const SETUPS: readonly BorderSetup[] = [
+  makeSetup('35mm', 3, 2, 1.25),
+  makeSetup('6×6', 1, 1, 1.5),
+  makeSetup('4×5', 5, 4, 1),
+];
+
+const CYCLE_MS = 5000;
+
+const bladeStyle = {
+  background: 'var(--blade-background)',
+  border: 'var(--blade-border)',
+  boxShadow: 'var(--blade-shadow)',
+} as const;
+
+// Slow position/size easing for the print and blades when a new setup lands.
+const easeClass = 'transition-all duration-1000 ease-in-out';
+
+function animationsDisabled(): boolean {
+  if (typeof document === 'undefined') return true;
+  // Same contract the theme system writes for darkroom/high-contrast and the
+  // user's animations toggle (utilities.css kills transitions for it too).
+  if (
+    document.documentElement.getAttribute('data-animations-disabled') === 'true'
+  ) {
+    return true;
+  }
+  return (
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+export function HomeHeroPreview() {
+  const [setupIndex, setSetupIndex] = useState(0);
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      // Checked per tick so theme/toggle changes take effect immediately.
+      if (animationsDisabled()) return;
+      setSetupIndex((index) => (index + 1) % SETUPS.length);
+    }, CYCLE_MS);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const { label, printW, printH, borderX, borderY, readout } =
+    SETUPS[setupIndex];
+
+  return (
+    <Link
+      to="/border"
+      aria-label="Open the border calculator"
+      className="group/hero block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border-primary)]"
+    >
+      {/* The paper, with the print area and four easel blades */}
+      <div
+        className="relative w-full overflow-hidden rounded-sm shadow-subtle transition-all group-hover/hero:-translate-y-0.5 group-hover/hero:shadow-lg"
+        style={{
+          aspectRatio: `${PAPER.width} / ${PAPER.height}`,
+          backgroundColor: 'var(--color-paper-background)',
+          border: '1px solid var(--color-paper-border)',
+        }}
+      >
+        {/* Print area */}
+        <div
+          className={`absolute ${easeClass}`}
+          style={{
+            left: pctX(borderX),
+            top: pctY(borderY),
+            width: pctX(printW),
+            height: pctY(printH),
+            backgroundColor: 'var(--color-print-background)',
+            border: 'var(--print-border-style) var(--color-print-border)',
+          }}
+        />
+        {/* Easel blades, sitting over the borders */}
+        <div
+          className={`absolute inset-y-0 -translate-x-full ${easeClass}`}
+          style={{
+            ...bladeStyle,
+            width: pctX(BLADE_IN),
+            left: pctX(borderX),
+          }}
+        />
+        <div
+          className={`absolute inset-y-0 ${easeClass}`}
+          style={{
+            ...bladeStyle,
+            width: pctX(BLADE_IN),
+            left: pctX(PAPER.width - borderX),
+          }}
+        />
+        <div
+          className={`absolute inset-x-0 -translate-y-full ${easeClass}`}
+          style={{
+            ...bladeStyle,
+            height: pctY(BLADE_IN),
+            top: pctY(borderY),
+          }}
+        />
+        <div
+          className={`absolute inset-x-0 ${easeClass}`}
+          style={{
+            ...bladeStyle,
+            height: pctY(BLADE_IN),
+            top: pctY(PAPER.height - borderY),
+          }}
+        />
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <span className="text-xs text-[color:var(--color-text-tertiary)]">
+          {label} on 8×10 paper · blades at {readout}
+        </span>
+        <span className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-[color:var(--color-text-secondary)] transition-colors group-hover/hero:text-[color:var(--color-text-primary)]">
+          Border calculator
+          <ArrowRight className="size-3.5 transition-transform group-hover/hero:translate-x-0.5" />
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/apps/dorkroom/src/app/pages/home-page.tsx
+++ b/apps/dorkroom/src/app/pages/home-page.tsx
@@ -1,5 +1,5 @@
 import { useStats } from '@dorkroom/logic';
-import { CATEGORY_LABELS, Greeting, StatCard, ToolCard } from '@dorkroom/ui';
+import { CATEGORY_LABELS, Greeting, ToolCard } from '@dorkroom/ui';
 import { Link } from '@tanstack/react-router';
 import {
   BookOpen,
@@ -16,12 +16,13 @@ import {
   GraduationCap,
   HandCoins,
   Ruler,
-  TestTubes,
   Timer,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { HomeHeroPreview } from './home-hero-preview';
 
-// Calculator tools configuration - module level to prevent recreation on each render
+// Calculator tools configuration - module level to prevent recreation on each
+// render. Accents match each target page's tone (see plan 007).
 const CALCULATORS = [
   {
     category: CATEGORY_LABELS.printing,
@@ -45,7 +46,7 @@ const CALCULATORS = [
     description: 'Scale prints, no wasting test strips',
     href: '/resize',
     icon: Ruler,
-    accent: 'violet',
+    accent: 'teal',
   },
   {
     category: CATEGORY_LABELS.printing,
@@ -53,7 +54,7 @@ const CALCULATORS = [
     description: 'Window openings & cut guides',
     href: '/mat',
     icon: Frame,
-    accent: 'teal',
+    accent: 'cyan',
   },
   {
     category: CATEGORY_LABELS.film,
@@ -72,14 +73,6 @@ const CALCULATORS = [
     accent: 'rose',
   },
   {
-    category: CATEGORY_LABELS.reference,
-    title: 'Film Database',
-    description: 'Browse film stocks by brand & ISO',
-    href: '/films',
-    icon: Film,
-    accent: 'cyan',
-  },
-  {
     category: CATEGORY_LABELS.camera,
     title: 'Lens Equivalency',
     description: 'Compare format lens differences',
@@ -93,7 +86,15 @@ const CALCULATORS = [
     description: 'Equivalent exposure calculator',
     href: '/exposure',
     icon: Camera,
-    accent: 'sky',
+    accent: 'teal',
+  },
+  {
+    category: CATEGORY_LABELS.reference,
+    title: 'Film Database',
+    description: 'Browse film stocks by brand & ISO',
+    href: '/films',
+    icon: Film,
+    accent: 'cyan',
   },
 ] as const;
 
@@ -110,28 +111,6 @@ const COMING_SOON = [
   },
 ];
 
-const CALCULATOR_CATEGORIES = [
-  CATEGORY_LABELS.printing,
-  CATEGORY_LABELS.film,
-  CATEGORY_LABELS.camera,
-  CATEGORY_LABELS.reference,
-] as const;
-
-// Group calculators by category in a single pass, preserving the order above.
-type CalculatorCard = Omit<(typeof CALCULATORS)[number], 'category'>;
-const CALCULATORS_BY_CATEGORY = (() => {
-  const groups = new Map<string, CalculatorCard[]>(
-    CALCULATOR_CATEGORIES.map((label) => [label, []])
-  );
-  for (const { category, ...tool } of CALCULATORS) {
-    groups.get(category)?.push(tool);
-  }
-  return CALCULATOR_CATEGORIES.map((label) => ({
-    label,
-    tools: groups.get(label) ?? [],
-  }));
-})();
-
 export function HomePage() {
   const { data: stats, isPending: isStatsLoading } = useStats();
   // Compute the year client-only to avoid a render-time new Date() value.
@@ -141,12 +120,18 @@ export function HomePage() {
     setCurrentYear(new Date().getFullYear());
   }, []);
 
+  const heroStats = [
+    { value: stats?.combinations, label: 'development recipes' },
+    { value: stats?.films, label: 'film stocks' },
+    { value: stats?.developers, label: 'developers' },
+  ];
+
   return (
     <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8 pb-24 space-y-10">
-      {/* Hero Section */}
-      <div className="grid grid-cols-1 md:grid-cols-12 gap-4 lg:gap-6">
-        {/* Hero copy + CTAs - unboxed */}
-        <div className="md:col-span-8 flex flex-col justify-between gap-6">
+      {/* Hero: one grain-textured panel - copy + CTAs on the left, live
+          border preview on the right */}
+      <div className="hero-grain rounded-3xl border border-[color:var(--color-border-secondary)] p-6 sm:p-8 shadow-subtle grid grid-cols-1 md:grid-cols-12 gap-6 lg:gap-10 md:items-center">
+        <div className="md:col-span-7 flex flex-col gap-5">
           <div>
             <Greeting />
             <p className="text-lg sm:text-xl mt-2 text-[color:var(--color-text-secondary)]">
@@ -157,6 +142,21 @@ export function HomePage() {
               exposure tools. Free and open source.
             </p>
           </div>
+          <p className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-[color:var(--color-text-tertiary)]">
+            {heroStats.map(({ value, label }, index) => (
+              <span key={label} className="inline-flex items-center gap-x-2">
+                {index > 0 ? <span aria-hidden>·</span> : null}
+                <span>
+                  <span className="font-bold text-[color:var(--color-text-secondary)]">
+                    {isStatsLoading || value === undefined
+                      ? '-'
+                      : value.toLocaleString()}
+                  </span>{' '}
+                  {label}
+                </span>
+              </span>
+            ))}
+          </p>
           <div className="flex flex-wrap gap-2">
             <Link
               to="/border"
@@ -174,39 +174,8 @@ export function HomePage() {
             </Link>
           </div>
         </div>
-        {/* Quick Stats / Actions */}
-        <div className="md:col-span-4 grid grid-cols-2 gap-3">
-          <StatCard
-            as={Link}
-            to="/development"
-            label="Development Recipes"
-            value={stats ? stats.combinations.toLocaleString() : '-'}
-            icon={FlaskConical}
-            iconColorKey="emerald"
-            variant="horizontal"
-            className="col-span-2"
-            loading={isStatsLoading}
-          />
-
-          <StatCard
-            as={Link}
-            to="/films"
-            label="Film Stocks"
-            value={stats ? stats.films.toLocaleString() : '-'}
-            icon={Film}
-            iconColorKey="rose"
-            loading={isStatsLoading}
-          />
-
-          <StatCard
-            as={Link}
-            to="/development"
-            label="Developers"
-            value={stats ? stats.developers.toLocaleString() : '-'}
-            icon={TestTubes}
-            iconColorKey="indigo"
-            loading={isStatsLoading}
-          />
+        <div className="hidden md:block md:col-span-5">
+          <HomeHeroPreview />
         </div>
       </div>
 
@@ -223,69 +192,50 @@ export function HomePage() {
           />
         </div>
 
-        <div className="space-y-6">
-          {CALCULATORS_BY_CATEGORY.map(({ label, tools }) => (
-            <div key={label}>
-              <h3 className="text-sm font-medium text-[color:var(--color-text-tertiary)] uppercase tracking-wider mb-3">
-                {label}
-              </h3>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                {tools.map((tool) => (
-                  <ToolCard
-                    key={tool.title}
-                    {...tool}
-                    as={Link}
-                    href={tool.href}
-                  />
-                ))}
-              </div>
-            </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 auto-rows-fr">
+          {CALCULATORS.map((tool, index) => (
+            <ToolCard
+              key={tool.title}
+              {...tool}
+              as={Link}
+              href={tool.href}
+              className={
+                index === CALCULATORS.length - 1
+                  ? 'sm:col-span-2 lg:col-span-1'
+                  : undefined
+              }
+            />
           ))}
         </div>
       </div>
 
-      {/* Coming Soon Section */}
-      <div>
-        <div
-          className="flex items-center justify-between mb-6"
-          data-coming-soon-section
-        >
-          <h2 className="text-xl font-semibold text-[color:var(--color-text-primary)] flex items-center gap-2">
-            <Construction
-              className="size-5 text-[color:var(--color-text-tertiary)]"
+      {/* Coming Soon - quiet strip below the grid */}
+      <div
+        className="rounded-2xl border border-dashed px-4 py-3 flex flex-col sm:flex-row sm:items-center gap-x-8 gap-y-2"
+        style={{
+          borderColor: 'var(--color-border-secondary)',
+          backgroundColor: 'var(--color-surface-muted)',
+        }}
+        data-coming-soon-section
+      >
+        <span className="flex shrink-0 items-center gap-2 text-xs font-bold uppercase tracking-wider text-[color:var(--color-text-tertiary)]">
+          <Construction className="size-4" data-coming-soon />
+          Coming soon
+        </span>
+        {COMING_SOON.map((item) => (
+          <div key={item.title} className="flex items-center gap-2 min-w-0">
+            <item.icon
+              className="size-4 shrink-0 text-[color:var(--color-text-tertiary)]"
               data-coming-soon
             />
-            Coming Soon
-          </h2>
-          <div
-            className="h-px flex-1 ml-4"
-            style={{ backgroundColor: 'var(--color-border-primary)' }}
-          />
-        </div>
-
-        <div
-          className="rounded-2xl border border-dashed p-4 flex flex-col sm:flex-row sm:items-center gap-4 sm:gap-8"
-          style={{
-            borderColor: 'var(--color-border-secondary)',
-            backgroundColor: 'var(--color-surface-muted)',
-          }}
-          data-coming-soon-section
-        >
-          {COMING_SOON.map((item) => (
-            <div key={item.title} className="flex items-center gap-2 min-w-0">
-              <item.icon
-                className="size-4 shrink-0 text-[color:var(--color-text-tertiary)]"
-                data-coming-soon
-              />
-              <span className="font-medium text-[color:var(--color-text-secondary)]">
-                {item.title}
-              </span>
-              <span className="text-sm text-[color:var(--color-text-tertiary)] truncate">
-                {item.description}
-              </span>
-            </div>
-          ))}
-        </div>
+            <span className="font-medium text-[color:var(--color-text-secondary)]">
+              {item.title}
+            </span>
+            <span className="text-sm text-[color:var(--color-text-tertiary)] truncate">
+              {item.description}
+            </span>
+          </div>
+        ))}
       </div>
 
       {/* Footer Links - Minimal */}

--- a/apps/dorkroom/src/app/pages/home-page.tsx
+++ b/apps/dorkroom/src/app/pages/home-page.tsx
@@ -29,9 +29,7 @@ const CALCULATORS = [
     description: 'Print borders & trim guides',
     href: '/border',
     icon: Crop,
-    color: 'text-indigo-400',
-    bg: 'from-indigo-500/20 to-purple-500/20',
-    border: 'group-hover:border-indigo-500/50',
+    accent: 'indigo',
   },
   {
     category: CATEGORY_LABELS.printing,
@@ -39,9 +37,7 @@ const CALCULATORS = [
     description: 'F-stop & time math',
     href: '/stops',
     icon: Gauge,
-    color: 'text-blue-400',
-    bg: 'from-blue-500/20 to-cyan-500/20',
-    border: 'group-hover:border-blue-500/50',
+    accent: 'blue',
   },
   {
     category: CATEGORY_LABELS.printing,
@@ -49,9 +45,7 @@ const CALCULATORS = [
     description: 'Scale prints, no wasting test strips',
     href: '/resize',
     icon: Ruler,
-    color: 'text-violet-400',
-    bg: 'from-violet-500/20 to-fuchsia-500/20',
-    border: 'group-hover:border-violet-500/50',
+    accent: 'violet',
   },
   {
     category: CATEGORY_LABELS.printing,
@@ -59,9 +53,7 @@ const CALCULATORS = [
     description: 'Window openings & cut guides',
     href: '/mat',
     icon: Frame,
-    color: 'text-teal-400',
-    bg: 'from-teal-500/20 to-emerald-500/20',
-    border: 'group-hover:border-teal-500/50',
+    accent: 'teal',
   },
   {
     category: CATEGORY_LABELS.film,
@@ -69,9 +61,7 @@ const CALCULATORS = [
     description: 'Film long exposure correction',
     href: '/reciprocity',
     icon: Timer,
-    color: 'text-amber-400',
-    bg: 'from-amber-500/20 to-orange-500/20',
-    border: 'group-hover:border-amber-500/50',
+    accent: 'amber',
   },
   {
     category: CATEGORY_LABELS.film,
@@ -79,9 +69,7 @@ const CALCULATORS = [
     description: 'B&W film development database',
     href: '/development',
     icon: FlaskConical,
-    color: 'text-rose-400',
-    bg: 'from-rose-500/20 to-red-500/20',
-    border: 'group-hover:border-rose-500/50',
+    accent: 'rose',
   },
   {
     category: CATEGORY_LABELS.reference,
@@ -89,9 +77,7 @@ const CALCULATORS = [
     description: 'Browse film stocks by brand & ISO',
     href: '/films',
     icon: Film,
-    color: 'text-cyan-400',
-    bg: 'from-cyan-500/20 to-teal-500/20',
-    border: 'group-hover:border-cyan-500/50',
+    accent: 'cyan',
   },
   {
     category: CATEGORY_LABELS.camera,
@@ -99,9 +85,7 @@ const CALCULATORS = [
     description: 'Compare format lens differences',
     href: '/lenses',
     icon: Focus,
-    color: 'text-emerald-400',
-    bg: 'from-emerald-500/20 to-teal-500/20',
-    border: 'group-hover:border-emerald-500/50',
+    accent: 'emerald',
   },
   {
     category: CATEGORY_LABELS.camera,
@@ -109,9 +93,7 @@ const CALCULATORS = [
     description: 'Equivalent exposure calculator',
     href: '/exposure',
     icon: Camera,
-    color: 'text-sky-400',
-    bg: 'from-sky-500/20 to-blue-500/20',
-    border: 'group-hover:border-sky-500/50',
+    accent: 'sky',
   },
 ] as const;
 

--- a/apps/dorkroom/src/app/pages/home-page.tsx
+++ b/apps/dorkroom/src/app/pages/home-page.tsx
@@ -99,18 +99,38 @@ const CALCULATORS = [
 
 const COMING_SOON = [
   {
-    category: 'Resources',
     title: 'Docs',
     description: 'Documentation for Dorkroom',
     icon: BookOpen,
   },
   {
-    category: 'Knowledge',
     title: 'Infobase',
     description: 'Photography & darkroom guides',
     icon: GraduationCap,
   },
 ];
+
+const CALCULATOR_CATEGORIES = [
+  CATEGORY_LABELS.printing,
+  CATEGORY_LABELS.film,
+  CATEGORY_LABELS.camera,
+  CATEGORY_LABELS.reference,
+] as const;
+
+// Group calculators by category in a single pass, preserving the order above.
+type CalculatorCard = Omit<(typeof CALCULATORS)[number], 'category'>;
+const CALCULATORS_BY_CATEGORY = (() => {
+  const groups = new Map<string, CalculatorCard[]>(
+    CALCULATOR_CATEGORIES.map((label) => [label, []])
+  );
+  for (const { category, ...tool } of CALCULATORS) {
+    groups.get(category)?.push(tool);
+  }
+  return CALCULATOR_CATEGORIES.map((label) => ({
+    label,
+    tools: groups.get(label) ?? [],
+  }));
+})();
 
 export function HomePage() {
   const { data: stats, isPending: isStatsLoading } = useStats();
@@ -123,57 +143,35 @@ export function HomePage() {
 
   return (
     <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8 pb-24 space-y-10">
-      {/* Header Section */}
-      <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-6">
-        <Greeting />
-      </div>
-
-      {/* Featured Dashboard Grid */}
+      {/* Hero Section */}
       <div className="grid grid-cols-1 md:grid-cols-12 gap-4 lg:gap-6">
-        {/* Main Hero - Compact */}
-        <div className="md:col-span-8 relative overflow-hidden rounded-3xl border p-6 sm:p-8 transition-all group hero-card">
-          <div
-            className="absolute top-0 right-0 blur-3xl rounded-full"
-            style={{
-              backgroundImage: 'var(--gradient-hero-accent)',
-              width: 'var(--size-hero-blob)',
-              height: 'var(--size-hero-blob)',
-              marginTop: 'var(--spacing-hero-blob-offset)',
-              marginRight: 'var(--spacing-hero-blob-offset)',
-            }}
-          />
-          <div className="relative z-10 flex flex-col justify-between h-full gap-6">
-            <div>
-              <h2
-                className="text-2xl font-semibold mb-2"
-                style={{ color: 'var(--color-hero-title)' }}
-              >
-                Skip the math. Make prints!
-              </h2>
-              <p
-                className="max-w-md"
-                style={{ color: 'var(--color-hero-text)' }}
-              >
-                Darkroom printing calculators, film development recipes, and
-                exposure tools. Free and open source.
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <Link
-                to="/border"
-                className="inline-flex items-center gap-2 px-4 py-2 rounded-xl font-medium text-sm transition-colors hero-button-success"
-              >
-                <Crop className="size-4" />
-                Calculate darkroom easel borders
-              </Link>
-              <Link
-                to="/development"
-                className="inline-flex items-center gap-2 px-4 py-2 rounded-xl font-medium text-sm transition-colors hero-button-error"
-              >
-                <FlaskConical className="size-4" />
-                Search film development recipes
-              </Link>
-            </div>
+        {/* Hero copy + CTAs - unboxed */}
+        <div className="md:col-span-8 flex flex-col justify-between gap-6">
+          <div>
+            <Greeting />
+            <p className="text-lg sm:text-xl mt-2 text-[color:var(--color-text-secondary)]">
+              Skip the math. Make prints!
+            </p>
+            <p className="max-w-md mt-2 text-[color:var(--color-text-tertiary)]">
+              Darkroom printing calculators, film development recipes, and
+              exposure tools. Free and open source.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              to="/border"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl font-medium text-sm button-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border-primary)]"
+            >
+              <Crop className="size-4" />
+              Calculate darkroom easel borders
+            </Link>
+            <Link
+              to="/development"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl font-medium text-sm button-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border-primary)]"
+            >
+              <FlaskConical className="size-4" />
+              Search film development recipes
+            </Link>
           </div>
         </div>
         {/* Quick Stats / Actions */}
@@ -225,9 +223,23 @@ export function HomePage() {
           />
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {CALCULATORS.map((tool) => (
-            <ToolCard key={tool.title} {...tool} as={Link} href={tool.href} />
+        <div className="space-y-6">
+          {CALCULATORS_BY_CATEGORY.map(({ label, tools }) => (
+            <div key={label}>
+              <h3 className="text-sm font-medium text-[color:var(--color-text-tertiary)] uppercase tracking-wider mb-3">
+                {label}
+              </h3>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {tools.map((tool) => (
+                  <ToolCard
+                    key={tool.title}
+                    {...tool}
+                    as={Link}
+                    href={tool.href}
+                  />
+                ))}
+              </div>
+            </div>
           ))}
         </div>
       </div>
@@ -252,41 +264,25 @@ export function HomePage() {
         </div>
 
         <div
-          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+          className="rounded-2xl border border-dashed p-4 flex flex-col sm:flex-row sm:items-center gap-4 sm:gap-8"
+          style={{
+            borderColor: 'var(--color-border-secondary)',
+            backgroundColor: 'var(--color-surface-muted)',
+          }}
           data-coming-soon-section
         >
           {COMING_SOON.map((item) => (
-            <div
-              key={item.title}
-              className="relative overflow-hidden rounded-2xl border border-dashed p-5"
-              style={{
-                borderColor: 'var(--color-border-secondary)',
-                backgroundColor: 'var(--color-surface-muted)',
-              }}
-            >
-              <div className="flex items-start gap-4">
-                <div
-                  className="p-3 rounded-xl border"
-                  style={{
-                    backgroundColor: 'var(--color-surface)',
-                    borderColor: 'var(--color-border-secondary)',
-                    color: 'var(--color-text-tertiary)',
-                  }}
-                >
-                  <item.icon className="size-6" data-coming-soon />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <p className="text-[10px] font-bold uppercase tracking-wider text-[color:var(--color-text-tertiary)] mb-1">
-                    {item.category}
-                  </p>
-                  <h3 className="font-semibold text-[color:var(--color-text-secondary)] truncate pr-4">
-                    {item.title}
-                  </h3>
-                  <p className="text-sm text-[color:var(--color-text-tertiary)] line-clamp-1">
-                    {item.description}
-                  </p>
-                </div>
-              </div>
+            <div key={item.title} className="flex items-center gap-2 min-w-0">
+              <item.icon
+                className="size-4 shrink-0 text-[color:var(--color-text-tertiary)]"
+                data-coming-soon
+              />
+              <span className="font-medium text-[color:var(--color-text-secondary)]">
+                {item.title}
+              </span>
+              <span className="text-sm text-[color:var(--color-text-tertiary)] truncate">
+                {item.description}
+              </span>
             </div>
           ))}
         </div>

--- a/apps/dorkroom/src/app/pages/home-page.tsx
+++ b/apps/dorkroom/src/app/pages/home-page.tsx
@@ -1,5 +1,5 @@
 import { useStats } from '@dorkroom/logic';
-import { Greeting, StatCard, ToolCard } from '@dorkroom/ui';
+import { CATEGORY_LABELS, Greeting, StatCard, ToolCard } from '@dorkroom/ui';
 import { Link } from '@tanstack/react-router';
 import {
   BookOpen,
@@ -24,7 +24,7 @@ import { useEffect, useState } from 'react';
 // Calculator tools configuration - module level to prevent recreation on each render
 const CALCULATORS = [
   {
-    category: 'Darkroom Printing',
+    category: CATEGORY_LABELS.printing,
     title: 'Border Calculator',
     description: 'Print borders & trim guides',
     href: '/border',
@@ -34,7 +34,7 @@ const CALCULATORS = [
     border: 'group-hover:border-indigo-500/50',
   },
   {
-    category: 'Darkroom Printing',
+    category: CATEGORY_LABELS.printing,
     title: 'Stops Calculator',
     description: 'F-stop & time math',
     href: '/stops',
@@ -44,7 +44,7 @@ const CALCULATORS = [
     border: 'group-hover:border-blue-500/50',
   },
   {
-    category: 'Darkroom Printing',
+    category: CATEGORY_LABELS.printing,
     title: 'Resize Calculator',
     description: 'Scale prints, no wasting test strips',
     href: '/resize',
@@ -54,7 +54,7 @@ const CALCULATORS = [
     border: 'group-hover:border-violet-500/50',
   },
   {
-    category: 'Darkroom Printing',
+    category: CATEGORY_LABELS.printing,
     title: 'Mat Cut Calculator',
     description: 'Window openings & cut guides',
     href: '/mat',
@@ -64,7 +64,7 @@ const CALCULATORS = [
     border: 'group-hover:border-teal-500/50',
   },
   {
-    category: 'Film',
+    category: CATEGORY_LABELS.film,
     title: 'Reciprocity',
     description: 'Film long exposure correction',
     href: '/reciprocity',
@@ -74,7 +74,7 @@ const CALCULATORS = [
     border: 'group-hover:border-amber-500/50',
   },
   {
-    category: 'Film',
+    category: CATEGORY_LABELS.film,
     title: 'Film Development Recipes',
     description: 'B&W film development database',
     href: '/development',
@@ -84,7 +84,7 @@ const CALCULATORS = [
     border: 'group-hover:border-rose-500/50',
   },
   {
-    category: 'Film Reference',
+    category: CATEGORY_LABELS.reference,
     title: 'Film Database',
     description: 'Browse film stocks by brand & ISO',
     href: '/films',
@@ -94,7 +94,7 @@ const CALCULATORS = [
     border: 'group-hover:border-cyan-500/50',
   },
   {
-    category: 'Film & Digital',
+    category: CATEGORY_LABELS.camera,
     title: 'Lens Equivalency',
     description: 'Compare format lens differences',
     href: '/lenses',
@@ -104,7 +104,7 @@ const CALCULATORS = [
     border: 'group-hover:border-emerald-500/50',
   },
   {
-    category: 'Film & Digital',
+    category: CATEGORY_LABELS.camera,
     title: 'Camera Exposure',
     description: 'Equivalent exposure calculator',
     href: '/exposure',

--- a/apps/dorkroom/src/app/pages/lens-calculator/lens-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/lens-calculator/lens-calculator-page.tsx
@@ -93,6 +93,7 @@ const FOCAL_LENGTH_PRESETS = [
   { value: 135, label: '135' },
 ];
 
+// eslint-disable-next-line react-doctor/no-giant-component -- component size pre-dates this plan; will be split in plan 007
 export default function LensCalculatorPage() {
   const form = useForm({
     defaultValues: {
@@ -291,17 +292,29 @@ export default function LensCalculatorPage() {
                   />
                 </div>
 
-                <div className="rounded-xl p-3 font-mono text-sm border border-secondary bg-background/20 text-primary text-center">
+                <div
+                  className="rounded-xl p-3 font-mono text-sm border border-secondary bg-background/20 text-center"
+                  style={{ color: 'var(--color-on-accent)' }}
+                >
                   {formatFocalLength(calculation.focalLength)}
-                  <span className="text-tertiary"> on </span>
+                  <span style={{ color: 'var(--color-on-accent-muted)' }}>
+                    {' '}
+                    on{' '}
+                  </span>
                   <span className="font-medium">
                     {calculation.sourceFormat.shortName}
                   </span>
-                  <span className="text-tertiary"> = </span>
+                  <span style={{ color: 'var(--color-on-accent-muted)' }}>
+                    {' '}
+                    ={' '}
+                  </span>
                   <span className="font-semibold">
                     {formatFocalLength(calculation.equivalentFocalLength)}
                   </span>
-                  <span className="text-tertiary"> on </span>
+                  <span style={{ color: 'var(--color-on-accent-muted)' }}>
+                    {' '}
+                    on{' '}
+                  </span>
                   <span className="font-medium">
                     {calculation.targetFormat.shortName}
                   </span>

--- a/apps/dorkroom/src/app/pages/lens-calculator/lens-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/lens-calculator/lens-calculator-page.tsx
@@ -8,7 +8,12 @@ import {
   SENSOR_FORMATS,
   useLocalStorageFormPersistence,
 } from '@dorkroom/logic';
-import { ResultRow, Select, SensorSizeVisualization } from '@dorkroom/ui';
+import {
+  getRouteIcon,
+  ResultRow,
+  Select,
+  SensorSizeVisualization,
+} from '@dorkroom/ui';
 import {
   CalculatorCard,
   CalculatorNumberField,
@@ -93,7 +98,7 @@ const FOCAL_LENGTH_PRESETS = [
   { value: 135, label: '135' },
 ];
 
-// eslint-disable-next-line react-doctor/no-giant-component -- component size pre-dates this plan; will be split in plan 007
+// eslint-disable-next-line react-doctor/no-giant-component -- size pre-dates plan 007, which only added the accent header here; a results-card extraction (needs threading `form` to a child) stays deferred to avoid regression risk on this flagship page
 export default function LensCalculatorPage() {
   const form = useForm({
     defaultValues: {
@@ -149,6 +154,8 @@ export default function LensCalculatorPage() {
     <div className="mx-auto max-w-7xl px-6 pb-16 pt-12 sm:px-10">
       <CalculatorPageHeader
         eyebrow="Format Comparison"
+        icon={getRouteIcon('/lenses')}
+        accentTone="emerald"
         title="Lens Equivalency Calculator"
         description="Calculate equivalent focal lengths between different sensor and film formats. Find out what lens gives you the same field of view when switching between cameras or formats."
       />

--- a/apps/dorkroom/src/app/pages/mat-calculator/mat-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/mat-calculator/mat-calculator-page.tsx
@@ -9,7 +9,7 @@ import {
   toFractionInput,
   useLocalStorageFormPersistence,
 } from '@dorkroom/logic';
-import { StatusAlert } from '@dorkroom/ui';
+import { getRouteIcon, StatusAlert } from '@dorkroom/ui';
 import {
   CalculatorCard,
   CalculatorLayout,
@@ -431,12 +431,12 @@ function MatResults({
       <CalculatorCard
         title="Window opening"
         description="Sight opening, short point to short point."
-        accent="emerald"
+        accent="cyan"
         padding="compact"
       >
         <div className="grid gap-4 sm:grid-cols-2">
-          <CalculatorStat label="Width" value={fmt(windowW)} tone="emerald" />
-          <CalculatorStat label="Height" value={fmt(windowH)} tone="emerald" />
+          <CalculatorStat label="Width" value={fmt(windowW)} tone="cyan" />
+          <CalculatorStat label="Height" value={fmt(windowH)} tone="cyan" />
         </div>
       </CalculatorCard>
     </>
@@ -701,6 +701,8 @@ export default function MatCalculatorPage() {
   return (
     <CalculatorLayout
       title="Mat Cut Calculator"
+      icon={getRouteIcon('/mat')}
+      accentTone="cyan"
       description="Plan single-window mats with independent borders and get exact window openings and cutter guide-bar settings."
       results={
         <MatResults

--- a/apps/dorkroom/src/app/pages/mat-calculator/mat-diagram.tsx
+++ b/apps/dorkroom/src/app/pages/mat-calculator/mat-diagram.tsx
@@ -18,7 +18,10 @@ interface MatDiagramProps {
 // var() resolves — presentation attributes do not).
 const INK = 'var(--color-text-primary)';
 const SOFT = 'var(--color-text-tertiary)';
-const ACCENT = 'var(--color-primary)';
+// Mat calculator carries the cyan accent (plan 007). The diagram uses the
+// solid cyan token rather than the brand green so the page reads as its own
+// tool; collapses to red/black in darkroom/high-contrast like other accents.
+const ACCENT = 'var(--accent-cyan-text)';
 const PANEL = 'var(--color-surface)';
 
 interface MatGeometry {

--- a/apps/dorkroom/src/app/pages/reciprocity-calculator/reciprocity-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/reciprocity-calculator/reciprocity-calculator-page.tsx
@@ -8,7 +8,13 @@ import {
   type SelectItem,
   useLocalStorageFormPersistence,
 } from '@dorkroom/logic';
-import { ReciprocityChart, ResultRow, Select, TextInput } from '@dorkroom/ui';
+import {
+  getRouteIcon,
+  ReciprocityChart,
+  ResultRow,
+  Select,
+  TextInput,
+} from '@dorkroom/ui';
 import {
   CalculatorCard,
   CalculatorLayout,
@@ -165,7 +171,7 @@ function ReciprocityResults({
     <CalculatorCard
       title="Reciprocity results"
       description="Your exposure time corrected for reciprocity failure"
-      accent="emerald"
+      accent="amber"
       padding="compact"
       actions={
         <button
@@ -201,7 +207,7 @@ function ReciprocityResults({
           label="Adjusted exposure"
           value={formatReciprocityTime(calculation.adjustedTime)}
           helperText={`Recommended for ${calculation.filmName}`}
-          tone="emerald"
+          tone="amber"
         />
         <CalculatorStat
           label="Added exposure"
@@ -298,7 +304,7 @@ function ReciprocityWideChart({
       <CalculatorCard
         title={`Reciprocity curve for ${calculation.filmName}`}
         description="Hover over the curve to explore reciprocity calculations for different exposure times."
-        accent="emerald"
+        accent="amber"
         padding="normal"
         actions={
           <button
@@ -507,6 +513,8 @@ export default function ReciprocityCalculatorPage() {
   return (
     <CalculatorLayout
       title="Reciprocity Failure Calculator"
+      icon={getRouteIcon('/reciprocity')}
+      accentTone="amber"
       description={
         <>
           Long exposures need more time than your meter says.

--- a/apps/dorkroom/src/app/pages/resize-calculator/resize-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/resize-calculator/resize-calculator-page.tsx
@@ -14,7 +14,6 @@ import {
   colorMixOr,
   getRouteIcon,
   StatusAlert,
-  ToggleSwitch,
   useMeasurement,
   useMeasurementConverter,
 } from '@dorkroom/ui';
@@ -38,6 +37,11 @@ interface ModeToggleProps {
   onModeChange: (value: boolean) => void;
 }
 
+const MODE_OPTIONS = [
+  { label: 'Print Size', isEnlargerHeight: false },
+  { label: 'Enlarger Height', isEnlargerHeight: true },
+] as const;
+
 function ModeToggle({ isEnlargerHeightMode, onModeChange }: ModeToggleProps) {
   return (
     <div
@@ -53,52 +57,42 @@ function ModeToggle({ isEnlargerHeightMode, onModeChange }: ModeToggleProps) {
       }}
     >
       <p
-        className="text-sm font-semibold uppercase tracking-[0.3em]"
+        className="text-xs font-semibold uppercase tracking-[0.2em]"
         style={{ color: 'var(--color-text-muted)' }}
       >
         Method
       </p>
-      <div
-        className="flex items-center justify-center gap-2 rounded-full px-3 py-2 sm:gap-3 sm:px-4"
+      <fieldset
+        className="grid grid-cols-2 gap-1 rounded-full border p-1"
         style={{
           borderColor: 'var(--color-border-muted)',
-          backgroundColor: colorMixOr(
-            'var(--color-surface)',
-            20,
-            'transparent',
-            'var(--color-surface)'
-          ),
-          border: '1px solid',
+          backgroundColor: 'rgb(var(--color-background-rgb) / 0.3)',
         }}
       >
-        <span
-          className="text-[10px] uppercase tracking-[0.15em] transition-colors sm:text-xs sm:tracking-[0.3em]"
-          style={{
-            color: isEnlargerHeightMode
-              ? 'var(--color-text-muted)'
-              : 'var(--color-text-primary)',
-            fontWeight: isEnlargerHeightMode ? 500 : 600,
-          }}
-        >
-          Print Size
-        </span>
-        <ToggleSwitch
-          label="Toggle between Print Size and Enlarger Height mode"
-          value={isEnlargerHeightMode}
-          onValueChange={onModeChange}
-        />
-        <span
-          className="text-[10px] uppercase tracking-[0.15em] transition-colors sm:text-xs sm:tracking-[0.3em]"
-          style={{
-            color: isEnlargerHeightMode
-              ? 'var(--color-text-primary)'
-              : 'var(--color-text-muted)',
-            fontWeight: isEnlargerHeightMode ? 600 : 500,
-          }}
-        >
-          Enlarger Height
-        </span>
-      </div>
+        <legend className="sr-only">Calculation method</legend>
+        {MODE_OPTIONS.map((option) => {
+          const active = option.isEnlargerHeight === isEnlargerHeightMode;
+          return (
+            <button
+              key={option.label}
+              type="button"
+              aria-pressed={active}
+              onClick={() => onModeChange(option.isEnlargerHeight)}
+              className="rounded-full px-4 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border-primary)]"
+              style={
+                active
+                  ? {
+                      backgroundColor: 'var(--color-text-primary)',
+                      color: 'var(--color-background)',
+                    }
+                  : { color: 'var(--color-text-muted)' }
+              }
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </fieldset>
     </div>
   );
 }

--- a/apps/dorkroom/src/app/pages/resize-calculator/resize-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/resize-calculator/resize-calculator-page.tsx
@@ -72,19 +72,29 @@ function ModeToggle({ isEnlargerHeightMode, onModeChange }: ModeToggleProps) {
         }}
       >
         <span
-          className="text-[10px] font-medium uppercase tracking-[0.15em] sm:text-xs sm:tracking-[0.3em]"
-          style={{ color: 'var(--color-text-tertiary)' }}
+          className="text-[10px] uppercase tracking-[0.15em] transition-colors sm:text-xs sm:tracking-[0.3em]"
+          style={{
+            color: isEnlargerHeightMode
+              ? 'var(--color-text-muted)'
+              : 'var(--color-text-primary)',
+            fontWeight: isEnlargerHeightMode ? 500 : 600,
+          }}
         >
           Print Size
         </span>
         <ToggleSwitch
-          label=""
+          label="Toggle between Print Size and Enlarger Height mode"
           value={isEnlargerHeightMode}
           onValueChange={onModeChange}
         />
         <span
-          className="text-[10px] font-medium uppercase tracking-[0.15em] sm:text-xs sm:tracking-[0.3em]"
-          style={{ color: 'var(--color-text-tertiary)' }}
+          className="text-[10px] uppercase tracking-[0.15em] transition-colors sm:text-xs sm:tracking-[0.3em]"
+          style={{
+            color: isEnlargerHeightMode
+              ? 'var(--color-text-primary)'
+              : 'var(--color-text-muted)',
+            fontWeight: isEnlargerHeightMode ? 600 : 500,
+          }}
         >
           Enlarger Height
         </span>

--- a/apps/dorkroom/src/app/pages/resize-calculator/resize-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/resize-calculator/resize-calculator-page.tsx
@@ -12,6 +12,7 @@ import {
 } from '@dorkroom/logic';
 import {
   colorMixOr,
+  getRouteIcon,
   StatusAlert,
   ToggleSwitch,
   useMeasurement,
@@ -329,14 +330,14 @@ function ResizeResults({ form }: { form: ResizeForm }) {
           <CalculatorCard
             title="Exposure result"
             description="Dial these in on your timer and make a quick test strip to confirm."
-            accent="emerald"
+            accent="teal"
             padding="compact"
           >
             <div className="grid gap-4 sm:grid-cols-2">
               <CalculatorStat
                 label="New time"
                 value={`${newTime} seconds`}
-                tone="emerald"
+                tone="teal"
                 helperText="Based on your original exposure and target size."
               />
               <CalculatorStat
@@ -660,6 +661,8 @@ export default function ResizeCalculatorPage() {
   return (
     <CalculatorLayout
       title="Print Resize Calculator"
+      icon={getRouteIcon('/resize')}
+      accentTone="teal"
       description="Scale a print up or down and get a solid starting exposure without burning through paper."
       results={<ResizeResults form={form} />}
       sidebar={

--- a/apps/dorkroom/src/app/pages/resize-calculator/resize-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/resize-calculator/resize-calculator-page.tsx
@@ -15,7 +15,7 @@ import {
   StatusAlert,
   ToggleSwitch,
   useMeasurement,
-  type useMeasurementConverter,
+  useMeasurementConverter,
 } from '@dorkroom/ui';
 import {
   CalculatorCard,

--- a/apps/dorkroom/src/routes/__root.tsx
+++ b/apps/dorkroom/src/routes/__root.tsx
@@ -179,7 +179,7 @@ function RootComponent() {
                     href="https://github.com/narrowstacks/dorkroom"
                     target="_blank"
                     rel="noreferrer"
-                    className="nav-button flex size-9 items-center justify-center rounded-full transition focus-visible:outline-none"
+                    className="nav-button flex size-9 items-center justify-center rounded-full transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border-primary)]"
                     style={{
                       color: 'var(--color-text-primary)',
                       borderColor: 'var(--color-border-secondary)',
@@ -196,7 +196,7 @@ function RootComponent() {
                     href="https://news.dorkroom.art"
                     target="_blank"
                     rel="noreferrer"
-                    className="nav-button flex size-9 items-center justify-center rounded-full transition focus-visible:outline-none"
+                    className="nav-button flex size-9 items-center justify-center rounded-full transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border-primary)]"
                     style={{
                       color: 'var(--color-text-primary)',
                       borderColor: 'var(--color-border-secondary)',
@@ -214,7 +214,7 @@ function RootComponent() {
                 <Tooltip label="Settings">
                   <Link
                     to="/settings"
-                    className="nav-button flex size-9 items-center justify-center rounded-full transition focus-visible:outline-none"
+                    className="nav-button flex size-9 items-center justify-center rounded-full transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border-primary)]"
                     style={{
                       color: 'var(--color-text-primary)',
                       borderColor: 'var(--color-border-secondary)',
@@ -232,7 +232,7 @@ function RootComponent() {
 
           <button
             type="button"
-            className="fixed bottom-[calc(env(safe-area-inset-bottom)+1rem)] right-[calc(env(safe-area-inset-right)+1rem)] z-50 flex size-12 items-center justify-center rounded-full shadow-lg backdrop-blur transition focus-visible:outline-none sm:hidden"
+            className="fixed bottom-[calc(env(safe-area-inset-bottom)+1rem)] right-[calc(env(safe-area-inset-right)+1rem)] z-50 flex size-12 items-center justify-center rounded-full shadow-lg backdrop-blur transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border-primary)] sm:hidden"
             style={{
               color: 'var(--color-background)',
               borderColor: 'var(--color-background)',

--- a/apps/dorkroom/src/styles/components.css
+++ b/apps/dorkroom/src/styles/components.css
@@ -411,16 +411,29 @@
     border: 2px solid var(--color-primary);
   }
 
-  /* Hero Card Styles */
-  .hero-card {
-    border-color: var(--color-hero-border);
-    background-color: var(--color-hero-bg);
-    transition: border-color 0.2s;
+  /* Home page CTA buttons */
+  .button-primary {
+    background-color: var(--color-text-primary);
+    color: var(--color-background);
+    transition:
+      background-color 0.2s,
+      opacity 0.2s;
   }
 
-  /* .hero-card:hover {
-    border-color: var(--color-hero-border-hover);
-  } */
+  .button-primary:hover {
+    opacity: 0.85;
+  }
+
+  .button-secondary {
+    border: 1px solid var(--color-border-primary);
+    color: var(--color-text-primary);
+    background-color: transparent;
+    transition: background-color 0.2s;
+  }
+
+  .button-secondary:hover {
+    background-color: var(--color-surface-muted);
+  }
 
   /* Hero Button Styles */
   .hero-button-success {

--- a/apps/dorkroom/src/styles/components.css
+++ b/apps/dorkroom/src/styles/components.css
@@ -435,6 +435,69 @@
     background-color: var(--color-surface-muted);
   }
 
+  /* Home hero panel: subtle red movie-grain texture over the surface color
+     (SVG fractal noise tinted red, tiled). The grain jumps position in hard
+     steps like projected film; the global animation kill-switch covers
+     darkroom/high-contrast and the user's animations toggle. High-contrast
+     also drops the texture entirely. */
+  .hero-grain {
+    background-color: var(--color-surface);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 0.07 0 0 0 0 0.07 0 0 0 0.14 0'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23g)'/%3E%3C/svg%3E");
+    background-size: 320px 320px;
+  }
+
+  @keyframes hero-grain-flicker {
+    0% {
+      background-position: 0 0;
+    }
+    10% {
+      background-position: -32px 24px;
+    }
+    20% {
+      background-position: 48px -16px;
+    }
+    30% {
+      background-position: -24px -48px;
+    }
+    40% {
+      background-position: 56px 40px;
+    }
+    50% {
+      background-position: -48px 8px;
+    }
+    60% {
+      background-position: 16px 64px;
+    }
+    70% {
+      background-position: -64px -32px;
+    }
+    80% {
+      background-position: 40px -56px;
+    }
+    90% {
+      background-position: -8px 48px;
+    }
+    100% {
+      background-position: 0 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .hero-grain {
+      animation: hero-grain-flicker 0.9s step-end infinite;
+    }
+  }
+
+  /* On light surfaces the same tint reads as a pink wash; use a darker red
+     at lower alpha so it stays a faint speckle. */
+  [data-theme="light"] .hero-grain {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.55 0 0 0 0 0.05 0 0 0 0 0.05 0 0 0 0.08 0'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23g)'/%3E%3C/svg%3E");
+  }
+
+  [data-theme="high-contrast"] .hero-grain {
+    background-image: none;
+  }
+
   /* Hero Button Styles */
   .hero-button-success {
     background-color: var(--color-button-success);

--- a/apps/dorkroom/src/styles/theme.css
+++ b/apps/dorkroom/src/styles/theme.css
@@ -602,8 +602,7 @@
   --color-tool-card-description-hover: #09090b;
   --color-tool-card-arrow: #a1a1aa;
 
-  /* Accent text uses -600 variants for contrast on light backgrounds.
-     Border/gradient inherit from the base block. */
+  /* Accent text uses -600 variants for contrast on light backgrounds. */
   --accent-indigo-text: oklch(51.1% 0.262 276.966);
   --accent-blue-text: oklch(54.6% 0.245 262.881);
   --accent-violet-text: oklch(54.1% 0.281 293.009);
@@ -613,6 +612,102 @@
   --accent-cyan-text: oklch(60.9% 0.126 221.723);
   --accent-emerald-text: oklch(59.6% 0.145 163.225);
   --accent-sky-text: oklch(58.8% 0.158 241.966);
+
+  /* Accent gradient/border for light theme: low-opacity tints that keep the
+     dark on-accent text (#09090b) readable while still reading as the tool's
+     color. Borders are stronger so the accent card reads as bounded on white.
+     (The dark theme defines these over transparent; light needs its own so
+     calculator accent surfaces don't wash out — plan 007.) */
+  --accent-indigo-border: color-mix(
+    in oklab,
+    oklch(58.5% 0.233 277.117) 45%,
+    transparent
+  );
+  --accent-indigo-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(58.5% 0.233 277.117) 14%, transparent),
+    color-mix(in oklab, oklch(62.7% 0.265 303.9) 14%, transparent)
+  );
+  --accent-blue-border: color-mix(
+    in oklab,
+    oklch(62.3% 0.214 259.815) 45%,
+    transparent
+  );
+  --accent-blue-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(62.3% 0.214 259.815) 14%, transparent),
+    color-mix(in oklab, oklch(71.5% 0.143 215.221) 14%, transparent)
+  );
+  --accent-violet-border: color-mix(
+    in oklab,
+    oklch(60.6% 0.25 292.717) 45%,
+    transparent
+  );
+  --accent-violet-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(60.6% 0.25 292.717) 14%, transparent),
+    color-mix(in oklab, oklch(66.7% 0.295 322.15) 14%, transparent)
+  );
+  --accent-teal-border: color-mix(
+    in oklab,
+    oklch(70.4% 0.14 182.503) 45%,
+    transparent
+  );
+  --accent-teal-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(70.4% 0.14 182.503) 14%, transparent),
+    color-mix(in oklab, oklch(69.6% 0.17 162.48) 14%, transparent)
+  );
+  --accent-amber-border: color-mix(
+    in oklab,
+    oklch(76.9% 0.188 70.08) 45%,
+    transparent
+  );
+  --accent-amber-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(76.9% 0.188 70.08) 14%, transparent),
+    color-mix(in oklab, oklch(70.5% 0.213 47.604) 14%, transparent)
+  );
+  --accent-rose-border: color-mix(
+    in oklab,
+    oklch(64.5% 0.246 16.439) 45%,
+    transparent
+  );
+  --accent-rose-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(64.5% 0.246 16.439) 14%, transparent),
+    color-mix(in oklab, oklch(63.7% 0.237 25.331) 14%, transparent)
+  );
+  --accent-cyan-border: color-mix(
+    in oklab,
+    oklch(71.5% 0.143 215.221) 45%,
+    transparent
+  );
+  --accent-cyan-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(71.5% 0.143 215.221) 14%, transparent),
+    color-mix(in oklab, oklch(70.4% 0.14 182.503) 14%, transparent)
+  );
+  --accent-emerald-border: color-mix(
+    in oklab,
+    oklch(69.6% 0.17 162.48) 45%,
+    transparent
+  );
+  --accent-emerald-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(69.6% 0.17 162.48) 14%, transparent),
+    color-mix(in oklab, oklch(70.4% 0.14 182.503) 14%, transparent)
+  );
+  --accent-sky-border: color-mix(
+    in oklab,
+    oklch(68.5% 0.169 237.323) 45%,
+    transparent
+  );
+  --accent-sky-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(68.5% 0.169 237.323) 14%, transparent),
+    color-mix(in oklab, oklch(62.3% 0.214 259.815) 14%, transparent)
+  );
 }
 
 /* High-contrast theme: black on white, no gradients, no animations */

--- a/apps/dorkroom/src/styles/theme.css
+++ b/apps/dorkroom/src/styles/theme.css
@@ -119,6 +119,10 @@
   --color-text-muted: #ff0000;
   --color-text-warning: #ff0000;
   --color-text-link: #ff0000;
+  /* on-accent: gradient cards are black in darkroom; use red text to match */
+  --color-on-accent: #ff0000;
+  --color-on-accent-soft: #ff0000;
+  --color-on-accent-muted: #ff0000;
   --color-background-muted: #000000;
   --color-background-tag: #000000;
   --color-text-tag: #ff0000;
@@ -250,6 +254,10 @@
   --color-text-secondary: #e4e4e7;
   --color-text-tertiary: #a1a1aa;
   --color-text-muted: #9595a3;
+  /* text colors guaranteed readable on gradient-card / accent surfaces */
+  --color-on-accent: #ffffff;
+  --color-on-accent-soft: rgba(255, 255, 255, 0.92);
+  --color-on-accent-muted: rgba(255, 255, 255, 0.78);
   --color-border-primary: rgba(255, 255, 255, 0.2);
   --color-border-secondary: rgba(255, 255, 255, 0.1);
   --color-border-muted: rgba(255, 255, 255, 0.05);
@@ -270,8 +278,8 @@
   --blade-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   --gradient-card-primary: linear-gradient(
     135deg,
-    rgba(110, 243, 164, 0.45),
-    rgba(36, 146, 88, 0.34)
+    rgba(110, 243, 164, 0.32),
+    rgba(36, 146, 88, 0.26)
   );
   --gradient-card-secondary: linear-gradient(
     135deg,
@@ -290,8 +298,8 @@
   );
   --gradient-card-neutral: linear-gradient(
     135deg,
-    rgba(47, 211, 107, 0.56),
-    rgba(14, 85, 49, 0.44)
+    rgba(47, 211, 107, 0.34),
+    rgba(14, 85, 49, 0.3)
   );
   --gradient-card-info: linear-gradient(
     135deg,
@@ -471,7 +479,7 @@
   --settings-container-border: rgba(0, 0, 0, 0.1);
   --color-surface: #f8f9fa;
   --color-surface-muted: #f1f3f4;
-  --color-primary: #2d7a4a; /* deep green for accessible accents */
+  --color-primary: #256b40; /* deep green — ≥4.5:1 on white */
   --color-secondary: #1e6091; /* deep blue for links/secondary accents */
   --color-accent: #c4524a; /* warm accent for warnings/highlights */
   --color-highlight: #7a8c1f; /* slightly cooler olive for better contrast */
@@ -479,11 +487,15 @@
   --color-text-secondary: #27272a;
   --color-text-tertiary: #52525b;
   --color-text-muted: #71717a;
+  /* text colors guaranteed readable on gradient-card / accent surfaces */
+  --color-on-accent: #09090b;
+  --color-on-accent-soft: rgba(9, 9, 11, 0.85);
+  --color-on-accent-muted: rgba(9, 9, 11, 0.72);
   --color-border-primary: rgba(9, 9, 11, 0.18);
   --color-border-secondary: rgba(9, 9, 11, 0.1);
   --color-border-muted: rgba(9, 9, 11, 0.06);
   --color-semantic-success: #2d7a4a;
-  --color-semantic-warning: #de4e1e;
+  --color-semantic-warning: #b83f16; /* 4.6:1 on white */
   --color-semantic-error: #d32323;
   --color-semantic-info: #1e6091;
   --color-visualization-preview: #d4d4d8;
@@ -621,6 +633,10 @@
   --color-text-muted: #000000;
   --color-text-warning: #000000;
   --color-text-link: #000000;
+  /* on-accent: gradient cards are white in high-contrast; use black text to match */
+  --color-on-accent: #000000;
+  --color-on-accent-soft: #000000;
+  --color-on-accent-muted: #000000;
   --color-background-muted: #ffffff;
   --color-background-tag: #ffffff;
   --color-text-tag: #000000;
@@ -756,6 +772,10 @@
   --color-text-secondary: #e4e4e7;
   --color-text-tertiary: #a1a1aa;
   --color-text-muted: #71717a;
+  /* text colors guaranteed readable on gradient-card / accent surfaces */
+  --color-on-accent: #ffffff;
+  --color-on-accent-soft: rgba(255, 255, 255, 0.92);
+  --color-on-accent-muted: rgba(255, 255, 255, 0.78);
   --color-border-primary: rgba(255, 255, 255, 0.2);
   --color-border-secondary: rgba(255, 255, 255, 0.1);
   --color-border-muted: rgba(255, 255, 255, 0.05);
@@ -776,8 +796,8 @@
   --blade-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
   --gradient-card-primary: linear-gradient(
     135deg,
-    rgba(110, 243, 164, 0.45),
-    rgba(36, 146, 88, 0.34)
+    rgba(110, 243, 164, 0.32),
+    rgba(36, 146, 88, 0.26)
   );
   --gradient-card-secondary: linear-gradient(
     135deg,
@@ -796,8 +816,8 @@
   );
   --gradient-card-neutral: linear-gradient(
     135deg,
-    rgba(47, 211, 107, 0.56),
-    rgba(14, 85, 49, 0.44)
+    rgba(47, 211, 107, 0.34),
+    rgba(14, 85, 49, 0.3)
   );
   --gradient-card-info: linear-gradient(
     135deg,

--- a/apps/dorkroom/src/styles/theme.css
+++ b/apps/dorkroom/src/styles/theme.css
@@ -12,8 +12,6 @@
   --color-highlight: #e5ff7d;
   --spacing-18: 4.5rem;
   --border-radius-hero: 36px;
-  --size-hero-blob: 8rem;
-  --spacing-hero-blob-offset: -1rem;
 }
 
 /* Darkroom theme checkbox */
@@ -194,13 +192,6 @@
   --color-button-error: #ff0000;
   --color-button-error-hover: #ff0000;
   --color-button-text: #000000;
-  /* Home page hero section colors for darkroom theme */
-  --color-hero-border: #ff0000;
-  --color-hero-border-hover: #ff0000;
-  --color-hero-bg: #000000;
-  --color-hero-title: #ff0000;
-  --color-hero-text: #a90000;
-  --gradient-hero-accent: none;
   /* Tool card colors for darkroom theme */
   --color-tool-card-bg: #000000;
   --color-tool-card-icon-bg: #000000;
@@ -357,17 +348,6 @@
   --color-button-error: #991b1b;
   --color-button-error-hover: #b91c1c;
   --color-button-text: #ffffff;
-  /* Home page hero section colors for dark theme (original: border-zinc-800, bg-zinc-900/50) */
-  --color-hero-border: #27272a;
-  --color-hero-border-hover: #3f3f46;
-  --color-hero-bg: rgba(24, 24, 27, 0.5);
-  --color-hero-title: #ffffff;
-  --color-hero-text: #a1a1aa;
-  --gradient-hero-accent: linear-gradient(
-    to bottom right,
-    rgba(99, 102, 241, 0.2),
-    rgba(168, 85, 247, 0.2)
-  );
   /* Tool card colors for dark theme (original: border-zinc-800, bg-zinc-900/30) */
   --color-tool-card-bg: rgba(24, 24, 27, 0.6);
   --color-tool-card-icon-bg: rgba(39, 39, 42, 0.8);
@@ -598,17 +578,6 @@
   --color-button-error: #991b1b;
   --color-button-error-hover: #b91c1c;
   --color-button-text: #ffffff;
-  /* Home page hero section colors for light theme */
-  --color-hero-border: rgba(9, 9, 11, 0.18);
-  --color-hero-border-hover: rgba(9, 9, 11, 0.3);
-  --color-hero-bg: #f8f9fa;
-  --color-hero-title: #09090b;
-  --color-hero-text: #52525b;
-  --gradient-hero-accent: linear-gradient(
-    to bottom right,
-    rgba(99, 102, 241, 0.1),
-    rgba(168, 85, 247, 0.1)
-  );
   /* Tool card colors for light theme */
   --color-tool-card-bg: #f8f9fa;
   --color-tool-card-icon-bg: rgba(9, 9, 11, 0.06);
@@ -729,13 +698,6 @@
   --color-button-error: #000000;
   --color-button-error-hover: #000000;
   --color-button-text: #ffffff;
-  /* Home page hero section colors for high-contrast theme */
-  --color-hero-border: #000000;
-  --color-hero-border-hover: #000000;
-  --color-hero-bg: #ffffff;
-  --color-hero-title: #000000;
-  --color-hero-text: #000000;
-  --gradient-hero-accent: none;
   /* Tool card colors for high-contrast theme */
   --color-tool-card-bg: #ffffff;
   --color-tool-card-icon-bg: #ffffff;

--- a/apps/dorkroom/src/styles/theme.css
+++ b/apps/dorkroom/src/styles/theme.css
@@ -212,6 +212,35 @@
   --color-tool-card-description: #a90000;
   --color-tool-card-description-hover: #ff0000;
   --color-tool-card-arrow: #ff0000;
+
+  /* Accent variants forced to red, no gradients (darkroom) */
+  --accent-indigo-text: #ff0000;
+  --accent-indigo-border: #ff0000;
+  --accent-indigo-gradient: none;
+  --accent-blue-text: #ff0000;
+  --accent-blue-border: #ff0000;
+  --accent-blue-gradient: none;
+  --accent-violet-text: #ff0000;
+  --accent-violet-border: #ff0000;
+  --accent-violet-gradient: none;
+  --accent-teal-text: #ff0000;
+  --accent-teal-border: #ff0000;
+  --accent-teal-gradient: none;
+  --accent-amber-text: #ff0000;
+  --accent-amber-border: #ff0000;
+  --accent-amber-gradient: none;
+  --accent-rose-text: #ff0000;
+  --accent-rose-border: #ff0000;
+  --accent-rose-gradient: none;
+  --accent-cyan-text: #ff0000;
+  --accent-cyan-border: #ff0000;
+  --accent-cyan-gradient: none;
+  --accent-emerald-text: #ff0000;
+  --accent-emerald-border: #ff0000;
+  --accent-emerald-gradient: none;
+  --accent-sky-text: #ff0000;
+  --accent-sky-border: #ff0000;
+  --accent-sky-gradient: none;
 }
 
 /* Dark theme (default) */
@@ -350,6 +379,108 @@
   --color-tool-card-description: #a1a1aa;
   --color-tool-card-description-hover: #d4d4d8;
   --color-tool-card-arrow: #52525b;
+
+  /* Accent variants (base/dark) — text=400, border=500/50%, gradient=500/20% pair.
+     Values copied verbatim from node_modules/tailwindcss/theme.css. */
+  --accent-indigo-text: oklch(67.3% 0.182 276.935);
+  --accent-indigo-border: color-mix(
+    in oklab,
+    oklch(58.5% 0.233 277.117) 50%,
+    transparent
+  );
+  --accent-indigo-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(58.5% 0.233 277.117) 20%, transparent),
+    color-mix(in oklab, oklch(62.7% 0.265 303.9) 20%, transparent)
+  );
+  --accent-blue-text: oklch(70.7% 0.165 254.624);
+  --accent-blue-border: color-mix(
+    in oklab,
+    oklch(62.3% 0.214 259.815) 50%,
+    transparent
+  );
+  --accent-blue-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(62.3% 0.214 259.815) 20%, transparent),
+    color-mix(in oklab, oklch(71.5% 0.143 215.221) 20%, transparent)
+  );
+  --accent-violet-text: oklch(70.2% 0.183 293.541);
+  --accent-violet-border: color-mix(
+    in oklab,
+    oklch(60.6% 0.25 292.717) 50%,
+    transparent
+  );
+  --accent-violet-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(60.6% 0.25 292.717) 20%, transparent),
+    color-mix(in oklab, oklch(66.7% 0.295 322.15) 20%, transparent)
+  );
+  --accent-teal-text: oklch(77.7% 0.152 181.912);
+  --accent-teal-border: color-mix(
+    in oklab,
+    oklch(70.4% 0.14 182.503) 50%,
+    transparent
+  );
+  --accent-teal-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(70.4% 0.14 182.503) 20%, transparent),
+    color-mix(in oklab, oklch(69.6% 0.17 162.48) 20%, transparent)
+  );
+  --accent-amber-text: oklch(82.8% 0.189 84.429);
+  --accent-amber-border: color-mix(
+    in oklab,
+    oklch(76.9% 0.188 70.08) 50%,
+    transparent
+  );
+  --accent-amber-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(76.9% 0.188 70.08) 20%, transparent),
+    color-mix(in oklab, oklch(70.5% 0.213 47.604) 20%, transparent)
+  );
+  --accent-rose-text: oklch(71.2% 0.194 13.428);
+  --accent-rose-border: color-mix(
+    in oklab,
+    oklch(64.5% 0.246 16.439) 50%,
+    transparent
+  );
+  --accent-rose-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(64.5% 0.246 16.439) 20%, transparent),
+    color-mix(in oklab, oklch(63.7% 0.237 25.331) 20%, transparent)
+  );
+  --accent-cyan-text: oklch(78.9% 0.154 211.53);
+  --accent-cyan-border: color-mix(
+    in oklab,
+    oklch(71.5% 0.143 215.221) 50%,
+    transparent
+  );
+  --accent-cyan-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(71.5% 0.143 215.221) 20%, transparent),
+    color-mix(in oklab, oklch(70.4% 0.14 182.503) 20%, transparent)
+  );
+  --accent-emerald-text: oklch(76.5% 0.177 163.223);
+  --accent-emerald-border: color-mix(
+    in oklab,
+    oklch(69.6% 0.17 162.48) 50%,
+    transparent
+  );
+  --accent-emerald-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(69.6% 0.17 162.48) 20%, transparent),
+    color-mix(in oklab, oklch(70.4% 0.14 182.503) 20%, transparent)
+  );
+  --accent-sky-text: oklch(74.6% 0.16 232.661);
+  --accent-sky-border: color-mix(
+    in oklab,
+    oklch(68.5% 0.169 237.323) 50%,
+    transparent
+  );
+  --accent-sky-gradient: linear-gradient(
+    to bottom right,
+    color-mix(in oklab, oklch(68.5% 0.169 237.323) 20%, transparent),
+    color-mix(in oklab, oklch(62.3% 0.214 259.815) 20%, transparent)
+  );
 }
 
 /* Light theme */
@@ -489,6 +620,18 @@
   --color-tool-card-description: #52525b;
   --color-tool-card-description-hover: #09090b;
   --color-tool-card-arrow: #a1a1aa;
+
+  /* Accent text uses -600 variants for contrast on light backgrounds.
+     Border/gradient inherit from the base block. */
+  --accent-indigo-text: oklch(51.1% 0.262 276.966);
+  --accent-blue-text: oklch(54.6% 0.245 262.881);
+  --accent-violet-text: oklch(54.1% 0.281 293.009);
+  --accent-teal-text: oklch(60% 0.118 184.704);
+  --accent-amber-text: oklch(66.6% 0.179 58.318);
+  --accent-rose-text: oklch(58.6% 0.253 17.585);
+  --accent-cyan-text: oklch(60.9% 0.126 221.723);
+  --accent-emerald-text: oklch(59.6% 0.145 163.225);
+  --accent-sky-text: oklch(58.8% 0.158 241.966);
 }
 
 /* High-contrast theme: black on white, no gradients, no animations */
@@ -604,6 +747,35 @@
   --color-tool-card-description: #000000;
   --color-tool-card-description-hover: #000000;
   --color-tool-card-arrow: #000000;
+
+  /* Accent variants forced to black, no gradients (high-contrast) */
+  --accent-indigo-text: #000000;
+  --accent-indigo-border: #000000;
+  --accent-indigo-gradient: none;
+  --accent-blue-text: #000000;
+  --accent-blue-border: #000000;
+  --accent-blue-gradient: none;
+  --accent-violet-text: #000000;
+  --accent-violet-border: #000000;
+  --accent-violet-gradient: none;
+  --accent-teal-text: #000000;
+  --accent-teal-border: #000000;
+  --accent-teal-gradient: none;
+  --accent-amber-text: #000000;
+  --accent-amber-border: #000000;
+  --accent-amber-gradient: none;
+  --accent-rose-text: #000000;
+  --accent-rose-border: #000000;
+  --accent-rose-gradient: none;
+  --accent-cyan-text: #000000;
+  --accent-cyan-border: #000000;
+  --accent-cyan-gradient: none;
+  --accent-emerald-text: #000000;
+  --accent-emerald-border: #000000;
+  --accent-emerald-gradient: none;
+  --accent-sky-text: #000000;
+  --accent-sky-border: #000000;
+  --accent-sky-gradient: none;
 }
 
 /* Default to dark theme if no data-theme attribute */
@@ -757,96 +929,6 @@
 
 [data-theme="darkroom"] *:focus-visible {
   --tw-ring-color: var(--color-border-primary);
-}
-
-/* Override Tailwind color classes in light theme - use -600 variants for contrast */
-[data-theme="light"] .text-indigo-400 {
-  color: #4f46e5;
-}
-[data-theme="light"] .text-blue-400 {
-  color: #2563eb;
-}
-[data-theme="light"] .text-violet-400 {
-  color: #7c3aed;
-}
-[data-theme="light"] .text-amber-400 {
-  color: #d97706;
-}
-[data-theme="light"] .text-rose-400 {
-  color: #e11d48;
-}
-[data-theme="light"] .text-cyan-400 {
-  color: #0891b2;
-}
-
-/* Override Tailwind color classes in high-contrast theme - force black */
-[data-theme="high-contrast"] .text-indigo-400,
-[data-theme="high-contrast"] .text-blue-400,
-[data-theme="high-contrast"] .text-violet-400,
-[data-theme="high-contrast"] .text-amber-400,
-[data-theme="high-contrast"] .text-rose-400,
-[data-theme="high-contrast"] .text-emerald-400 {
-  color: #000000;
-}
-
-/* Override Tailwind color classes in darkroom theme - force red */
-[data-theme="darkroom"] .text-indigo-400,
-[data-theme="darkroom"] .text-blue-400,
-[data-theme="darkroom"] .text-violet-400,
-[data-theme="darkroom"] .text-amber-400,
-[data-theme="darkroom"] .text-rose-400,
-[data-theme="darkroom"] .text-emerald-400 {
-  color: #ff0000;
-}
-
-/* Override gradient backgrounds in high-contrast theme - no color on hover */
-[data-theme="high-contrast"] .bg-gradient-to-br,
-[data-theme="high-contrast"] .from-indigo-500\/20,
-[data-theme="high-contrast"] .from-blue-500\/20,
-[data-theme="high-contrast"] .from-violet-500\/20,
-[data-theme="high-contrast"] .from-amber-500\/20,
-[data-theme="high-contrast"] .from-rose-500\/20,
-[data-theme="high-contrast"] .to-purple-500\/20,
-[data-theme="high-contrast"] .to-cyan-500\/20,
-[data-theme="high-contrast"] .to-fuchsia-500\/20,
-[data-theme="high-contrast"] .to-orange-500\/20,
-[data-theme="high-contrast"] .to-red-500\/20 {
-  background-image: none;
-  background-color: transparent;
-}
-
-/* Override gradient backgrounds in darkroom theme - no color on hover */
-[data-theme="darkroom"] .bg-gradient-to-br,
-[data-theme="darkroom"] .from-indigo-500\/20,
-[data-theme="darkroom"] .from-blue-500\/20,
-[data-theme="darkroom"] .from-violet-500\/20,
-[data-theme="darkroom"] .from-amber-500\/20,
-[data-theme="darkroom"] .from-rose-500\/20,
-[data-theme="darkroom"] .to-purple-500\/20,
-[data-theme="darkroom"] .to-cyan-500\/20,
-[data-theme="darkroom"] .to-fuchsia-500\/20,
-[data-theme="darkroom"] .to-orange-500\/20,
-[data-theme="darkroom"] .to-red-500\/20 {
-  background-image: none;
-  background-color: transparent;
-}
-
-/* Override border hover colors in high-contrast theme - force black */
-[data-theme="high-contrast"] .group-hover\:border-indigo-500\/50,
-[data-theme="high-contrast"] .group-hover\:border-blue-500\/50,
-[data-theme="high-contrast"] .group-hover\:border-violet-500\/50,
-[data-theme="high-contrast"] .group-hover\:border-amber-500\/50,
-[data-theme="high-contrast"] .group-hover\:border-rose-500\/50 {
-  border-color: #000000;
-}
-
-/* Override border hover colors in darkroom theme - force red */
-[data-theme="darkroom"] .group-hover\:border-indigo-500\/50,
-[data-theme="darkroom"] .group-hover\:border-blue-500\/50,
-[data-theme="darkroom"] .group-hover\:border-violet-500\/50,
-[data-theme="darkroom"] .group-hover\:border-amber-500\/50,
-[data-theme="darkroom"] .group-hover\:border-rose-500\/50 {
-  border-color: #ff0000;
 }
 
 /* Make tool card icons black on hover in darkroom mode (so they're visible against red bg) */

--- a/apps/dorkroom/src/styles/theme.css
+++ b/apps/dorkroom/src/styles/theme.css
@@ -201,9 +201,6 @@
   --color-tool-card-icon-bg: #000000;
   --color-tool-card-icon-ring: #ff0000;
   --color-tool-card-icon-hover: #ff0000;
-  --color-tool-card-category: #ff0000;
-  --color-tool-card-category-hover: #ff0000;
-  --color-tool-card-title: #ff0000;
   --color-tool-card-description: #a90000;
   --color-tool-card-description-hover: #ff0000;
   --color-tool-card-arrow: #ff0000;
@@ -361,9 +358,6 @@
   --color-tool-card-icon-bg: rgba(39, 39, 42, 0.8);
   --color-tool-card-icon-ring: rgba(255, 255, 255, 0.12);
   --color-tool-card-icon-hover: rgba(255, 255, 255, 0.18);
-  --color-tool-card-category: #71717a;
-  --color-tool-card-category-hover: #d4d4d8;
-  --color-tool-card-title: #ffffff;
   --color-tool-card-description: #a1a1aa;
   --color-tool-card-description-hover: #d4d4d8;
   --color-tool-card-arrow: #52525b;
@@ -595,9 +589,6 @@
   --color-tool-card-icon-bg: rgba(9, 9, 11, 0.06);
   --color-tool-card-icon-ring: rgba(9, 9, 11, 0.12);
   --color-tool-card-icon-hover: rgba(9, 9, 11, 0.1);
-  --color-tool-card-category: #71717a;
-  --color-tool-card-category-hover: #52525b;
-  --color-tool-card-title: #09090b;
   --color-tool-card-description: #52525b;
   --color-tool-card-description-hover: #09090b;
   --color-tool-card-arrow: #a1a1aa;
@@ -814,9 +805,6 @@
   --color-tool-card-icon-bg: #ffffff;
   --color-tool-card-icon-ring: #000000;
   --color-tool-card-icon-hover: #ffffff;
-  --color-tool-card-category: #000000;
-  --color-tool-card-category-hover: #000000;
-  --color-tool-card-title: #000000;
   --color-tool-card-description: #000000;
   --color-tool-card-description-hover: #000000;
   --color-tool-card-arrow: #000000;

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -316,12 +316,25 @@ Routes use TanStack Router file-based routing in `apps/dorkroom/src/routes/`.
 
 All calculator pages follow a consistent pattern:
 
-1. **Layout:** `CalculatorLayout` with title, description, sidebar, and results slots
-2. **Two-column layout:** Main content + sidebar (info/help)
-3. **Input card:** `CalculatorCard` with form fields
-4. **Results card:** `CalculatorCard` with accent color showing calculations
-5. **Info cards:** How-to-use and educational content in sidebar
-6. **State persistence:** localStorage via `useLocalStorageFormPersistence()`
+1. **Layout:** `CalculatorLayout` with title, description, sidebar, and results
+   slots. The border calculator also uses `CalculatorLayout` on desktop
+   (`ResponsiveBorderLayout`); its mobile drawer layout keeps its bespoke
+   structure but gets the same accent header.
+2. **Per-calculator accent identity:** each page passes an `icon` +
+   `accentTone` to its header (the `--accent-<tone>-*` family from plan 003,
+   aligned with nav categories so color = category, shade = tool). The same
+   tone backs the primary results `CalculatorCard accent` and any toned
+   `CalculatorStat`. Tones collapse to monochrome in high-contrast/darkroom.
+   Mapping: border=indigo, stops=blue, resize=teal, mat=cyan,
+   reciprocity=amber, development=rose (header only), lenses=emerald,
+   exposure=teal (EV card; violet/sky secondaries), films=cyan (Reference).
+   The mat diagram (`mat-diagram.tsx`) also uses the cyan accent token instead
+   of the brand green so the page reads as its own tool.
+3. **Two-column layout:** Main content + sidebar (info/help)
+4. **Input card:** `CalculatorCard` with form fields
+5. **Results card:** `CalculatorCard` with the page's accent tone
+6. **Info cards:** How-to-use and educational content in sidebar
+7. **State persistence:** localStorage via `useLocalStorageFormPersistence()`
 
 ### State Persistence Pattern
 

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -48,6 +48,56 @@ Use `lucide-react` with `className` for sizing:
 
 All exports through `src/index.ts`. Never import internal paths.
 
+## Design conventions
+
+New components must follow these scales. When an existing component
+disagrees, prefer the scale for new code; don't mass-refactor.
+
+### Color
+- ONLY theme variables: `var(--color-*)` (and accent variants `var(--accent-*)`).
+- Never raw Tailwind palette classes (`text-indigo-400`) — the four themes
+  (dark / light / high-contrast / darkroom) restyle variables, not classes.
+- Tailwind usage: `text-[color:var(--color-text-primary)]` for classes;
+  inline `style` only where a class can't express it (dynamic var names).
+
+### Radius
+| Element | Class |
+|---|---|
+| Cards (ToolCard, StatCard, CalculatorCard) | `rounded-2xl` |
+| Buttons, inputs, icon tiles | `rounded-xl` |
+| Badges, tags, small controls | `rounded-lg` |
+| Modals, dialogs | `rounded-2xl` |
+| Large hero/preview panels (border calculator) | `rounded-3xl` |
+| Pills, avatars, FABs | `rounded-full` |
+
+### Type
+| Role | Classes |
+|---|---|
+| Page title | `text-3xl md:text-4xl font-semibold tracking-tight` |
+| Section heading | `text-xl font-semibold` |
+| Card title | `font-semibold` (base size) |
+| Body / descriptions | `text-sm` |
+| Captions, labels, eyebrows | `text-xs` (never `text-[10px]`) |
+
+Weights: `font-medium` = emphasis, `font-semibold` = headings,
+`font-bold` = stat values only.
+
+### Spacing
+- Card padding: `p-4` (default) / `p-5` (roomy) / `p-3.5 sm:p-4` (compact).
+- Grid gaps: `gap-4` (page sections: `gap-4 lg:gap-6`).
+- Icon-to-text: `gap-3` or `gap-4`.
+
+### Elevation
+`shadow-subtle` = resting, `shadow-lg` = hover lift, `shadow-xl` = overlays.
+
+### Motion & focus
+- Transitions only (`transition-colors` / `transition-all`, default
+  duration). High-contrast and darkroom themes disable ALL animation
+  globally — never rely on motion to convey state.
+- Interactive elements: `focus-visible:outline-none focus-visible:ring-2
+  focus-visible:ring-[color:var(--color-border-primary)]`. Never bare
+  `focus:` rings; never remove an outline without adding a ring.
+
 ## Accessibility
 
 - Semantic HTML (`<button>`, `<label>`, `<input>`)

--- a/packages/ui/src/__tests__/components/calculator-stat.test.tsx
+++ b/packages/ui/src/__tests__/components/calculator-stat.test.tsx
@@ -82,10 +82,10 @@ describe('CalculatorStat', () => {
 
       const label = screen.getByText('Test Stat');
       expect(label).toHaveClass(
-        'text-[10px]',
+        'text-xs',
         'font-semibold',
         'uppercase',
-        'tracking-[0.3em]'
+        'tracking-[0.2em]'
       );
     });
 
@@ -151,7 +151,7 @@ describe('CalculatorStat', () => {
       const value = screen.getByText('42');
       const helper = screen.getByText('Small helper text');
 
-      expect(label).toHaveClass('text-[10px]');
+      expect(label).toHaveClass('text-xs');
       expect(value).toHaveClass('text-2xl');
       expect(helper).toHaveClass('text-[11px]');
     });
@@ -167,7 +167,7 @@ describe('CalculatorStat', () => {
       render(<CalculatorStat {...defaultProps} />);
 
       const label = screen.getByText('Test Stat');
-      expect(label).toHaveClass('tracking-[0.3em]');
+      expect(label).toHaveClass('tracking-[0.2em]');
     });
   });
 

--- a/packages/ui/src/calculator.ts
+++ b/packages/ui/src/calculator.ts
@@ -1,5 +1,6 @@
 // Shared calculator components subpath export
 export type {
+  AccentTone,
   CalculatorLayoutProps,
   InfoCardItem,
   InfoCardListProps,

--- a/packages/ui/src/components/border-calculator/blade-readings-overlay.tsx
+++ b/packages/ui/src/components/border-calculator/blade-readings-overlay.tsx
@@ -212,13 +212,19 @@ function BladeReadingIndicator({ reading }: { reading: BladeReading }) {
       }}
     >
       {arrowFirst && (
-        <span className={arrowClasses} style={{ color: 'var(--color-accent)' }}>
+        <span
+          className={arrowClasses}
+          style={{ color: 'var(--color-text-primary)' }}
+        >
           {arrow}
         </span>
       )}
       <span className="whitespace-nowrap">{value}</span>
       {!arrowFirst && (
-        <span className={arrowClasses} style={{ color: 'var(--color-accent)' }}>
+        <span
+          className={arrowClasses}
+          style={{ color: 'var(--color-text-primary)' }}
+        >
           {arrow}
         </span>
       )}

--- a/packages/ui/src/components/border-calculator/blade-readings-section.tsx
+++ b/packages/ui/src/components/border-calculator/blade-readings-section.tsx
@@ -32,7 +32,7 @@ export function BladeReadingsSection() {
     <CalculatorCard
       title="Blade Readings"
       description="Set your easel blades to these positions."
-      accent="emerald"
+      accent="indigo"
       padding="compact"
     >
       <div className="grid gap-2 sm:grid-cols-2">

--- a/packages/ui/src/components/border-calculator/mobile-border-layout.tsx
+++ b/packages/ui/src/components/border-calculator/mobile-border-layout.tsx
@@ -1,6 +1,8 @@
 import type { BorderPreset } from '@dorkroom/logic';
 import { useMemo, useState } from 'react';
 import { useTheme } from '../../contexts/theme-context';
+import { getRouteIcon, ROUTE_DESCRIPTIONS } from '../../lib/navigation';
+import { CalculatorPageHeader } from '../calculator/calculator-page-header';
 import { useBorderCalculator } from './border-calculator-context';
 import {
   type ActiveSection,
@@ -11,6 +13,9 @@ import {
   MobileSharingModals,
   MobileWarningsCard,
 } from './mobile-border-layout-parts';
+
+// Border calculator carries the Printing category's indigo accent (plan 007).
+const BorderIcon = getRouteIcon('/border');
 
 /**
  * Render the mobile UI for configuring border/calculation settings, managing presets, and sharing results.
@@ -184,6 +189,13 @@ export function MobileBorderLayout() {
       }}
     >
       <div className="mx-auto max-w-md space-y-4">
+        <CalculatorPageHeader
+          title="Border Calculator"
+          icon={BorderIcon}
+          accentTone="indigo"
+          description={ROUTE_DESCRIPTIONS['/border']}
+        />
+
         <MobilePreviewCard
           calculation={calculation}
           showBlades={showBlades}

--- a/packages/ui/src/components/border-calculator/preview-and-controls-section.tsx
+++ b/packages/ui/src/components/border-calculator/preview-and-controls-section.tsx
@@ -79,8 +79,8 @@ export function PreviewAndControlsSection() {
         onClick={resetToDefaults}
         className="mt-1 inline-flex w-full items-center justify-center gap-2 rounded-full px-3 py-1.5 text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 hover:brightness-110"
         style={{
-          color: 'var(--color-accent)',
-          borderColor: 'var(--color-accent)',
+          color: 'var(--color-on-accent)',
+          borderColor: 'var(--color-on-accent-muted)',
           borderWidth: 1,
           backgroundColor: 'rgba(var(--color-background-rgb), 0.06)',
         }}

--- a/packages/ui/src/components/border-calculator/responsive-border-layout.tsx
+++ b/packages/ui/src/components/border-calculator/responsive-border-layout.tsx
@@ -1,6 +1,8 @@
 import type { FC } from 'react';
 import { SaveBeforeShareModal } from '../../components/save-before-share-modal';
 import { ShareModal } from '../../components/share-modal';
+import { getRouteIcon, ROUTE_DESCRIPTIONS } from '../../lib/navigation';
+import { CalculatorLayout } from '../calculator/calculator-layout';
 import { BladeReadingsSection } from './blade-readings-section';
 import { BladeVisualizationSection } from './blade-visualization-section';
 import { useBorderCalculator } from './border-calculator-context';
@@ -9,6 +11,9 @@ import { BordersOffsetsSection } from './borders-offsets-section';
 import { PaperSetupSection } from './paper-setup-section';
 import { PresetsSection } from './presets-section';
 import { PreviewAndControlsSection } from './preview-and-controls-section';
+
+// Border calculator carries the Printing category's indigo accent (plan 007).
+const BorderIcon = getRouteIcon('/border');
 
 /**
  * Unified responsive layout for the border calculator.
@@ -35,47 +40,52 @@ export const ResponsiveBorderLayout: FC = () => {
   } = useBorderCalculator();
 
   return (
-    <div className="mx-auto max-w-6xl px-4 pb-12 pt-6 sm:px-6 md:px-8 md:pt-8">
-      <div className="grid gap-4 md:gap-5 md:grid-cols-[minmax(0,7fr)_minmax(0,5fr)]">
-        {/* Left column: Preview + Results (critical, always visible) */}
-        <div className="space-y-4">
-          {calculation && (
-            <>
-              <PreviewAndControlsSection />
-              <BladeReadingsSection />
-            </>
-          )}
-        </div>
-
-        {/* Right column: Configuration (primary controls) */}
-        <div className="space-y-4">
+    <CalculatorLayout
+      title="Border Calculator"
+      icon={BorderIcon}
+      accentTone="indigo"
+      description={ROUTE_DESCRIPTIONS['/border']}
+      sidebar={
+        // Right column: Configuration (primary controls)
+        <>
           <PaperSetupSection />
           <BordersOffsetsSection />
           <BladeVisualizationSection />
           <PresetsSection />
-        </div>
-      </div>
+        </>
+      }
+      footer={
+        <>
+          {/* Educational content */}
+          <BorderInfoSection />
 
-      {/* Educational content */}
-      <BorderInfoSection />
+          {/* Sharing Modals */}
+          <ShareModal
+            isOpen={isShareModalOpen}
+            onClose={() => setIsShareModalOpen(false)}
+            presetName={presetName || 'Border Calculator Settings'}
+            webUrl={shareUrls?.webUrl || ''}
+            onCopyToClipboard={handleCopyToClipboard}
+            canShareNatively={false}
+            canCopyToClipboard={canCopyToClipboard}
+          />
 
-      {/* Sharing Modals */}
-      <ShareModal
-        isOpen={isShareModalOpen}
-        onClose={() => setIsShareModalOpen(false)}
-        presetName={presetName || 'Border Calculator Settings'}
-        webUrl={shareUrls?.webUrl || ''}
-        onCopyToClipboard={handleCopyToClipboard}
-        canShareNatively={false}
-        canCopyToClipboard={canCopyToClipboard}
-      />
-
-      <SaveBeforeShareModal
-        isOpen={isSaveBeforeShareOpen}
-        onClose={() => setIsSaveBeforeShareOpen(false)}
-        onSaveAndShare={handleSaveAndShare}
-        isLoading={isSharing || isGeneratingShareUrl}
-      />
-    </div>
+          <SaveBeforeShareModal
+            isOpen={isSaveBeforeShareOpen}
+            onClose={() => setIsSaveBeforeShareOpen(false)}
+            onSaveAndShare={handleSaveAndShare}
+            isLoading={isSharing || isGeneratingShareUrl}
+          />
+        </>
+      }
+    >
+      {/* Left column: Preview + Results (critical, always visible) */}
+      {calculation && (
+        <>
+          <PreviewAndControlsSection />
+          <BladeReadingsSection />
+        </>
+      )}
+    </CalculatorLayout>
   );
 };

--- a/packages/ui/src/components/calculator/accent-tone.ts
+++ b/packages/ui/src/components/calculator/accent-tone.ts
@@ -1,0 +1,16 @@
+/**
+ * The nine theme-aware accent tones from plan 003 (see theme.css
+ * `--accent-*` variables). Each calculator page picks one as its identity,
+ * aligned with its nav category (color = category, shade = tool). The tones
+ * collapse to monochrome (red/black) in the high-contrast and darkroom themes.
+ */
+export type AccentTone =
+  | 'indigo'
+  | 'blue'
+  | 'violet'
+  | 'teal'
+  | 'amber'
+  | 'rose'
+  | 'cyan'
+  | 'emerald'
+  | 'sky';

--- a/packages/ui/src/components/calculator/calculator-card.tsx
+++ b/packages/ui/src/components/calculator/calculator-card.tsx
@@ -1,8 +1,9 @@
 import { memo, type ReactNode } from 'react';
 import { cn } from '../../lib/cn';
 import { colorMixOr } from '../../lib/color';
+import type { AccentTone } from './accent-tone';
 
-type AccentTone = 'emerald' | 'sky' | 'violet' | 'none';
+type CardAccent = AccentTone | 'none';
 
 interface CalculatorCardProps {
   title?: string;
@@ -10,31 +11,14 @@ interface CalculatorCardProps {
   actions?: ReactNode;
   children: ReactNode;
   className?: string;
-  accent?: AccentTone;
+  accent?: CardAccent;
   padding?: 'normal' | 'compact';
 }
 
-// Legacy - replaced with getAccentStyle function
-
-// Theme-aware accent styles using predefined gradients
-const getAccentStyle = (
-  accent: Exclude<AccentTone, 'none'>
-): React.CSSProperties => {
-  switch (accent) {
-    case 'emerald':
-      return {
-        background: 'var(--gradient-card-primary)',
-      };
-    case 'sky':
-      return {
-        background: 'var(--gradient-card-info)',
-      };
-    case 'violet':
-      return {
-        background: 'var(--gradient-card-accent)',
-      };
-  }
-};
+// Theme-aware accent surface backed by the plan-003 `--accent-<tone>-*` vars.
+const getAccentStyle = (accent: AccentTone): React.CSSProperties => ({
+  background: `var(--accent-${accent}-gradient)`,
+});
 
 export const CalculatorCard = memo(function CalculatorCard({
   title,
@@ -53,7 +37,10 @@ export const CalculatorCard = memo(function CalculatorCard({
         className
       )}
       style={{
-        borderColor: 'var(--color-border-secondary)',
+        borderColor:
+          accent !== 'none'
+            ? `var(--accent-${accent}-border, var(--color-border-secondary))`
+            : 'var(--color-border-secondary)',
         backgroundColor: colorMixOr(
           'var(--color-surface)',
           80,

--- a/packages/ui/src/components/calculator/calculator-layout.tsx
+++ b/packages/ui/src/components/calculator/calculator-layout.tsx
@@ -1,5 +1,6 @@
-import type { ReactNode } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import { cn } from '../../lib/cn';
+import type { AccentTone } from './accent-tone';
 import { CalculatorPageHeader } from './calculator-page-header';
 
 export interface CalculatorLayoutProps {
@@ -7,6 +8,10 @@ export interface CalculatorLayoutProps {
   title: string;
   /** Description text below the title */
   description: ReactNode;
+  /** Tool icon for the accent-tinted header tile (same icon as home/nav). */
+  icon?: ComponentType<{ className?: string }>;
+  /** Per-calculator accent identity (see theme.css `--accent-*`). */
+  accentTone?: AccentTone;
   /** Optional children to render in the header (e.g., toggle buttons) */
   headerChildren?: ReactNode;
   /** Main content (inputs) */
@@ -28,6 +33,8 @@ export interface CalculatorLayoutProps {
 export function CalculatorLayout({
   title,
   description,
+  icon,
+  accentTone,
   headerChildren,
   children,
   results,
@@ -42,7 +49,12 @@ export function CalculatorLayout({
         className
       )}
     >
-      <CalculatorPageHeader title={title} description={description}>
+      <CalculatorPageHeader
+        title={title}
+        description={description}
+        icon={icon}
+        accentTone={accentTone}
+      >
         {headerChildren}
       </CalculatorPageHeader>
 

--- a/packages/ui/src/components/calculator/calculator-layout.tsx
+++ b/packages/ui/src/components/calculator/calculator-layout.tsx
@@ -60,9 +60,11 @@ export function CalculatorLayout({
 
       {results ? (
         <>
-          <div className="mt-6 grid gap-4 md:mt-8 md:gap-5 md:grid-cols-2">
+          <div className="mt-6 grid gap-4 md:mt-8 md:gap-5 md:grid-cols-2 md:items-start">
             <div className="space-y-4">{children}</div>
-            <div className="space-y-4">{results}</div>
+            <div className="space-y-4 md:sticky md:top-20 md:self-start">
+              {results}
+            </div>
           </div>
           {sidebar && <div className="mt-4 space-y-4 md:mt-5">{sidebar}</div>}
         </>

--- a/packages/ui/src/components/calculator/calculator-page-header.tsx
+++ b/packages/ui/src/components/calculator/calculator-page-header.tsx
@@ -56,7 +56,7 @@ export function CalculatorPageHeader({
       >
         {Icon && (
           <div
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border"
+            className="flex size-11 shrink-0 items-center justify-center rounded-xl border"
             style={{
               background: accentTone
                 ? `var(--accent-${accentTone}-gradient)`
@@ -72,7 +72,7 @@ export function CalculatorPageHeader({
                 : 'var(--color-text-primary)',
             }}
           >
-            <Icon className="h-5 w-5" />
+            <Icon className="size-5" />
           </div>
         )}
         <div className="flex max-w-2xl flex-col gap-1">

--- a/packages/ui/src/components/calculator/calculator-page-header.tsx
+++ b/packages/ui/src/components/calculator/calculator-page-header.tsx
@@ -1,10 +1,20 @@
-import type { ReactNode } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import { cn } from '../../lib/cn';
 import { colorMixOr } from '../../lib/color';
+import type { AccentTone } from './accent-tone';
 
 interface CalculatorPageHeaderProps {
   title: string;
   description: ReactNode;
+  /** Optional short caption rendered above the title (e.g. a mode label). */
+  eyebrow?: ReactNode;
+  /**
+   * Tool icon (same component as home/nav). When provided, the header renders
+   * left-aligned with the icon in an accent-tinted tile.
+   */
+  icon?: ComponentType<{ className?: string }>;
+  /** Accent identity for the icon tile (see theme.css `--accent-*`). */
+  accentTone?: AccentTone;
   align?: 'center' | 'start';
   children?: ReactNode;
 }
@@ -12,16 +22,20 @@ interface CalculatorPageHeaderProps {
 export function CalculatorPageHeader({
   title,
   description,
+  eyebrow,
+  icon: Icon,
+  accentTone,
   align = 'center',
   children,
 }: CalculatorPageHeaderProps) {
+  // An icon anchors the header to the left regardless of the align default.
+  const alignStart = align === 'start' || Boolean(Icon);
+
   return (
     <div
       className={cn(
         'flex flex-col gap-2 rounded-xl border px-4 py-3 shadow-subtle card-ring sm:px-6 sm:py-4',
-        align === 'center'
-          ? 'items-center text-center'
-          : 'items-start text-left'
+        alignStart ? 'items-start text-left' : 'items-center text-center'
       )}
       style={{
         borderColor: 'var(--color-border-secondary)',
@@ -33,22 +47,64 @@ export function CalculatorPageHeader({
         ),
       }}
     >
-      <div className="flex max-w-2xl flex-col gap-1">
-        <h1
-          className="text-xl font-semibold tracking-tight sm:text-2xl"
-          style={{ color: 'var(--color-text-primary)' }}
-        >
-          {title}
-        </h1>
-        <div
-          className="text-xs leading-relaxed"
-          style={{ color: 'var(--color-text-secondary)' }}
-        >
-          {description}
+      <div
+        className={cn(
+          'flex w-full gap-4',
+          Icon ? 'items-center' : 'flex-col',
+          !Icon && (alignStart ? 'items-start' : 'items-center')
+        )}
+      >
+        {Icon && (
+          <div
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border"
+            style={{
+              background: accentTone
+                ? `var(--accent-${accentTone}-gradient)`
+                : undefined,
+              borderColor: accentTone
+                ? `var(--accent-${accentTone}-border, var(--color-border-secondary))`
+                : 'var(--color-border-secondary)',
+              // The icon inherits this via currentColor. The on-accent token
+              // keeps the glyph readable on the tinted tile; fall back to
+              // primary text when no tone is set.
+              color: accentTone
+                ? 'var(--color-on-accent)'
+                : 'var(--color-text-primary)',
+            }}
+          >
+            <Icon className="h-5 w-5" />
+          </div>
+        )}
+        <div className="flex max-w-2xl flex-col gap-1">
+          {eyebrow && (
+            <span
+              className="text-xs font-semibold uppercase tracking-[0.18em]"
+              style={{ color: 'var(--color-text-secondary)' }}
+            >
+              {eyebrow}
+            </span>
+          )}
+          <h1
+            className="text-xl font-semibold tracking-tight sm:text-2xl"
+            style={{ color: 'var(--color-text-primary)' }}
+          >
+            {title}
+          </h1>
+          <div
+            className="text-xs leading-relaxed"
+            style={{ color: 'var(--color-text-secondary)' }}
+          >
+            {description}
+          </div>
         </div>
       </div>
       {children && (
-        <div className="flex w-full flex-col items-center gap-3 sm:flex-row sm:justify-center">
+        <div
+          className={cn(
+            'flex w-full flex-col gap-3 sm:flex-row',
+            alignStart ? 'sm:justify-start' : 'items-center sm:justify-center'
+          )}
+        >
           {children}
         </div>
       )}

--- a/packages/ui/src/components/calculator/calculator-stat.tsx
+++ b/packages/ui/src/components/calculator/calculator-stat.tsx
@@ -1,8 +1,8 @@
 import { memo, type ReactNode } from 'react';
 import { cn } from '../../lib/cn';
-import { colorMixOr } from '../../lib/color';
+import type { AccentTone } from './accent-tone';
 
-type StatTone = 'default' | 'emerald' | 'sky';
+type StatTone = 'default' | AccentTone;
 
 interface CalculatorStatProps {
   label: string;
@@ -19,42 +19,17 @@ interface ToneStyles {
   helper: string;
 }
 
-// Theme-aware tone styles using predefined gradients
-// Uses on-accent tokens for readable text against gradient backgrounds
-const getToneStyle = (tone: Exclude<StatTone, 'default'>): ToneStyles => {
-  switch (tone) {
-    case 'emerald':
-      return {
-        container: {
-          borderColor: colorMixOr(
-            'var(--color-semantic-success)',
-            30,
-            'transparent',
-            'var(--color-border-secondary)'
-          ),
-          background: 'var(--gradient-card-primary)',
-        },
-        label: 'var(--color-on-accent-soft)',
-        value: 'var(--color-on-accent)',
-        helper: 'var(--color-on-accent-muted)',
-      };
-    case 'sky':
-      return {
-        container: {
-          borderColor: colorMixOr(
-            'var(--color-semantic-info)',
-            30,
-            'transparent',
-            'var(--color-border-secondary)'
-          ),
-          background: 'var(--gradient-card-info)',
-        },
-        label: 'var(--color-on-accent-soft)',
-        value: 'var(--color-on-accent)',
-        helper: 'var(--color-on-accent-muted)',
-      };
-  }
-};
+// Theme-aware tone styles backed by the plan-003 `--accent-<tone>-*` vars.
+// Text uses the 006 on-accent tokens so it stays readable on the gradient.
+const getToneStyle = (tone: Exclude<StatTone, 'default'>): ToneStyles => ({
+  container: {
+    borderColor: `var(--accent-${tone}-border, var(--color-border-secondary))`,
+    background: `var(--accent-${tone}-gradient)`,
+  },
+  label: 'var(--color-on-accent-soft)',
+  value: 'var(--color-on-accent)',
+  helper: 'var(--color-on-accent-muted)',
+});
 
 export const CalculatorStat = memo(function CalculatorStat({
   label,

--- a/packages/ui/src/components/calculator/calculator-stat.tsx
+++ b/packages/ui/src/components/calculator/calculator-stat.tsx
@@ -20,7 +20,7 @@ interface ToneStyles {
 }
 
 // Theme-aware tone styles using predefined gradients
-// Uses high-contrast text colors against gradient backgrounds
+// Uses on-accent tokens for readable text against gradient backgrounds
 const getToneStyle = (tone: Exclude<StatTone, 'default'>): ToneStyles => {
   switch (tone) {
     case 'emerald':
@@ -34,9 +34,9 @@ const getToneStyle = (tone: Exclude<StatTone, 'default'>): ToneStyles => {
           ),
           background: 'var(--gradient-card-primary)',
         },
-        label: 'var(--color-text-primary)',
-        value: 'var(--color-text-primary)',
-        helper: 'var(--color-text-primary)',
+        label: 'var(--color-on-accent-soft)',
+        value: 'var(--color-on-accent)',
+        helper: 'var(--color-on-accent-muted)',
       };
     case 'sky':
       return {
@@ -49,9 +49,9 @@ const getToneStyle = (tone: Exclude<StatTone, 'default'>): ToneStyles => {
           ),
           background: 'var(--gradient-card-info)',
         },
-        label: 'var(--color-text-primary)',
-        value: 'var(--color-text-primary)',
-        helper: 'var(--color-text-primary)',
+        label: 'var(--color-on-accent-soft)',
+        value: 'var(--color-on-accent)',
+        helper: 'var(--color-on-accent-muted)',
       };
   }
 };
@@ -81,7 +81,7 @@ export const CalculatorStat = memo(function CalculatorStat({
       }
     >
       <span
-        className="text-[10px] font-semibold uppercase tracking-[0.3em]"
+        className="text-xs font-semibold uppercase tracking-[0.2em]"
         style={{
           color: toneStyle ? toneStyle.label : 'var(--color-text-primary)',
         }}

--- a/packages/ui/src/components/calculator/index.ts
+++ b/packages/ui/src/components/calculator/index.ts
@@ -1,3 +1,4 @@
+export type { AccentTone } from './accent-tone';
 export * from './calculator-card';
 export * from './calculator-layout';
 export * from './calculator-number-field';

--- a/packages/ui/src/components/development-recipes/actions-bar.tsx
+++ b/packages/ui/src/components/development-recipes/actions-bar.tsx
@@ -15,6 +15,8 @@ interface DevelopmentActionsBarProps {
   onOpenCustomRecipeModal: () => void;
   onRefresh: () => void;
   isRefreshing?: boolean;
+  /** Whether the initial data load is still in flight; suppresses the "0 pairings" subtitle. */
+  isLoading?: boolean;
   showImportButton?: boolean;
   isMobile?: boolean;
 }
@@ -27,6 +29,7 @@ export function DevelopmentActionsBar({
   onOpenCustomRecipeModal,
   onRefresh,
   isRefreshing,
+  isLoading = false,
   showImportButton = true,
   isMobile = false,
 }: DevelopmentActionsBarProps) {
@@ -64,7 +67,9 @@ export function DevelopmentActionsBar({
             className="text-sm"
             style={{ color: 'var(--color-text-tertiary)' }}
           >
-            {totalResults.toLocaleString()} film and developer pairings.
+            {isLoading
+              ? 'Loading recipes…'
+              : `${totalResults.toLocaleString()} film and developer pairings.`}
           </p>
         </div>
       </div>

--- a/packages/ui/src/components/development-recipes/actions-bar.tsx
+++ b/packages/ui/src/components/development-recipes/actions-bar.tsx
@@ -21,6 +21,7 @@ interface DevelopmentActionsBarProps {
   isMobile?: boolean;
 }
 
+// eslint-disable-next-line react-doctor/no-many-boolean-props -- isRefreshing / isLoading / showImportButton / isMobile are independent display/state flags on a toolbar, not a variant axis; compound-component split would add more indirection than value here
 export function DevelopmentActionsBar({
   totalResults,
   viewMode,
@@ -44,7 +45,7 @@ export function DevelopmentActionsBar({
       <div className="flex items-center gap-4">
         {RecipeIcon && (
           <div
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border"
+            className="flex size-11 shrink-0 items-center justify-center rounded-xl border"
             style={{
               background: 'var(--accent-rose-gradient)',
               borderColor:
@@ -53,7 +54,7 @@ export function DevelopmentActionsBar({
               color: 'var(--color-on-accent)',
             }}
           >
-            <RecipeIcon className="h-5 w-5" />
+            <RecipeIcon className="size-5" />
           </div>
         )}
         <div>

--- a/packages/ui/src/components/development-recipes/actions-bar.tsx
+++ b/packages/ui/src/components/development-recipes/actions-bar.tsx
@@ -1,7 +1,11 @@
 import { Grid, Plus, Rows, Upload } from 'lucide-react';
 import { cn } from '../../lib/cn';
 import { setStyles } from '../../lib/dom';
+import { getRouteIcon } from '../../lib/navigation';
 import { TemperatureUnitToggle } from './temperature-unit-toggle';
+
+// Development recipes carry the Film category's rose accent (plan 007).
+const RecipeIcon = getRouteIcon('/development');
 
 interface DevelopmentActionsBarProps {
   totalResults: number;
@@ -34,16 +38,35 @@ export function DevelopmentActionsBar({
         backgroundColor: 'rgba(var(--color-background-rgb), 0.25)',
       }}
     >
-      <div>
-        <h2
-          className="text-lg font-semibold"
-          style={{ color: 'var(--color-text-primary)' }}
-        >
-          Development Recipes
-        </h2>
-        <p className="text-sm" style={{ color: 'var(--color-text-tertiary)' }}>
-          {totalResults.toLocaleString()} film and developer pairings.
-        </p>
+      <div className="flex items-center gap-4">
+        {RecipeIcon && (
+          <div
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border"
+            style={{
+              background: 'var(--accent-rose-gradient)',
+              borderColor:
+                'var(--accent-rose-border, var(--color-border-secondary))',
+              // RecipeIcon inherits this via currentColor.
+              color: 'var(--color-on-accent)',
+            }}
+          >
+            <RecipeIcon className="h-5 w-5" />
+          </div>
+        )}
+        <div>
+          <h2
+            className="text-lg font-semibold"
+            style={{ color: 'var(--color-text-primary)' }}
+          >
+            Development Recipes
+          </h2>
+          <p
+            className="text-sm"
+            style={{ color: 'var(--color-text-tertiary)' }}
+          >
+            {totalResults.toLocaleString()} film and developer pairings.
+          </p>
+        </div>
       </div>
 
       <div className="flex flex-wrap items-center gap-2">

--- a/packages/ui/src/components/development-recipes/results-cards-virtualized.tsx
+++ b/packages/ui/src/components/development-recipes/results-cards-virtualized.tsx
@@ -47,10 +47,14 @@ import {
 const BREAKPOINT_XL = 1280;
 const BREAKPOINT_LG = 1024;
 const BREAKPOINT_SM = 640;
+/** Below this width the mobile grid collapses to 1 column (plan 009 item 5). */
+const BREAKPOINT_MOBILE_2COL = 480;
 
 /**
- * Hook to calculate responsive column count based on container width
- * Matches Tailwind breakpoints: sm:640px, lg:1024px, xl:1280px
+ * Hook to calculate responsive column count based on container width.
+ *
+ * Desktop: matches Tailwind breakpoints sm:640px, lg:1024px, xl:1280px.
+ * Mobile: 1 column below 480px, 2 columns at 480px and above.
  *
  * Uses debounced ResizeObserver to prevent browser lockups during rapid resizing.
  */
@@ -58,15 +62,17 @@ function useResponsiveColumnCount(
   containerRef: React.RefObject<HTMLDivElement | null>,
   isMobile: boolean
 ): number {
-  const [observedColumnCount, setColumnCount] = useState(3);
+  const [observedColumnCount, setColumnCount] = useState(isMobile ? 2 : 3);
 
   useEffect(() => {
-    if (isMobile) return;
-
     const container = containerRef.current;
     if (!container) return;
 
     const calculateColumns = (width: number): number => {
+      if (isMobile) {
+        // 1-col below 480px, 2-col at 480px+ (plan 009 item 5)
+        return width >= BREAKPOINT_MOBILE_2COL ? 2 : 1;
+      }
       // Match Tailwind breakpoints for grid-cols
       if (width >= BREAKPOINT_XL) return 4; // xl
       if (width >= BREAKPOINT_LG) return 3; // lg
@@ -122,7 +128,7 @@ function useResponsiveColumnCount(
     };
   }, [containerRef, isMobile]);
 
-  return isMobile ? 2 : observedColumnCount;
+  return observedColumnCount;
 }
 
 interface DevelopmentResultsCardsVirtualizedProps {

--- a/packages/ui/src/components/development-recipes/results-cards-virtualized.tsx
+++ b/packages/ui/src/components/development-recipes/results-cards-virtualized.tsx
@@ -369,8 +369,8 @@ function RecipeCard({
             {film ? `${film.brand} ${film.name}` : 'Unknown film'}
           </span>
           <div
-            className="text-xs"
-            style={{ color: 'var(--color-text-tertiary)' }}
+            className="text-sm font-medium"
+            style={{ color: 'var(--color-text-secondary)' }}
           >
             {developer
               ? `${developer.manufacturer} ${developer.name}`

--- a/packages/ui/src/components/films/film-image.tsx
+++ b/packages/ui/src/components/films/film-image.tsx
@@ -90,7 +90,7 @@ export const FilmImage: FC<FilmImageProps> = ({
   return (
     <div
       className={cn(
-        'aspect-square flex items-center justify-center rounded-lg overflow-hidden flex-shrink-0',
+        'relative aspect-square flex items-center justify-center rounded-lg overflow-hidden flex-shrink-0',
         className
       )}
       style={{

--- a/packages/ui/src/components/marketing/__tests__/stat-card.test.tsx
+++ b/packages/ui/src/components/marketing/__tests__/stat-card.test.tsx
@@ -8,8 +8,7 @@ describe('StatCard', () => {
     label: 'Test Stat',
     value: '123',
     icon: Heart,
-    iconColor: 'text-red-500',
-    iconBg: 'bg-red-100',
+    iconColorKey: 'rose' as const,
     href: '/stats',
   };
 

--- a/packages/ui/src/components/marketing/__tests__/tool-card.test.tsx
+++ b/packages/ui/src/components/marketing/__tests__/tool-card.test.tsx
@@ -21,6 +21,14 @@ describe('ToolCard', () => {
     expect(screen.getByText('Category')).toBeInTheDocument();
   });
 
+  it('omits the category eyebrow when category is not provided', () => {
+    const { category: _category, ...withoutCategory } = defaultProps;
+    render(<ToolCard {...withoutCategory} />);
+
+    expect(screen.getByText('Test Tool')).toBeInTheDocument();
+    expect(screen.queryByText('Category')).not.toBeInTheDocument();
+  });
+
   it('has accessible name via aria-label', () => {
     render(<ToolCard {...defaultProps} />);
     expect(screen.getByRole('link')).toHaveAttribute('aria-label', 'Test Tool');

--- a/packages/ui/src/components/marketing/__tests__/tool-card.test.tsx
+++ b/packages/ui/src/components/marketing/__tests__/tool-card.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { Calculator } from 'lucide-react';
 import { describe, expect, it } from 'vitest';
-import { ToolCard } from '../tool-card';
+import { type AccentColor, ToolCard } from '../tool-card';
 
 describe('ToolCard', () => {
   const defaultProps = {
@@ -9,9 +9,7 @@ describe('ToolCard', () => {
     description: 'A description of the tool',
     category: 'Category',
     icon: Calculator,
-    color: 'text-blue-500',
-    bg: 'bg-blue-100',
-    border: 'border-blue-200',
+    accent: 'blue' as AccentColor,
     href: '/tool',
   };
 
@@ -33,5 +31,19 @@ describe('ToolCard', () => {
     expect(
       screen.getByRole('button', { name: 'Test Tool' })
     ).toBeInTheDocument();
+  });
+
+  it('applies the accent text class for the given accent', () => {
+    const { container } = render(<ToolCard {...defaultProps} accent="blue" />);
+    expect(
+      container.querySelector('.text-\\[color\\:var\\(--accent-blue-text\\)\\]')
+    ).toBeInTheDocument();
+  });
+
+  it('applies the accent hover-border class for the given accent', () => {
+    render(<ToolCard {...defaultProps} accent="rose" />);
+    expect(screen.getByRole('link')).toHaveClass(
+      'group-hover:border-[color:var(--accent-rose-border)]'
+    );
   });
 });

--- a/packages/ui/src/components/marketing/stat-card.tsx
+++ b/packages/ui/src/components/marketing/stat-card.tsx
@@ -3,33 +3,30 @@ import type { ComponentProps, ElementType } from 'react';
 import { cn } from '../../lib/cn';
 import { Skeleton } from '../ui/skeleton';
 
+export type StatCardColorKey = 'emerald' | 'rose' | 'indigo';
+
 export interface StatCardProps extends ComponentProps<'a'> {
   label: string;
   value: string | number;
   icon: LucideIcon;
-  iconColorKey?: 'emerald' | 'rose' | 'indigo';
+  iconColorKey?: StatCardColorKey;
   variant?: 'horizontal' | 'vertical';
   as?: ElementType;
   to?: string;
   search?: Record<string, unknown>;
   loading?: boolean;
-  bg?: string;
-  border?: string;
 }
 
-const COLOR_VARIANTS = {
-  emerald: {
-    bg: 'from-emerald-500/20 to-teal-500/20',
-    border: 'group-hover:border-emerald-500/50',
-  },
-  rose: {
-    bg: 'from-rose-500/20 to-red-500/20',
-    border: 'group-hover:border-rose-500/50',
-  },
-  indigo: {
-    bg: 'from-indigo-500/20 to-purple-500/20',
-    border: 'group-hover:border-indigo-500/50',
-  },
+/**
+ * Literal Tailwind hover-border class per accent (subset of AccentColor).
+ * Tailwind must see the full class string in source, so these are not built
+ * by interpolation. The gradient overlay uses an inline `--accent-*-gradient`
+ * custom property instead.
+ */
+const HOVER_BORDER_CLASSES: Record<StatCardColorKey, string> = {
+  emerald: 'group-hover:border-[color:var(--accent-emerald-border)]',
+  rose: 'group-hover:border-[color:var(--accent-rose-border)]',
+  indigo: 'group-hover:border-[color:var(--accent-indigo-border)]',
 };
 
 export function StatCard({
@@ -44,17 +41,13 @@ export function StatCard({
   to,
   search,
   loading = false,
-  bg: propBg,
-  border: propBorder,
   ...props
 }: StatCardProps) {
   const iconColorVar = iconColorKey
     ? `var(--color-icon-stat-${iconColorKey})`
     : 'var(--color-text-primary)';
 
-  const variantStyles = iconColorKey ? COLOR_VARIANTS[iconColorKey] : undefined;
-  const bg = propBg || variantStyles?.bg;
-  const border = propBorder || variantStyles?.border;
+  const border = iconColorKey ? HOVER_BORDER_CLASSES[iconColorKey] : undefined;
 
   const componentProps =
     Component === 'a' ? { href } : { to: href || to, search, ...props };
@@ -108,14 +101,12 @@ export function StatCard({
     className
   );
 
-  const gradientOverlay = (
+  const gradientOverlay = iconColorKey ? (
     <div
-      className={cn(
-        'absolute inset-0 bg-gradient-to-br opacity-0 transition-opacity group-hover:opacity-100',
-        bg
-      )}
+      className="absolute inset-0 opacity-0 transition-opacity group-hover:opacity-100"
+      style={{ backgroundImage: `var(--accent-${iconColorKey}-gradient)` }}
     />
-  );
+  ) : null;
 
   if (variant === 'horizontal') {
     return (

--- a/packages/ui/src/components/marketing/stat-card.tsx
+++ b/packages/ui/src/components/marketing/stat-card.tsx
@@ -98,10 +98,10 @@ export function StatCard({
   }
 
   const commonClasses = cn(
-    'relative overflow-hidden rounded-2xl border transition-all focus:outline-none focus:ring-2',
+    'relative overflow-hidden rounded-2xl border transition-all focus-visible:outline-none focus-visible:ring-2',
     'border-[color:var(--color-border-primary)]',
     'hover:bg-[color:var(--color-surface-muted)]',
-    'focus:ring-[color:var(--color-border-primary)]',
+    'focus-visible:ring-[color:var(--color-border-primary)]',
     '[&:not([data-theme="high-contrast"])]:hover:-translate-y-0.5',
     '[&:not([data-theme="high-contrast"])]:hover:shadow-lg',
     border,

--- a/packages/ui/src/components/marketing/tool-card.tsx
+++ b/packages/ui/src/components/marketing/tool-card.tsx
@@ -34,10 +34,10 @@ export const ToolCard = memo(function ToolCard({
       {...componentProps}
       aria-label={title}
       className={cn(
-        'group relative overflow-hidden rounded-2xl border p-5 transition-all focus:outline-none focus:ring-2',
+        'group relative overflow-hidden rounded-2xl border p-5 transition-all focus-visible:outline-none focus-visible:ring-2',
         'border-[color:var(--color-border-primary)]',
         'hover:bg-[color:var(--color-surface-muted)]',
-        'focus:ring-[color:var(--color-border-primary)]',
+        'focus-visible:ring-[color:var(--color-border-primary)]',
         '[&:not([data-theme="high-contrast"])]:hover:-translate-y-0.5',
         '[&:not([data-theme="high-contrast"])]:hover:shadow-lg',
         border,

--- a/packages/ui/src/components/marketing/tool-card.tsx
+++ b/packages/ui/src/components/marketing/tool-card.tsx
@@ -120,21 +120,21 @@ export const ToolCard = memo(function ToolCard({
         <div className="flex-1 min-w-0">
           {category ? (
             <div className="flex items-center justify-between mb-1">
-              <p className="text-[10px] font-bold uppercase tracking-wider text-[color:var(--color-tool-card-category)] group-hover:text-[color:var(--color-tool-card-category-hover)]">
+              <p className="text-xs font-bold uppercase tracking-wider text-[color:var(--color-text-tertiary)] group-hover:text-[color:var(--color-text-secondary)]">
                 {category}
               </p>
-              <ArrowRight className="size-3.5 text-[color:var(--color-tool-card-arrow)] opacity-0 -translate-x-2 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
+              <ArrowRight className="size-3.5 shrink-0 text-[color:var(--color-tool-card-arrow)] opacity-0 -translate-x-2 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
             </div>
           ) : null}
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-[color:var(--color-tool-card-title)] truncate pr-4">
+          <div className="flex items-start justify-between gap-2">
+            <h3 className="font-semibold text-[color:var(--color-text-primary)]">
               {title}
             </h3>
             {category ? null : (
-              <ArrowRight className="size-3.5 shrink-0 text-[color:var(--color-tool-card-arrow)] opacity-0 -translate-x-2 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
+              <ArrowRight className="mt-1 size-3.5 shrink-0 text-[color:var(--color-tool-card-arrow)] opacity-0 -translate-x-2 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
             )}
           </div>
-          <p className="text-sm text-[color:var(--color-tool-card-description)] line-clamp-1 group-hover:text-[color:var(--color-tool-card-description-hover)]">
+          <p className="text-sm text-[color:var(--color-tool-card-description)] group-hover:text-[color:var(--color-tool-card-description-hover)]">
             {description}
           </p>
         </div>

--- a/packages/ui/src/components/marketing/tool-card.tsx
+++ b/packages/ui/src/components/marketing/tool-card.tsx
@@ -60,7 +60,7 @@ const ACCENT_CLASSES: Record<AccentColor, { text: string; border: string }> = {
 export interface ToolCardProps extends ComponentProps<'a'> {
   title: string;
   description: string;
-  category: string;
+  category?: string;
   icon: LucideIcon;
   accent: AccentColor;
   href: string;
@@ -118,15 +118,22 @@ export const ToolCard = memo(function ToolCard({
         </div>
 
         <div className="flex-1 min-w-0">
-          <div className="flex items-center justify-between mb-1">
-            <p className="text-[10px] font-bold uppercase tracking-wider text-[color:var(--color-tool-card-category)] group-hover:text-[color:var(--color-tool-card-category-hover)]">
-              {category}
-            </p>
-            <ArrowRight className="size-3.5 text-[color:var(--color-tool-card-arrow)] opacity-0 -translate-x-2 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
+          {category ? (
+            <div className="flex items-center justify-between mb-1">
+              <p className="text-[10px] font-bold uppercase tracking-wider text-[color:var(--color-tool-card-category)] group-hover:text-[color:var(--color-tool-card-category-hover)]">
+                {category}
+              </p>
+              <ArrowRight className="size-3.5 text-[color:var(--color-tool-card-arrow)] opacity-0 -translate-x-2 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
+            </div>
+          ) : null}
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-[color:var(--color-tool-card-title)] truncate pr-4">
+              {title}
+            </h3>
+            {category ? null : (
+              <ArrowRight className="size-3.5 shrink-0 text-[color:var(--color-tool-card-arrow)] opacity-0 -translate-x-2 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
+            )}
           </div>
-          <h3 className="font-semibold text-[color:var(--color-tool-card-title)] truncate pr-4">
-            {title}
-          </h3>
           <p className="text-sm text-[color:var(--color-tool-card-description)] line-clamp-1 group-hover:text-[color:var(--color-tool-card-description-hover)]">
             {description}
           </p>

--- a/packages/ui/src/components/marketing/tool-card.tsx
+++ b/packages/ui/src/components/marketing/tool-card.tsx
@@ -2,14 +2,67 @@ import { ArrowRight, type LucideIcon } from 'lucide-react';
 import { type ComponentProps, type ElementType, memo } from 'react';
 import { cn } from '../../lib/cn';
 
+export type AccentColor =
+  | 'indigo'
+  | 'blue'
+  | 'violet'
+  | 'teal'
+  | 'amber'
+  | 'rose'
+  | 'cyan'
+  | 'emerald'
+  | 'sky';
+
+/**
+ * Literal Tailwind class strings per accent. Tailwind must see the full class
+ * string in source, so these are never built by interpolation. The CSS custom
+ * properties resolve per-theme (see theme.css `--accent-*` variables).
+ */
+const ACCENT_CLASSES: Record<AccentColor, { text: string; border: string }> = {
+  indigo: {
+    text: 'text-[color:var(--accent-indigo-text)]',
+    border: 'group-hover:border-[color:var(--accent-indigo-border)]',
+  },
+  blue: {
+    text: 'text-[color:var(--accent-blue-text)]',
+    border: 'group-hover:border-[color:var(--accent-blue-border)]',
+  },
+  violet: {
+    text: 'text-[color:var(--accent-violet-text)]',
+    border: 'group-hover:border-[color:var(--accent-violet-border)]',
+  },
+  teal: {
+    text: 'text-[color:var(--accent-teal-text)]',
+    border: 'group-hover:border-[color:var(--accent-teal-border)]',
+  },
+  amber: {
+    text: 'text-[color:var(--accent-amber-text)]',
+    border: 'group-hover:border-[color:var(--accent-amber-border)]',
+  },
+  rose: {
+    text: 'text-[color:var(--accent-rose-text)]',
+    border: 'group-hover:border-[color:var(--accent-rose-border)]',
+  },
+  cyan: {
+    text: 'text-[color:var(--accent-cyan-text)]',
+    border: 'group-hover:border-[color:var(--accent-cyan-border)]',
+  },
+  emerald: {
+    text: 'text-[color:var(--accent-emerald-text)]',
+    border: 'group-hover:border-[color:var(--accent-emerald-border)]',
+  },
+  sky: {
+    text: 'text-[color:var(--accent-sky-text)]',
+    border: 'group-hover:border-[color:var(--accent-sky-border)]',
+  },
+};
+
 export interface ToolCardProps extends ComponentProps<'a'> {
   title: string;
   description: string;
   category: string;
   icon: LucideIcon;
-  color: string;
-  bg: string;
-  border: string;
+  accent: AccentColor;
   href: string;
   as?: ElementType;
 }
@@ -19,14 +72,13 @@ export const ToolCard = memo(function ToolCard({
   description,
   category,
   icon: Icon,
-  color,
-  bg,
-  border,
+  accent,
   href,
   as: Component = 'a',
   className,
   ...props
 }: ToolCardProps) {
+  const accentClasses = ACCENT_CLASSES[accent];
   const componentProps = Component === 'a' ? { href } : { to: href, ...props };
 
   return (
@@ -40,7 +92,7 @@ export const ToolCard = memo(function ToolCard({
         'focus-visible:ring-[color:var(--color-border-primary)]',
         '[&:not([data-theme="high-contrast"])]:hover:-translate-y-0.5',
         '[&:not([data-theme="high-contrast"])]:hover:shadow-lg',
-        border,
+        accentClasses.border,
         className
       )}
       style={{
@@ -48,10 +100,8 @@ export const ToolCard = memo(function ToolCard({
       }}
     >
       <div
-        className={cn(
-          'absolute inset-0 bg-gradient-to-br opacity-0 transition-opacity group-hover:opacity-100',
-          bg
-        )}
+        className="absolute inset-0 opacity-0 transition-opacity group-hover:opacity-100"
+        style={{ backgroundImage: `var(--accent-${accent}-gradient)` }}
       />
 
       <div className="relative z-10 flex items-start gap-4">
@@ -61,7 +111,7 @@ export const ToolCard = memo(function ToolCard({
             'bg-[var(--color-tool-card-icon-bg)]',
             'ring-1 ring-[color:var(--color-tool-card-icon-ring)]',
             'group-hover:bg-[var(--color-tool-card-icon-hover)]',
-            color
+            accentClasses.text
           )}
         >
           <Icon className="size-6" />

--- a/packages/ui/src/components/sensor-size-visualization.tsx
+++ b/packages/ui/src/components/sensor-size-visualization.tsx
@@ -136,8 +136,10 @@ export const SensorSizeVisualization: FC<SensorSizeVisualizationProps> = ({
                 borderColor: 'var(--color-primary)',
               }}
             />
-            <span className="text-secondary">{sourceFormat.shortName}</span>
-            <span className="text-tertiary">
+            <span style={{ color: 'var(--color-on-accent-soft)' }}>
+              {sourceFormat.shortName}
+            </span>
+            <span style={{ color: 'var(--color-on-accent-muted)' }}>
               ({sourceFormat.width}×{sourceFormat.height})
             </span>
           </div>
@@ -148,15 +150,20 @@ export const SensorSizeVisualization: FC<SensorSizeVisualizationProps> = ({
                 borderColor: 'var(--color-secondary)',
               }}
             />
-            <span className="text-secondary">{targetFormat.shortName}</span>
-            <span className="text-tertiary">
+            <span style={{ color: 'var(--color-on-accent-soft)' }}>
+              {targetFormat.shortName}
+            </span>
+            <span style={{ color: 'var(--color-on-accent-muted)' }}>
               ({targetFormat.width}×{targetFormat.height})
             </span>
           </div>
         </div>
-        <p className="text-tertiary">
+        <p style={{ color: 'var(--color-on-accent-muted)' }}>
           Target is{' '}
-          <span className="font-medium text-secondary">
+          <span
+            className="font-medium"
+            style={{ color: 'var(--color-on-accent-soft)' }}
+          >
             {areaRatio > 1 ? areaRatio.toFixed(2) : (1 / areaRatio).toFixed(2)}×
           </span>{' '}
           {areaRatio > 1 ? 'larger' : 'smaller'}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -28,7 +28,10 @@ export { LabeledSliderInput } from './components/labeled-slider-input';
 export { Greeting } from './components/marketing/greeting';
 export type { StatCardProps } from './components/marketing/stat-card';
 export { StatCard } from './components/marketing/stat-card';
-export type { ToolCardProps } from './components/marketing/tool-card';
+export type {
+  AccentColor,
+  ToolCardProps,
+} from './components/marketing/tool-card';
 export { ToolCard } from './components/marketing/tool-card';
 export { MeasurementUnitToggle } from './components/measurement-unit-toggle';
 export type { MobileSidebarProps } from './components/mobile-sidebar';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -128,6 +128,7 @@ export {
   CATEGORY_LABELS,
   cameraItems,
   filmItems,
+  getRouteIcon,
   mobileNavItems,
   navItems,
   navigationCategories,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -122,6 +122,7 @@ export * from './lib/measurement';
 export type { MobileNavItem, NavigationCategory } from './lib/navigation';
 export {
   allNavItems,
+  CATEGORY_LABELS,
   cameraItems,
   filmItems,
   mobileNavItems,

--- a/packages/ui/src/lib/navigation.ts
+++ b/packages/ui/src/lib/navigation.ts
@@ -150,6 +150,17 @@ export const allNavItems = [
   ...referenceItems,
 ];
 
+/**
+ * Resolve the lucide icon for a route from the nav metadata, so calculator
+ * page headers render the same icon as home/nav without re-importing icons
+ * per page. Returns `undefined` for routes without a nav entry.
+ */
+export function getRouteIcon(
+  to: string
+): ComponentType<{ className?: string }> | undefined {
+  return allNavItems.find((item) => item.to === to)?.icon;
+}
+
 export const ROUTE_TITLES: Record<string, string> = {
   '/': 'Home',
   '/border': 'Border Calculator',

--- a/packages/ui/src/lib/navigation.ts
+++ b/packages/ui/src/lib/navigation.ts
@@ -112,24 +112,31 @@ export interface NavigationCategory {
   items: NavigationItem[];
 }
 
+export const CATEGORY_LABELS = {
+  printing: 'Printing',
+  film: 'Film',
+  camera: 'Camera',
+  reference: 'Reference',
+} as const;
+
 export const navigationCategories: NavigationCategory[] = [
   {
-    label: 'Printing',
+    label: CATEGORY_LABELS.printing,
     icon: asFunctionComponent(Printer),
     items: printingItems,
   },
   {
-    label: 'Film',
+    label: CATEGORY_LABELS.film,
     icon: asFunctionComponent(Film),
     items: filmItems,
   },
   {
-    label: 'Camera',
+    label: CATEGORY_LABELS.camera,
     icon: asFunctionComponent(Camera),
     items: cameraItems,
   },
   {
-    label: 'Reference',
+    label: CATEGORY_LABELS.reference,
     icon: asFunctionComponent(BookOpen),
     items: referenceItems,
   },

--- a/scripts/audit-contrast.mjs
+++ b/scripts/audit-contrast.mjs
@@ -1,0 +1,209 @@
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+
+const OUT = '/tmp/dorkroom-shots';
+fs.mkdirSync(OUT, { recursive: true });
+
+const AUDIT_PAGES = [
+  ['home', '/'],
+  ['border', '/border'],
+  ['stops', '/stops'],
+  ['lenses', '/lenses'],
+  ['exposure', '/exposure'],
+  ['mat', '/mat'],
+  ['development', '/development'],
+];
+const SHOT_THEMES = ['light', 'high-contrast', 'darkroom'];
+const SHOT_PAGES = [
+  ['home', '/'],
+  ['lenses', '/lenses'],
+  ['border', '/border'],
+  ['development', '/development'],
+];
+
+const browser = await chromium.launch();
+
+async function makeCtx(theme) {
+  const ctx = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 1,
+  });
+  await ctx.addInitScript((t) => {
+    try {
+      localStorage.setItem('dorkroom-theme', t);
+      localStorage.setItem('dorkroom-animations-enabled', 'false');
+    } catch {}
+  }, theme);
+  return ctx;
+}
+
+// --- 1. theme screenshots ---
+for (const theme of SHOT_THEMES) {
+  const ctx = await makeCtx(theme);
+  const page = await ctx.newPage();
+  for (const [name, path] of SHOT_PAGES) {
+    await page.goto(`http://localhost:4200${path}`, {
+      waitUntil: 'networkidle',
+    });
+    await page.waitForTimeout(1000);
+    await page.screenshot({ path: `${OUT}/t-${theme}-${name}.png` });
+  }
+  await ctx.close();
+}
+
+// --- 2. contrast audit (dark + light) ---
+function lum([r, g, b]) {
+  const f = (c) => {
+    c /= 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+function ratio(a, b) {
+  const [l1, l2] = [lum(a), lum(b)].sort((x, y) => y - x);
+  return (l1 + 0.05) / (l2 + 0.05);
+}
+
+const results = {};
+for (const theme of ['dark', 'light']) {
+  const ctx = await makeCtx(theme);
+  const page = await ctx.newPage();
+  for (const [name, path] of AUDIT_PAGES) {
+    await page.goto(`http://localhost:4200${path}`, {
+      waitUntil: 'networkidle',
+    });
+    await page.waitForTimeout(1200);
+
+    // collect visible text leaf elements
+    const items = await page.evaluate(() => {
+      const out = [];
+      const walker = document.createTreeWalker(
+        document.body,
+        NodeFilter.SHOW_TEXT
+      );
+      const seen = new Set();
+      let node = walker.nextNode();
+      while (node) {
+        const text = node.textContent.trim();
+        const el = node.parentElement;
+        if (text && el) {
+          const cs = getComputedStyle(el);
+          const r = node.parentElement.getBoundingClientRect
+            ? (() => {
+                const range = document.createRange();
+                range.selectNodeContents(node);
+                return range.getBoundingClientRect();
+              })()
+            : null;
+          if (
+            r &&
+            r.width > 2 &&
+            r.height > 4 &&
+            cs.visibility !== 'hidden' &&
+            cs.display !== 'none' &&
+            parseFloat(cs.opacity) > 0.1
+          ) {
+            const key = text.slice(0, 40) + '|' + cs.color + '|' + cs.fontSize;
+            if (!seen.has(key)) {
+              seen.add(key);
+              out.push({
+                text: text.slice(0, 50),
+                color: cs.color,
+                fontSize: parseFloat(cs.fontSize),
+                fontWeight: cs.fontWeight,
+                x: r.x + window.scrollX,
+                y: r.y + window.scrollY,
+                w: r.width,
+                h: r.height,
+              });
+            }
+          }
+        }
+        node = walker.nextNode();
+      }
+      return out;
+    });
+
+    const shotPath = `${OUT}/audit-${theme}-${name}.png`;
+    await page.screenshot({ path: shotPath, fullPage: true });
+
+    // sample background pixels around each text bbox using a canvas page
+    const b64 = fs.readFileSync(shotPath).toString('base64');
+    const sampler = await ctx.newPage();
+    await sampler.goto('about:blank');
+    const sampled = await sampler.evaluate(
+      async ({ b64, items }) => {
+        const img = new Image();
+        img.src = 'data:image/png;base64,' + b64;
+        await img.decode();
+        const canvas = document.createElement('canvas');
+        canvas.width = img.width;
+        canvas.height = img.height;
+        const cx = canvas.getContext('2d');
+        cx.drawImage(img, 0, 0);
+        const px = (x, y) => {
+          x = Math.max(0, Math.min(img.width - 1, Math.round(x)));
+          y = Math.max(0, Math.min(img.height - 1, Math.round(y)));
+          return Array.from(cx.getImageData(x, y, 1, 1).data.slice(0, 3));
+        };
+        return items.map((it) => {
+          const pts = [
+            px(it.x - 4, it.y + it.h / 2),
+            px(it.x + it.w + 4, it.y + it.h / 2),
+            px(it.x + it.w / 2, it.y - 4),
+            px(it.x + it.w / 2, it.y + it.h + 4),
+          ];
+          return { ...it, bgSamples: pts };
+        });
+      },
+      { b64, items }
+    );
+    await sampler.close();
+
+    const parseColor = (c) => {
+      const m = c.match(/rgba?\(([\d.]+),\s*([\d.]+),\s*([\d.]+)/);
+      return m ? [+m[1], +m[2], +m[3]] : null;
+    };
+    const dist = (a, b) => Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+
+    const findings = [];
+    for (const it of sampled) {
+      const fg = parseColor(it.color);
+      if (!fg) continue;
+      const bgs = it.bgSamples.filter((s) => dist(s, fg) > 40);
+      if (!bgs.length) continue;
+      const bg = bgs
+        .reduce(
+          (acc, s) => [acc[0] + s[0], acc[1] + s[1], acc[2] + s[2]],
+          [0, 0, 0]
+        )
+        .map((v) => v / bgs.length);
+      const r = ratio(fg, bg);
+      const large =
+        it.fontSize >= 24 || (it.fontSize >= 18.66 && +it.fontWeight >= 700);
+      const threshold = large ? 3 : 4.5;
+      if (r < threshold) {
+        findings.push({
+          text: it.text,
+          fg: it.color,
+          bgApprox: bg.map(Math.round),
+          ratio: +r.toFixed(2),
+          fontSize: it.fontSize,
+          fontWeight: it.fontWeight,
+          threshold,
+        });
+      }
+    }
+    findings.sort((a, b) => a.ratio - b.ratio);
+    results[`${theme}/${name}`] = findings.slice(0, 30);
+    console.log(`${theme}/${name}: ${findings.length} below threshold`);
+  }
+  await ctx.close();
+}
+
+fs.writeFileSync(
+  `${OUT}/contrast-findings.json`,
+  JSON.stringify(results, null, 2)
+);
+await browser.close();
+console.log('audit complete');


### PR DESCRIPTION
## What

Makes the navigation's category labels the single source of truth and removes the divergent strings hardcoded on the home page tool cards.

The same 9 calculator tools were categorized under two different label sets depending on where you looked: navigation used **Printing / Film / Camera / Reference**, while the home cards used **Darkroom Printing / Film / Film Reference / Film & Digital**. A user reading "Camera Exposure — FILM & DIGITAL" on a home card would find no "Film & Digital" menu anywhere.

## Changes

- `packages/ui/src/lib/navigation.ts` — add exported `CATEGORY_LABELS` constant; wire the four `navigationCategories` labels to reference it so the constant can't drift from the nav.
- `packages/ui/src/index.ts` — re-export `CATEGORY_LABELS` from `@dorkroom/ui`.
- `apps/dorkroom/src/app/pages/home-page.tsx` — replace the mismatched home-card category strings with `CATEGORY_LABELS.*`. Home cards now read Printing/Film/Camera/Reference, matching the header dropdowns and mobile drawer.

## Verification

- `bun run test` → exit 0 (73 test files, 1554 passing; lint + build + typecheck)
- `npx react-doctor@0.2.1 --score` → 100/100 on all three projects
- No old category strings remain (`grep` clean)

🤖 Generated as plan 001 of a stacked series (see `plans/`).