### PR TITLE
feat(home): front page interest pass — filled grid, hero with live border preview

### DIFF
--- a/apps/dorkroom/src/app/pages/camera-exposure-calculator/camera-exposure-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/camera-exposure-calculator/camera-exposure-calculator-page.tsx
@@ -667,34 +667,53 @@ export default function CameraExposureCalculatorPage() {
       sidebar={<CameraExposureSidebar />}
       results={
         <div className="space-y-6">
-          {/* EV Result - desktop only (mobile instance is in children) */}
+          {/* EV Result — desktop right column only */}
           <div className="hidden md:block">
             <EVResultCard form={form} formValues={formValues} />
           </div>
 
-          {/* Equivalent Exposures */}
-          <EquivalentExposuresCard form={form} />
+          {/* Equivalent Exposures — desktop right column only */}
+          <div className="hidden md:block">
+            <EquivalentExposuresCard form={form} />
+          </div>
+
+          {/* EV Presets — desktop right column only */}
+          <div className="hidden md:block">
+            <EVPresetsCard
+              form={form}
+              presetsOpen={presetsOpen}
+              onToggle={() => setPresetsOpen((prev) => !prev)}
+              onPresetClick={handlePresetClick}
+            />
+          </div>
         </div>
       }
     >
-      {/* Exposure Settings */}
+      {/* Exposure Settings — always visible */}
       <ExposureSettingsCard form={form} />
 
-      {/* Exposure Comparison */}
-      <ExposureComparisonCard form={form} />
-
-      {/* EV Result - mobile only (desktop instance is in results) */}
+      {/* EV Result — mobile only; on desktop this lives in the results column */}
       <div className="md:hidden">
         <EVResultCard form={form} formValues={formValues} />
       </div>
 
-      {/* EV Presets - collapsible */}
-      <EVPresetsCard
-        form={form}
-        presetsOpen={presetsOpen}
-        onToggle={() => setPresetsOpen((prev) => !prev)}
-        onPresetClick={handlePresetClick}
-      />
+      {/* Equivalent Exposures — mobile only; on desktop this lives in the results column */}
+      <div className="md:hidden">
+        <EquivalentExposuresCard form={form} />
+      </div>
+
+      {/* Exposure Comparison — always visible */}
+      <ExposureComparisonCard form={form} />
+
+      {/* EV Presets — mobile only; on desktop this lives in the results column */}
+      <div className="md:hidden">
+        <EVPresetsCard
+          form={form}
+          presetsOpen={presetsOpen}
+          onToggle={() => setPresetsOpen((prev) => !prev)}
+          onPresetClick={handlePresetClick}
+        />
+      </div>
     </CalculatorLayout>
   );
 }

--- a/apps/dorkroom/src/app/pages/development-recipes/components/recipe-results-section.tsx
+++ b/apps/dorkroom/src/app/pages/development-recipes/components/recipe-results-section.tsx
@@ -92,7 +92,7 @@ export const RecipeResultsSection: FC<RecipeResultsSectionProps> = (props) => {
               className={cn(
                 'grid gap-4',
                 isMobile
-                  ? 'grid-cols-2'
+                  ? 'grid-cols-1 min-[480px]:grid-cols-2'
                   : 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
               )}
             >

--- a/apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
+++ b/apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
@@ -443,6 +443,7 @@ export default function DevelopmentRecipesPage() {
           }}
           onRefresh={handleRefreshAll}
           isRefreshing={isRefreshingData}
+          isLoading={isLoading}
           showImportButton={flags.RECIPE_IMPORT}
           isMobile={isMobile}
         />

--- a/apps/dorkroom/src/app/pages/exposure-calculator/exposure-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/exposure-calculator/exposure-calculator-page.tsx
@@ -215,7 +215,7 @@ export default function ExposureCalculatorPage() {
 
               <div className="rounded-2xl p-4 font-mono text-sm border border-secondary bg-background/20 text-primary">
                 {`${formatExposureTime(calculation.originalTimeValue)} `}
-                <span className="align-super text-xs font-semibold text-[color:var(--color-primary)]">
+                <span className="align-super text-xs font-semibold text-[color:var(--color-on-accent)]">
                   ×2^
                   {calculation.stopsValue}
                 </span>

--- a/apps/dorkroom/src/app/pages/home-hero-preview.tsx
+++ b/apps/dorkroom/src/app/pages/home-hero-preview.tsx
@@ -1,0 +1,201 @@
+import {
+  bladeReadings,
+  calculateBladeThickness,
+  computePrintSize,
+} from '@dorkroom/logic';
+import { Link } from '@tanstack/react-router';
+import { ArrowRight } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+/* ------------------------------------------------------------------ *
+   Read-only border-calculator preview for the home hero.
+
+   Cycles through a few classic negative formats centered on 8x10 paper,
+   with the easel blades set by the same geometry helpers the border
+   calculator uses. All geometry is computed once at module level - no
+   data fetching, no per-frame math.
+\* ------------------------------------------------------------------ */
+
+const PAPER = { width: 10, height: 8 }; // 8x10 paper, landscape
+
+// calculateBladeThickness returns pixels for the calculator's 400px-wide
+// canvas; convert to inches so the blades scale with this fluid preview.
+const BLADE_IN =
+  (calculateBladeThickness(PAPER.width, PAPER.height) / 400) * PAPER.width;
+
+const pctX = (inches: number) => `${(inches / PAPER.width) * 100}%`;
+const pctY = (inches: number) => `${(inches / PAPER.height) * 100}%`;
+
+const FRACTION_GLYPHS: ReadonlyArray<readonly [number, string]> = [
+  [0.25, '¼'],
+  [0.5, '½'],
+  [0.75, '¾'],
+];
+
+/** Format inches with vulgar fractions: 8.25 -> "8 1/4". */
+function formatInches(value: number): string {
+  const whole = Math.trunc(value);
+  const rest = value - whole;
+  if (rest < 0.001) return `${whole}`;
+  const glyph = FRACTION_GLYPHS.find(
+    ([fraction]) => Math.abs(rest - fraction) < 0.001
+  )?.[1];
+  return glyph ? `${whole}${glyph}` : value.toFixed(2);
+}
+
+interface BorderSetup {
+  label: string;
+  printW: number;
+  printH: number;
+  borderX: number;
+  borderY: number;
+  readout: string;
+}
+
+// Min borders are chosen so every blade reading lands on a quarter inch.
+function makeSetup(
+  label: string,
+  ratioW: number,
+  ratioH: number,
+  minBorder: number
+): BorderSetup {
+  const { printW, printH } = computePrintSize(
+    PAPER.width,
+    PAPER.height,
+    ratioW,
+    ratioH,
+    minBorder
+  );
+  const readings = bladeReadings(printW, printH, 0, 0);
+  return {
+    label,
+    printW,
+    printH,
+    borderX: (PAPER.width - printW) / 2,
+    borderY: (PAPER.height - printH) / 2,
+    // Non-breaking spaces keep the readout on one line in the caption.
+    readout: `${formatInches(readings.left)} × ${formatInches(readings.top)}`,
+  };
+}
+
+const SETUPS: readonly BorderSetup[] = [
+  makeSetup('35mm', 3, 2, 1.25),
+  makeSetup('6×6', 1, 1, 1.5),
+  makeSetup('4×5', 5, 4, 1),
+];
+
+const CYCLE_MS = 5000;
+
+const bladeStyle = {
+  background: 'var(--blade-background)',
+  border: 'var(--blade-border)',
+  boxShadow: 'var(--blade-shadow)',
+} as const;
+
+// Slow position/size easing for the print and blades when a new setup lands.
+const easeClass = 'transition-all duration-1000 ease-in-out';
+
+function animationsDisabled(): boolean {
+  if (typeof document === 'undefined') return true;
+  // Same contract the theme system writes for darkroom/high-contrast and the
+  // user's animations toggle (utilities.css kills transitions for it too).
+  if (
+    document.documentElement.getAttribute('data-animations-disabled') === 'true'
+  ) {
+    return true;
+  }
+  return (
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+export function HomeHeroPreview() {
+  const [setupIndex, setSetupIndex] = useState(0);
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      // Checked per tick so theme/toggle changes take effect immediately.
+      if (animationsDisabled()) return;
+      setSetupIndex((index) => (index + 1) % SETUPS.length);
+    }, CYCLE_MS);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const { label, printW, printH, borderX, borderY, readout } =
+    SETUPS[setupIndex];
+
+  return (
+    <Link
+      to="/border"
+      aria-label="Open the border calculator"
+      className="group/hero block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border-primary)]"
+    >
+      {/* The paper, with the print area and four easel blades */}
+      <div
+        className="relative w-full overflow-hidden rounded-sm shadow-subtle transition-all group-hover/hero:-translate-y-0.5 group-hover/hero:shadow-lg"
+        style={{
+          aspectRatio: `${PAPER.width} / ${PAPER.height}`,
+          backgroundColor: 'var(--color-paper-background)',
+          border: '1px solid var(--color-paper-border)',
+        }}
+      >
+        {/* Print area */}
+        <div
+          className={`absolute ${easeClass}`}
+          style={{
+            left: pctX(borderX),
+            top: pctY(borderY),
+            width: pctX(printW),
+            height: pctY(printH),
+            backgroundColor: 'var(--color-print-background)',
+            border: 'var(--print-border-style) var(--color-print-border)',
+          }}
+        />
+        {/* Easel blades, sitting over the borders */}
+        <div
+          className={`absolute inset-y-0 -translate-x-full ${easeClass}`}
+          style={{
+            ...bladeStyle,
+            width: pctX(BLADE_IN),
+            left: pctX(borderX),
+          }}
+        />
+        <div
+          className={`absolute inset-y-0 ${easeClass}`}
+          style={{
+            ...bladeStyle,
+            width: pctX(BLADE_IN),
+            left: pctX(PAPER.width - borderX),
+          }}
+        />
+        <div
+          className={`absolute inset-x-0 -translate-y-full ${easeClass}`}
+          style={{
+            ...bladeStyle,
+            height: pctY(BLADE_IN),
+            top: pctY(borderY),
+          }}
+        />
+        <div
+          className={`absolute inset-x-0 ${easeClass}`}
+          style={{
+            ...bladeStyle,
+            height: pctY(BLADE_IN),
+            top: pctY(PAPER.height - borderY),
+          }}
+        />
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <span className="text-xs text-[color:var(--color-text-tertiary)]">
+          {label} on 8×10 paper · blades at {readout}
+        </span>
+        <span className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-[color:var(--color-text-secondary)] transition-colors group-hover/hero:text-[color:var(--color-text-primary)]">
+          Border calculator
+          <ArrowRight className="size-3.5 transition-transform group-hover/hero:translate-x-0.5" />
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/apps/dorkroom/src/app/pages/home-page.tsx
+++ b/apps/dorkroom/src/app/pages/home-page.tsx
@@ -1,5 +1,5 @@
 import { useStats } from '@dorkroom/logic';
-import { CATEGORY_LABELS, Greeting, StatCard, ToolCard } from '@dorkroom/ui';
+import { CATEGORY_LABELS, Greeting, ToolCard } from '@dorkroom/ui';
 import { Link } from '@tanstack/react-router';
 import {
   BookOpen,
@@ -16,12 +16,13 @@ import {
   GraduationCap,
   HandCoins,
   Ruler,
-  TestTubes,
   Timer,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { HomeHeroPreview } from './home-hero-preview';
 
-// Calculator tools configuration - module level to prevent recreation on each render
+// Calculator tools configuration - module level to prevent recreation on each
+// render. Accents match each target page's tone (see plan 007).
 const CALCULATORS = [
   {
     category: CATEGORY_LABELS.printing,
@@ -45,7 +46,7 @@ const CALCULATORS = [
     description: 'Scale prints, no wasting test strips',
     href: '/resize',
     icon: Ruler,
-    accent: 'violet',
+    accent: 'teal',
   },
   {
     category: CATEGORY_LABELS.printing,
@@ -53,7 +54,7 @@ const CALCULATORS = [
     description: 'Window openings & cut guides',
     href: '/mat',
     icon: Frame,
-    accent: 'teal',
+    accent: 'cyan',
   },
   {
     category: CATEGORY_LABELS.film,
@@ -72,14 +73,6 @@ const CALCULATORS = [
     accent: 'rose',
   },
   {
-    category: CATEGORY_LABELS.reference,
-    title: 'Film Database',
-    description: 'Browse film stocks by brand & ISO',
-    href: '/films',
-    icon: Film,
-    accent: 'cyan',
-  },
-  {
     category: CATEGORY_LABELS.camera,
     title: 'Lens Equivalency',
     description: 'Compare format lens differences',
@@ -93,7 +86,15 @@ const CALCULATORS = [
     description: 'Equivalent exposure calculator',
     href: '/exposure',
     icon: Camera,
-    accent: 'sky',
+    accent: 'teal',
+  },
+  {
+    category: CATEGORY_LABELS.reference,
+    title: 'Film Database',
+    description: 'Browse film stocks by brand & ISO',
+    href: '/films',
+    icon: Film,
+    accent: 'cyan',
   },
 ] as const;
 
@@ -110,28 +111,6 @@ const COMING_SOON = [
   },
 ];
 
-const CALCULATOR_CATEGORIES = [
-  CATEGORY_LABELS.printing,
-  CATEGORY_LABELS.film,
-  CATEGORY_LABELS.camera,
-  CATEGORY_LABELS.reference,
-] as const;
-
-// Group calculators by category in a single pass, preserving the order above.
-type CalculatorCard = Omit<(typeof CALCULATORS)[number], 'category'>;
-const CALCULATORS_BY_CATEGORY = (() => {
-  const groups = new Map<string, CalculatorCard[]>(
-    CALCULATOR_CATEGORIES.map((label) => [label, []])
-  );
-  for (const { category, ...tool } of CALCULATORS) {
-    groups.get(category)?.push(tool);
-  }
-  return CALCULATOR_CATEGORIES.map((label) => ({
-    label,
-    tools: groups.get(label) ?? [],
-  }));
-})();
-
 export function HomePage() {
   const { data: stats, isPending: isStatsLoading } = useStats();
   // Compute the year client-only to avoid a render-time new Date() value.
@@ -141,12 +120,18 @@ export function HomePage() {
     setCurrentYear(new Date().getFullYear());
   }, []);
 
+  const heroStats = [
+    { value: stats?.combinations, label: 'development recipes' },
+    { value: stats?.films, label: 'film stocks' },
+    { value: stats?.developers, label: 'developers' },
+  ];
+
   return (
     <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8 pb-24 space-y-10">
-      {/* Hero Section */}
-      <div className="grid grid-cols-1 md:grid-cols-12 gap-4 lg:gap-6">
-        {/* Hero copy + CTAs - unboxed */}
-        <div className="md:col-span-8 flex flex-col justify-between gap-6">
+      {/* Hero: one grain-textured panel - copy + CTAs on the left, live
+          border preview on the right */}
+      <div className="hero-grain rounded-3xl border border-[color:var(--color-border-secondary)] p-6 sm:p-8 shadow-subtle grid grid-cols-1 md:grid-cols-12 gap-6 lg:gap-10 md:items-center">
+        <div className="md:col-span-7 flex flex-col gap-5">
           <div>
             <Greeting />
             <p className="text-lg sm:text-xl mt-2 text-[color:var(--color-text-secondary)]">
@@ -157,6 +142,21 @@ export function HomePage() {
               exposure tools. Free and open source.
             </p>
           </div>
+          <p className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-[color:var(--color-text-tertiary)]">
+            {heroStats.map(({ value, label }, index) => (
+              <span key={label} className="inline-flex items-center gap-x-2">
+                {index > 0 ? <span aria-hidden>·</span> : null}
+                <span>
+                  <span className="font-bold text-[color:var(--color-text-secondary)]">
+                    {isStatsLoading || value === undefined
+                      ? '-'
+                      : value.toLocaleString()}
+                  </span>{' '}
+                  {label}
+                </span>
+              </span>
+            ))}
+          </p>
           <div className="flex flex-wrap gap-2">
             <Link
               to="/border"
@@ -174,39 +174,8 @@ export function HomePage() {
             </Link>
           </div>
         </div>
-        {/* Quick Stats / Actions */}
-        <div className="md:col-span-4 grid grid-cols-2 gap-3">
-          <StatCard
-            as={Link}
-            to="/development"
-            label="Development Recipes"
-            value={stats ? stats.combinations.toLocaleString() : '-'}
-            icon={FlaskConical}
-            iconColorKey="emerald"
-            variant="horizontal"
-            className="col-span-2"
-            loading={isStatsLoading}
-          />
-
-          <StatCard
-            as={Link}
-            to="/films"
-            label="Film Stocks"
-            value={stats ? stats.films.toLocaleString() : '-'}
-            icon={Film}
-            iconColorKey="rose"
-            loading={isStatsLoading}
-          />
-
-          <StatCard
-            as={Link}
-            to="/development"
-            label="Developers"
-            value={stats ? stats.developers.toLocaleString() : '-'}
-            icon={TestTubes}
-            iconColorKey="indigo"
-            loading={isStatsLoading}
-          />
+        <div className="hidden md:block md:col-span-5">
+          <HomeHeroPreview />
         </div>
       </div>
 
@@ -223,69 +192,50 @@ export function HomePage() {
           />
         </div>
 
-        <div className="space-y-6">
-          {CALCULATORS_BY_CATEGORY.map(({ label, tools }) => (
-            <div key={label}>
-              <h3 className="text-sm font-medium text-[color:var(--color-text-tertiary)] uppercase tracking-wider mb-3">
-                {label}
-              </h3>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                {tools.map((tool) => (
-                  <ToolCard
-                    key={tool.title}
-                    {...tool}
-                    as={Link}
-                    href={tool.href}
-                  />
-                ))}
-              </div>
-            </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 auto-rows-fr">
+          {CALCULATORS.map((tool, index) => (
+            <ToolCard
+              key={tool.title}
+              {...tool}
+              as={Link}
+              href={tool.href}
+              className={
+                index === CALCULATORS.length - 1
+                  ? 'sm:col-span-2 lg:col-span-1'
+                  : undefined
+              }
+            />
           ))}
         </div>
       </div>
 
-      {/* Coming Soon Section */}
-      <div>
-        <div
-          className="flex items-center justify-between mb-6"
-          data-coming-soon-section
-        >
-          <h2 className="text-xl font-semibold text-[color:var(--color-text-primary)] flex items-center gap-2">
-            <Construction
-              className="size-5 text-[color:var(--color-text-tertiary)]"
+      {/* Coming Soon - quiet strip below the grid */}
+      <div
+        className="rounded-2xl border border-dashed px-4 py-3 flex flex-col sm:flex-row sm:items-center gap-x-8 gap-y-2"
+        style={{
+          borderColor: 'var(--color-border-secondary)',
+          backgroundColor: 'var(--color-surface-muted)',
+        }}
+        data-coming-soon-section
+      >
+        <span className="flex shrink-0 items-center gap-2 text-xs font-bold uppercase tracking-wider text-[color:var(--color-text-tertiary)]">
+          <Construction className="size-4" data-coming-soon />
+          Coming soon
+        </span>
+        {COMING_SOON.map((item) => (
+          <div key={item.title} className="flex items-center gap-2 min-w-0">
+            <item.icon
+              className="size-4 shrink-0 text-[color:var(--color-text-tertiary)]"
               data-coming-soon
             />
-            Coming Soon
-          </h2>
-          <div
-            className="h-px flex-1 ml-4"
-            style={{ backgroundColor: 'var(--color-border-primary)' }}
-          />
-        </div>
-
-        <div
-          className="rounded-2xl border border-dashed p-4 flex flex-col sm:flex-row sm:items-center gap-4 sm:gap-8"
-          style={{
-            borderColor: 'var(--color-border-secondary)',
-            backgroundColor: 'var(--color-surface-muted)',
-          }}
-          data-coming-soon-section
-        >
-          {COMING_SOON.map((item) => (
-            <div key={item.title} className="flex items-center gap-2 min-w-0">
-              <item.icon
-                className="size-4 shrink-0 text-[color:var(--color-text-tertiary)]"
-                data-coming-soon
-              />
-              <span className="font-medium text-[color:var(--color-text-secondary)]">
-                {item.title}
-              </span>
-              <span className="text-sm text-[color:var(--color-text-tertiary)] truncate">
-                {item.description}
-              </span>
-            </div>
-          ))}
-        </div>
+            <span className="font-medium text-[color:var(--color-text-secondary)]">
+              {item.title}
+            </span>
+            <span className="text-sm text-[color:var(--color-text-tertiary)] truncate">
+              {item.description}
+            </span>
+          </div>
+        ))}
       </div>
 
       {/* Footer Links - Minimal */}

--- a/apps/dorkroom/src/app/pages/resize-calculator/resize-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/resize-calculator/resize-calculator-page.tsx
@@ -14,7 +14,6 @@ import {
   colorMixOr,
   getRouteIcon,
   StatusAlert,
-  ToggleSwitch,
   useMeasurement,
   useMeasurementConverter,
 } from '@dorkroom/ui';
@@ -38,6 +37,11 @@ interface ModeToggleProps {
   onModeChange: (value: boolean) => void;
 }
 
+const MODE_OPTIONS = [
+  { label: 'Print Size', isEnlargerHeight: false },
+  { label: 'Enlarger Height', isEnlargerHeight: true },
+] as const;
+
 function ModeToggle({ isEnlargerHeightMode, onModeChange }: ModeToggleProps) {
   return (
     <div
@@ -53,52 +57,42 @@ function ModeToggle({ isEnlargerHeightMode, onModeChange }: ModeToggleProps) {
       }}
     >
       <p
-        className="text-sm font-semibold uppercase tracking-[0.3em]"
+        className="text-xs font-semibold uppercase tracking-[0.2em]"
         style={{ color: 'var(--color-text-muted)' }}
       >
         Method
       </p>
-      <div
-        className="flex items-center justify-center gap-2 rounded-full px-3 py-2 sm:gap-3 sm:px-4"
+      <fieldset
+        className="grid grid-cols-2 gap-1 rounded-full border p-1"
         style={{
           borderColor: 'var(--color-border-muted)',
-          backgroundColor: colorMixOr(
-            'var(--color-surface)',
-            20,
-            'transparent',
-            'var(--color-surface)'
-          ),
-          border: '1px solid',
+          backgroundColor: 'rgb(var(--color-background-rgb) / 0.3)',
         }}
       >
-        <span
-          className="text-[10px] uppercase tracking-[0.15em] transition-colors sm:text-xs sm:tracking-[0.3em]"
-          style={{
-            color: isEnlargerHeightMode
-              ? 'var(--color-text-muted)'
-              : 'var(--color-text-primary)',
-            fontWeight: isEnlargerHeightMode ? 500 : 600,
-          }}
-        >
-          Print Size
-        </span>
-        <ToggleSwitch
-          label="Toggle between Print Size and Enlarger Height mode"
-          value={isEnlargerHeightMode}
-          onValueChange={onModeChange}
-        />
-        <span
-          className="text-[10px] uppercase tracking-[0.15em] transition-colors sm:text-xs sm:tracking-[0.3em]"
-          style={{
-            color: isEnlargerHeightMode
-              ? 'var(--color-text-primary)'
-              : 'var(--color-text-muted)',
-            fontWeight: isEnlargerHeightMode ? 600 : 500,
-          }}
-        >
-          Enlarger Height
-        </span>
-      </div>
+        <legend className="sr-only">Calculation method</legend>
+        {MODE_OPTIONS.map((option) => {
+          const active = option.isEnlargerHeight === isEnlargerHeightMode;
+          return (
+            <button
+              key={option.label}
+              type="button"
+              aria-pressed={active}
+              onClick={() => onModeChange(option.isEnlargerHeight)}
+              className="rounded-full px-4 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border-primary)]"
+              style={
+                active
+                  ? {
+                      backgroundColor: 'var(--color-text-primary)',
+                      color: 'var(--color-background)',
+                    }
+                  : { color: 'var(--color-text-muted)' }
+              }
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </fieldset>
     </div>
   );
 }

--- a/apps/dorkroom/src/app/pages/resize-calculator/resize-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/resize-calculator/resize-calculator-page.tsx
@@ -72,19 +72,29 @@ function ModeToggle({ isEnlargerHeightMode, onModeChange }: ModeToggleProps) {
         }}
       >
         <span
-          className="text-[10px] font-medium uppercase tracking-[0.15em] sm:text-xs sm:tracking-[0.3em]"
-          style={{ color: 'var(--color-text-tertiary)' }}
+          className="text-[10px] uppercase tracking-[0.15em] transition-colors sm:text-xs sm:tracking-[0.3em]"
+          style={{
+            color: isEnlargerHeightMode
+              ? 'var(--color-text-muted)'
+              : 'var(--color-text-primary)',
+            fontWeight: isEnlargerHeightMode ? 500 : 600,
+          }}
         >
           Print Size
         </span>
         <ToggleSwitch
-          label=""
+          label="Toggle between Print Size and Enlarger Height mode"
           value={isEnlargerHeightMode}
           onValueChange={onModeChange}
         />
         <span
-          className="text-[10px] font-medium uppercase tracking-[0.15em] sm:text-xs sm:tracking-[0.3em]"
-          style={{ color: 'var(--color-text-tertiary)' }}
+          className="text-[10px] uppercase tracking-[0.15em] transition-colors sm:text-xs sm:tracking-[0.3em]"
+          style={{
+            color: isEnlargerHeightMode
+              ? 'var(--color-text-primary)'
+              : 'var(--color-text-muted)',
+            fontWeight: isEnlargerHeightMode ? 600 : 500,
+          }}
         >
           Enlarger Height
         </span>

--- a/apps/dorkroom/src/styles/components.css
+++ b/apps/dorkroom/src/styles/components.css
@@ -435,6 +435,69 @@
     background-color: var(--color-surface-muted);
   }
 
+  /* Home hero panel: subtle red movie-grain texture over the surface color
+     (SVG fractal noise tinted red, tiled). The grain jumps position in hard
+     steps like projected film; the global animation kill-switch covers
+     darkroom/high-contrast and the user's animations toggle. High-contrast
+     also drops the texture entirely. */
+  .hero-grain {
+    background-color: var(--color-surface);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 0.07 0 0 0 0 0.07 0 0 0 0.14 0'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23g)'/%3E%3C/svg%3E");
+    background-size: 320px 320px;
+  }
+
+  @keyframes hero-grain-flicker {
+    0% {
+      background-position: 0 0;
+    }
+    10% {
+      background-position: -32px 24px;
+    }
+    20% {
+      background-position: 48px -16px;
+    }
+    30% {
+      background-position: -24px -48px;
+    }
+    40% {
+      background-position: 56px 40px;
+    }
+    50% {
+      background-position: -48px 8px;
+    }
+    60% {
+      background-position: 16px 64px;
+    }
+    70% {
+      background-position: -64px -32px;
+    }
+    80% {
+      background-position: 40px -56px;
+    }
+    90% {
+      background-position: -8px 48px;
+    }
+    100% {
+      background-position: 0 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .hero-grain {
+      animation: hero-grain-flicker 0.9s step-end infinite;
+    }
+  }
+
+  /* On light surfaces the same tint reads as a pink wash; use a darker red
+     at lower alpha so it stays a faint speckle. */
+  [data-theme="light"] .hero-grain {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='g'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.55 0 0 0 0 0.05 0 0 0 0 0.05 0 0 0 0.08 0'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23g)'/%3E%3C/svg%3E");
+  }
+
+  [data-theme="high-contrast"] .hero-grain {
+    background-image: none;
+  }
+
   /* Hero Button Styles */
   .hero-button-success {
     background-color: var(--color-button-success);

--- a/apps/dorkroom/src/styles/theme.css
+++ b/apps/dorkroom/src/styles/theme.css
@@ -201,9 +201,6 @@
   --color-tool-card-icon-bg: #000000;
   --color-tool-card-icon-ring: #ff0000;
   --color-tool-card-icon-hover: #ff0000;
-  --color-tool-card-category: #ff0000;
-  --color-tool-card-category-hover: #ff0000;
-  --color-tool-card-title: #ff0000;
   --color-tool-card-description: #a90000;
   --color-tool-card-description-hover: #ff0000;
   --color-tool-card-arrow: #ff0000;
@@ -361,9 +358,6 @@
   --color-tool-card-icon-bg: rgba(39, 39, 42, 0.8);
   --color-tool-card-icon-ring: rgba(255, 255, 255, 0.12);
   --color-tool-card-icon-hover: rgba(255, 255, 255, 0.18);
-  --color-tool-card-category: #71717a;
-  --color-tool-card-category-hover: #d4d4d8;
-  --color-tool-card-title: #ffffff;
   --color-tool-card-description: #a1a1aa;
   --color-tool-card-description-hover: #d4d4d8;
   --color-tool-card-arrow: #52525b;
@@ -595,9 +589,6 @@
   --color-tool-card-icon-bg: rgba(9, 9, 11, 0.06);
   --color-tool-card-icon-ring: rgba(9, 9, 11, 0.12);
   --color-tool-card-icon-hover: rgba(9, 9, 11, 0.1);
-  --color-tool-card-category: #71717a;
-  --color-tool-card-category-hover: #52525b;
-  --color-tool-card-title: #09090b;
   --color-tool-card-description: #52525b;
   --color-tool-card-description-hover: #09090b;
   --color-tool-card-arrow: #a1a1aa;
@@ -814,9 +805,6 @@
   --color-tool-card-icon-bg: #ffffff;
   --color-tool-card-icon-ring: #000000;
   --color-tool-card-icon-hover: #ffffff;
-  --color-tool-card-category: #000000;
-  --color-tool-card-category-hover: #000000;
-  --color-tool-card-title: #000000;
   --color-tool-card-description: #000000;
   --color-tool-card-description-hover: #000000;
   --color-tool-card-arrow: #000000;

--- a/packages/ui/src/components/calculator/calculator-layout.tsx
+++ b/packages/ui/src/components/calculator/calculator-layout.tsx
@@ -60,9 +60,11 @@ export function CalculatorLayout({
 
       {results ? (
         <>
-          <div className="mt-6 grid gap-4 md:mt-8 md:gap-5 md:grid-cols-2">
+          <div className="mt-6 grid gap-4 md:mt-8 md:gap-5 md:grid-cols-2 md:items-start">
             <div className="space-y-4">{children}</div>
-            <div className="space-y-4">{results}</div>
+            <div className="space-y-4 md:sticky md:top-20 md:self-start">
+              {results}
+            </div>
           </div>
           {sidebar && <div className="mt-4 space-y-4 md:mt-5">{sidebar}</div>}
         </>

--- a/packages/ui/src/components/calculator/calculator-page-header.tsx
+++ b/packages/ui/src/components/calculator/calculator-page-header.tsx
@@ -56,7 +56,7 @@ export function CalculatorPageHeader({
       >
         {Icon && (
           <div
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border"
+            className="flex size-11 shrink-0 items-center justify-center rounded-xl border"
             style={{
               background: accentTone
                 ? `var(--accent-${accentTone}-gradient)`
@@ -72,7 +72,7 @@ export function CalculatorPageHeader({
                 : 'var(--color-text-primary)',
             }}
           >
-            <Icon className="h-5 w-5" />
+            <Icon className="size-5" />
           </div>
         )}
         <div className="flex max-w-2xl flex-col gap-1">

--- a/packages/ui/src/components/development-recipes/actions-bar.tsx
+++ b/packages/ui/src/components/development-recipes/actions-bar.tsx
@@ -15,6 +15,8 @@ interface DevelopmentActionsBarProps {
   onOpenCustomRecipeModal: () => void;
   onRefresh: () => void;
   isRefreshing?: boolean;
+  /** Whether the initial data load is still in flight; suppresses the "0 pairings" subtitle. */
+  isLoading?: boolean;
   showImportButton?: boolean;
   isMobile?: boolean;
 }
@@ -27,6 +29,7 @@ export function DevelopmentActionsBar({
   onOpenCustomRecipeModal,
   onRefresh,
   isRefreshing,
+  isLoading = false,
   showImportButton = true,
   isMobile = false,
 }: DevelopmentActionsBarProps) {
@@ -64,7 +67,9 @@ export function DevelopmentActionsBar({
             className="text-sm"
             style={{ color: 'var(--color-text-tertiary)' }}
           >
-            {totalResults.toLocaleString()} film and developer pairings.
+            {isLoading
+              ? 'Loading recipes…'
+              : `${totalResults.toLocaleString()} film and developer pairings.`}
           </p>
         </div>
       </div>

--- a/packages/ui/src/components/development-recipes/actions-bar.tsx
+++ b/packages/ui/src/components/development-recipes/actions-bar.tsx
@@ -21,6 +21,7 @@ interface DevelopmentActionsBarProps {
   isMobile?: boolean;
 }
 
+// eslint-disable-next-line react-doctor/no-many-boolean-props -- isRefreshing / isLoading / showImportButton / isMobile are independent display/state flags on a toolbar, not a variant axis; compound-component split would add more indirection than value here
 export function DevelopmentActionsBar({
   totalResults,
   viewMode,
@@ -44,7 +45,7 @@ export function DevelopmentActionsBar({
       <div className="flex items-center gap-4">
         {RecipeIcon && (
           <div
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border"
+            className="flex size-11 shrink-0 items-center justify-center rounded-xl border"
             style={{
               background: 'var(--accent-rose-gradient)',
               borderColor:
@@ -53,7 +54,7 @@ export function DevelopmentActionsBar({
               color: 'var(--color-on-accent)',
             }}
           >
-            <RecipeIcon className="h-5 w-5" />
+            <RecipeIcon className="size-5" />
           </div>
         )}
         <div>

--- a/packages/ui/src/components/development-recipes/results-cards-virtualized.tsx
+++ b/packages/ui/src/components/development-recipes/results-cards-virtualized.tsx
@@ -47,10 +47,14 @@ import {
 const BREAKPOINT_XL = 1280;
 const BREAKPOINT_LG = 1024;
 const BREAKPOINT_SM = 640;
+/** Below this width the mobile grid collapses to 1 column (plan 009 item 5). */
+const BREAKPOINT_MOBILE_2COL = 480;
 
 /**
- * Hook to calculate responsive column count based on container width
- * Matches Tailwind breakpoints: sm:640px, lg:1024px, xl:1280px
+ * Hook to calculate responsive column count based on container width.
+ *
+ * Desktop: matches Tailwind breakpoints sm:640px, lg:1024px, xl:1280px.
+ * Mobile: 1 column below 480px, 2 columns at 480px and above.
  *
  * Uses debounced ResizeObserver to prevent browser lockups during rapid resizing.
  */
@@ -58,15 +62,17 @@ function useResponsiveColumnCount(
   containerRef: React.RefObject<HTMLDivElement | null>,
   isMobile: boolean
 ): number {
-  const [observedColumnCount, setColumnCount] = useState(3);
+  const [observedColumnCount, setColumnCount] = useState(isMobile ? 2 : 3);
 
   useEffect(() => {
-    if (isMobile) return;
-
     const container = containerRef.current;
     if (!container) return;
 
     const calculateColumns = (width: number): number => {
+      if (isMobile) {
+        // 1-col below 480px, 2-col at 480px+ (plan 009 item 5)
+        return width >= BREAKPOINT_MOBILE_2COL ? 2 : 1;
+      }
       // Match Tailwind breakpoints for grid-cols
       if (width >= BREAKPOINT_XL) return 4; // xl
       if (width >= BREAKPOINT_LG) return 3; // lg
@@ -122,7 +128,7 @@ function useResponsiveColumnCount(
     };
   }, [containerRef, isMobile]);
 
-  return isMobile ? 2 : observedColumnCount;
+  return observedColumnCount;
 }
 
 interface DevelopmentResultsCardsVirtualizedProps {

--- a/packages/ui/src/components/development-recipes/results-cards-virtualized.tsx
+++ b/packages/ui/src/components/development-recipes/results-cards-virtualized.tsx
@@ -369,8 +369,8 @@ function RecipeCard({
             {film ? `${film.brand} ${film.name}` : 'Unknown film'}
           </span>
           <div
-            className="text-xs"
-            style={{ color: 'var(--color-text-tertiary)' }}
+            className="text-sm font-medium"
+            style={{ color: 'var(--color-text-secondary)' }}
           >
             {developer
               ? `${developer.manufacturer} ${developer.name}`

--- a/packages/ui/src/components/films/film-image.tsx
+++ b/packages/ui/src/components/films/film-image.tsx
@@ -90,7 +90,7 @@ export const FilmImage: FC<FilmImageProps> = ({
   return (
     <div
       className={cn(
-        'aspect-square flex items-center justify-center rounded-lg overflow-hidden flex-shrink-0',
+        'relative aspect-square flex items-center justify-center rounded-lg overflow-hidden flex-shrink-0',
         className
       )}
       style={{

--- a/packages/ui/src/components/marketing/tool-card.tsx
+++ b/packages/ui/src/components/marketing/tool-card.tsx
@@ -120,21 +120,21 @@ export const ToolCard = memo(function ToolCard({
         <div className="flex-1 min-w-0">
           {category ? (
             <div className="flex items-center justify-between mb-1">
-              <p className="text-[10px] font-bold uppercase tracking-wider text-[color:var(--color-tool-card-category)] group-hover:text-[color:var(--color-tool-card-category-hover)]">
+              <p className="text-xs font-bold uppercase tracking-wider text-[color:var(--color-text-tertiary)] group-hover:text-[color:var(--color-text-secondary)]">
                 {category}
               </p>
-              <ArrowRight className="size-3.5 text-[color:var(--color-tool-card-arrow)] opacity-0 -translate-x-2 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
+              <ArrowRight className="size-3.5 shrink-0 text-[color:var(--color-tool-card-arrow)] opacity-0 -translate-x-2 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
             </div>
           ) : null}
-          <div className="flex items-center justify-between">
-            <h3 className="font-semibold text-[color:var(--color-tool-card-title)] truncate pr-4">
+          <div className="flex items-start justify-between gap-2">
+            <h3 className="font-semibold text-[color:var(--color-text-primary)]">
               {title}
             </h3>
             {category ? null : (
-              <ArrowRight className="size-3.5 shrink-0 text-[color:var(--color-tool-card-arrow)] opacity-0 -translate-x-2 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
+              <ArrowRight className="mt-1 size-3.5 shrink-0 text-[color:var(--color-tool-card-arrow)] opacity-0 -translate-x-2 transition-all group-hover:opacity-100 group-hover:translate-x-0" />
             )}
           </div>
-          <p className="text-sm text-[color:var(--color-tool-card-description)] line-clamp-1 group-hover:text-[color:var(--color-tool-card-description-hover)]">
+          <p className="text-sm text-[color:var(--color-tool-card-description)] group-hover:text-[color:var(--color-tool-card-description-hover)]">
             {description}
           </p>
         </div>


### PR DESCRIPTION
Executes plan 008 (design review round 2). Stacked on #103. Executed on Fable with live maintainer art direction.

## What

- **One continuous 3×3 tool grid** (shape (a) from the plan): zero dead cells at lg (was: per-category rows leaving a third of the grid empty). Category is expressed per-card via eyebrow + page-tone icon tile; at sm the 9th card spans both columns; single column on mobile. `truncate`/`line-clamp-1` removed from ToolCard — "Film Development Recipes" renders in full at every width ≥320px, rows equalized with `auto-rows-fr`.
- **Hero is one composition**: name, tagline, inline stat strip (1,020 recipes · 165 films · 23 developers), the two CTAs, and a **live read-only border preview** on the right (links to /border) — rung 1 of the plan's visual ladder. It's a thin fluid component driven by real `@dorkroom/logic` geometry (the existing AnimatedPreview is hard-coded to 400×300 and reads window.innerWidth, so it couldn't sit in the hero column). Maintainer-requested touches during execution: subtle red film-grain texture (SVG fractalNoise, stepped like projected film) and a slow 35mm → 6×6 → 4×5 format cycle with synced blade readouts.
- **Motion contract respected**: all animation honors `data-animations-disabled` (darkroom/high-contrast/user toggle — verified byte-identical frames in darkroom) and `prefers-reduced-motion`; high-contrast drops the texture.
- **Home-card accents reconciled with page tones** (the #103 follow-up): resize→teal, mat→cyan, exposure→teal; rest already matched.
- Dead var cleanup: `--color-tool-card-title`/`-category(-hover)` deleted (identical to text tokens in all 4 themes); remaining tool-card vars kept (genuinely distinct per-theme values).
- "Recently used" chips cut per the plan's explicit scope valve.

## Verification

- Screenshots at 1440/1024/768/390 × all four themes (executor run + advisor re-check of dark/light).
- `node scripts/audit-contrast.mjs`: **0 findings**, all 14 page/theme combos.
- `bun run test`: 16/16 tasks, 1557 tests. React Doctor: 100/100/100. Format clean.
- Home route chunk +9.5KB total — under the plan's 15KB STOP cap; no data fetch before first paint.