### PR TITLE
chore(design-sync): import @dorkroom/ui to Claude Design

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,68 @@
+# design-sync notes — @dorkroom/ui
+
+Repo-specific gotchas for syncing `@dorkroom/ui` to claude.ai/design. Read before any re-sync.
+
+## Shape & entry
+
+- **Package shape, no Storybook.** Component list comes from the `.d.ts` tree.
+- `@dorkroom/ui` ships **no JS dist** — `package.json` `main` points at `src/index.ts`, and the build (`tsgo`) emits only `.d.ts`. So the bundle `--entry` is the **TS source**: `packages/ui/src/index.ts` (esbuild compiles it). The `.d.ts` tree for prop extraction comes from `packages/ui/dist/*.d.ts` (built by `tsgo`).
+- Workspace deps `@dorkroom/api` and `@dorkroom/logic` build to real JS dist (`packages/{api,logic}/dist/index.js`) — they must be built before the converter runs so esbuild can resolve them. `bun run build` (turbo) builds the whole graph.
+- `--node-modules` = **repo-root** `node_modules` (bun hoists; `react`/`react-dom` live there, not under `packages/ui`).
+
+## CSS (Tailwind 4, the tricky part)
+
+- The UI package has **no compiled CSS** — components use Tailwind v4 utility classes + theme tokens defined in the app's `@theme`/`[data-theme]` blocks under `apps/dorkroom/src/styles/`.
+- The converter appends `cfg.cssEntry` **verbatim** (no Tailwind run), so we pre-compile it: `.design-sync/build-ds-css.mjs` runs `@tailwindcss/postcss` over `apps/dorkroom/src/styles.css` (which `@source`s the whole monorepo → includes every utility every UI component uses) → `packages/ui/dist/ds.css`.
+- `cfg.cssEntry` must resolve **inside** `packages/ui` (security bound), hence the `dist/ds.css` target (`dist/` is gitignored, regenerated).
+- Default (no `[data-theme]` on the iframe root) renders the **dark** theme (the `@theme` defaults are dark). That's the app's default theme, so previews look right out of the box.
+- Re-sync must regenerate this CSS — it's the second half of `cfg.buildCmd`.
+
+## Providers & dark theme (`.design-sync/preview-provider.mjs`)
+
+- `cfg.provider.component` = `DesignSyncPreviewRoot`, a small module (`.design-sync/preview-provider.mjs`) wired via `cfg.extraEntries`. It wraps the full context chain (all children-only): `ThemeProvider › MeasurementProvider › TemperatureProvider › VolumeProvider › ToastProvider`. Measurement/Temperature/Volume come from `createUnitContext` with sane defaults — no required props.
+- **It forces the brand DARK theme** (the app's `@theme` default; user-chosen): seeds `localStorage['dorkroom-theme']='dark'` before `ThemeProvider` mounts, and **paints the dark canvas** by setting `document.body.style.background` to `var(--color-background)`. Needed because the converter's preview template hardcodes `body{background:#fff}` (unlayered) which beats base.css's layered dark background — without the override, dark-theme components render light-on-white.
+- `extraEntries` are merged into the **same** esbuild graph as the package, so the provider's React context is shared with the components (no duplicate-context breakage).
+- To change the default card theme later, edit the seeded value in `preview-provider.mjs` (`'dark'` → `'light'`/`'darkroom'`/`'high-contrast'`).
+
+## Scope
+
+- Synced the main entry (`exports['.']`) components. The `./forms` subpath components are **not** included in this run — add them later via a separate entry if desired.
+
+## Re-sync risks (watch-list)
+
+- **`packages/ui/dist/ds.css` is generated, gitignored, and required.** A re-sync that skips `cfg.buildCmd` (or runs only `tsgo`) leaves it stale/missing → unstyled previews. Always run `build-ds-css.mjs`.
+- **Hashed app CSS is NOT the source** — we compile our own `ds.css`; don't repoint `cssEntry` at `apps/dorkroom/dist/assets/index-*.css` (hash churns every build).
+- The bundle entry is TS source, not a JS dist — if the package ever gains a real JS build, prefer that entry and revisit.
+- Tailwind/PostCSS toolchain version drift can change the compiled CSS; output is deterministic per toolchain version.
+
+## Known render warns (triaged — re-syncs: a warn NOT listed here is new)
+
+- **`[TOKENS_MISSING]`** for: `--border-color`, `--border-color-focused`, `--color-text-primary-rgb`, `--row-bg-hover`, `--card-bg-hover`, `--card-border-hover`, `--del-bg-hover`, `--del-color-hover`. These are set at **runtime** (inline style / JS) by the components that use them — expected absent from the shipped stylesheet. `--color-text-primary-rgb` is defined nowhere in source either (likely a latent app-side gap); non-blocking, renders pass.
+- **`[FONT_MISSING]`** for `"Montserrat Sans"` and `"Fraunces"` (NOT the `Variable` families). These are **fallback aliases** in the font-family stacks, never separate font files. The real brand families `Montserrat Variable` + `Fraunces Variable` ship via `cfg.extraFonts`. Safe to ignore.
+- Small/low-content default previews (NumberInput, Skeleton*, ThemeToggle, Tooltip, the DetailPanel icon buttons, CollapsibleSection/ResultRow/StatCard/ToolCard) may flag `[RENDER_BLANK]`/`[RENDER_THIN]` until their previews are authored — now all authored.
+- **`[RENDER_THIN]` (maxHeight 0px) on `Drawer`, `DrawerBody`, `DrawerContent`** — BENIGN. These render via `createPortal` (fixed bottom sheet); the portal content renders visibly (confirmed by screenshot — a real "Recipe details" drawer) but doesn't contribute height to `#root`, so the measurement reads 0. Do not chase.
+- **`[GRID_OVERFLOW]` "escape" on `ShareModal`, `SaveBeforeShareModal`** — BENIGN. These are non-portal `fixed inset-0` + `min-h-screen` overlays; their previews wrap each cell in a `transform: translateZ(0)` containing block (height 640, `overflow:hidden`) so the overlay is trapped and renders in-card (all variants visible). The detector still heuristically flags fixed/min-h-screen, but the frame contains it — confirmed by screenshot.
+
+## cardMode overrides (`cfg.overrides`) — why each exists
+
+Modals/drawers that escape the grid cell (fixed/portal), and compositions wider than a grid cell, get a `cardMode` override:
+- **`single`** (fixed/portal escape, capture full viewport): `ConfirmModal`, `Modal`, `ResponsiveModal`, `Drawer`, `DrawerBody`, `DrawerContent`, `Toast`.
+- **`column`** (one story per full-width row): `DetailPanel`, `DetailPanelCloseButton`, `DetailPanelExpandButton`, `ShareButton`, `ToolCard`, `StatCard`, `SkeletonCard`, `SkeletonTableRow`, plus `ShareModal`/`SaveBeforeShareModal` (each cell is the transform-framed modal).
+- `ErrorBoundary` has a preview override (its `Fallback` cell intentionally throws).
+
+## Authoring playbook (reusable preview idioms for re-syncs / new components)
+
+- **No generic `Button` is exported** from `@dorkroom/ui` — compose footer actions as native `<button>` styled with `var(--color-primary)` / `var(--color-surface-muted)` / `var(--color-border-secondary)`.
+- **`fixed`-position, auto-dismissing components (`Toast`)**: wrap in `position: relative` and pass a very large `duration` (e.g. `600000`) so they stay on-screen and fully slid-in for the static capture.
+- **Non-portal `fixed inset-0` modals (`ShareModal`, `SaveBeforeShareModal`)**: wrap each cell in a `transform: translateZ(0)` + `overflow:hidden` frame (≈640px tall) so the overlay is contained and captured. Portal modals (`Modal`/`ConfirmModal`) don't need this — use `cardMode: single`.
+- **Hover-only components with no controlled `open` (`Tooltip`)**: only the trigger can render statically; compose a faithful trigger and note the limitation.
+- **`h-full` drawer/panel components (`MobileSidebar`)**: wrap in a fixed-height box (e.g. `300×560, overflow:hidden`) or they collapse to zero height.
+- **`SkeletonTableRow` returns a bare `<tr>`** — wrap in `<table><tbody>…</tbody></table>`.
+- **Context-only toggles take NO props** (`VolumeUnitToggle`, `MeasurementUnitToggle`) — single canonical cell each; the global provider supplies the context.
+- **Threshold components** only render when a value differs from default: `PushPullAlert` (`pushPull !== 0`), `TemperatureAlert` (temp ≠ 68°F/20°C). Pass off-default values.
+- **`FilterPanel*` family**: compose Header/Section/ClearButton **inside `FilterPanelContainer`** (it IS the `FilterPanelContext.Provider`) — no `cfg.provider` change needed. `FilterPanelContainer` requires `activeFilterCount` + `hasActiveFilters`.
+- **`DetailPanel`**: the desktop sidebar (`isMobile={false}`, `isOpen`, not expanded) renders inline and captures cleanly; it portals only in expanded/mobile mode. The close/expand buttons render in its header slot.
+- **Real nav data is exported from `@dorkroom/ui`**: `navItems`, `printingItems`, `filmItems`, `cameraItems`, `referenceItems`, `navigationCategories` — use these for faithful nav previews.
+- **`SensorFormat` is NOT re-exported** from `@dorkroom/logic`'s index, and previews may only import `@dorkroom/ui`/`lucide-react`/`react` — inline the format object literals (shape in `packages/logic/src/constants/lens-calculator-defaults.ts`) for `SensorSizeVisualization`.
+- **`.d.ts` with `[key: string]: unknown`** (e.g. `ErrorBoundary`) is uninformative — read the component source for the real prop shape.
+- Menu/popover open-state in nav components (`Select`, `SearchableSelect`, `NavigationDropdown`, `ThemeToggle`) is internal `useState` triggered on click/focus → static capture shows the **closed** trigger. Build the variant axis around resting-render props (variant, active path, selected value).

--- a/.design-sync/build-ds-css.mjs
+++ b/.design-sync/build-ds-css.mjs
@@ -1,0 +1,26 @@
+// design-sync: compile the app's Tailwind CSS 4 stylesheet into a single
+// fully-resolved CSS file that the converter appends to _ds_bundle.css.
+//
+// @dorkroom/ui ships NO compiled CSS — components style themselves with
+// Tailwind utility classes plus theme tokens defined in the app's
+// `@theme`/`[data-theme]` blocks. The converter's cssEntry is appended
+// VERBATIM (no Tailwind run), so it needs a pre-compiled stylesheet. The app
+// entry `apps/dorkroom/src/styles.css` `@source`s the whole monorepo, so the
+// output includes every utility every UI component uses, plus the tokens.
+//
+// cssEntry must resolve inside PKG_DIR (packages/ui), hence the dist/ target.
+// Run from the repo root: `node .design-sync/build-ds-css.mjs`.
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import postcss from 'postcss';
+import tailwind from '@tailwindcss/postcss';
+
+const repoRoot = resolve(dirname(new URL(import.meta.url).pathname), '..');
+const input = resolve(repoRoot, 'apps/dorkroom/src/styles.css');
+const output = resolve(repoRoot, 'packages/ui/dist/ds.css');
+
+const css = readFileSync(input, 'utf8');
+const result = await postcss([tailwind()]).process(css, { from: input, to: output });
+mkdirSync(dirname(output), { recursive: true });
+writeFileSync(output, result.css);
+console.error(`build-ds-css: wrote ${output} (${(result.css.length / 1024).toFixed(0)} KB)`);

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,37 @@
+{
+  "projectId": "66b5be48-c524-47a9-a36f-da0157032914",
+  "pkg": "@dorkroom/ui",
+  "shape": "package",
+  "globalName": "DorkroomUI",
+  "buildCmd": "bun run build && node .design-sync/build-ds-css.mjs",
+  "tsconfig": "tsconfig.json",
+  "cssEntry": "dist/ds.css",
+  "readmeHeader": ".design-sync/conventions.md",
+  "extraFonts": [
+    "../../node_modules/@fontsource-variable/montserrat/index.css",
+    "../../node_modules/@fontsource-variable/fraunces/index.css"
+  ],
+  "extraEntries": ["../../.design-sync/preview-provider.mjs"],
+  "provider": {
+    "component": "DesignSyncPreviewRoot"
+  },
+  "overrides": {
+    "DetailPanel": { "cardMode": "column" },
+    "DetailPanelCloseButton": { "cardMode": "column" },
+    "DetailPanelExpandButton": { "cardMode": "column" },
+    "ShareButton": { "cardMode": "column" },
+    "ToolCard": { "cardMode": "column" },
+    "SkeletonCard": { "cardMode": "column" },
+    "SkeletonTableRow": { "cardMode": "column" },
+    "StatCard": { "cardMode": "column" },
+    "ConfirmModal": { "cardMode": "single", "primaryStory": "Destructive" },
+    "Drawer": { "cardMode": "single", "primaryStory": "BottomSheet" },
+    "DrawerBody": { "cardMode": "single", "primaryStory": "ScrollableList" },
+    "DrawerContent": { "cardMode": "single", "primaryStory": "InBottomDrawer" },
+    "Modal": { "cardMode": "single", "primaryStory": "Default" },
+    "ResponsiveModal": { "cardMode": "single", "primaryStory": "Desktop" },
+    "Toast": { "cardMode": "single", "primaryStory": "Success" },
+    "ShareModal": { "cardMode": "column" },
+    "SaveBeforeShareModal": { "cardMode": "column" }
+  }
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,59 @@
+# Dorkroom UI — conventions
+
+`@dorkroom/ui` is the component library for Dorkroom, an analog-photography calculator app. It is **dark-first** (near-black surfaces, neon-green primary) built on **React 19 + Tailwind CSS 4**. Build with the real exported components and the token/utility vocabulary below — do not invent new class names or restyle from scratch.
+
+## Setup — wrap the app in the provider chain
+
+Theme tokens and several components depend on React context. Wrap the app once, outermost, in this chain (all imported from `@dorkroom/ui`, all take only `children`):
+
+```jsx
+import {
+  ThemeProvider, MeasurementProvider, TemperatureProvider, VolumeProvider, ToastProvider,
+} from '@dorkroom/ui';
+
+<ThemeProvider>
+  <MeasurementProvider><TemperatureProvider><VolumeProvider><ToastProvider>
+    {/* app */}
+  </ToastProvider></VolumeProvider></TemperatureProvider></MeasurementProvider>
+</ThemeProvider>
+```
+
+Without `ThemeProvider`, components that call `useTheme`/`useToast`/unit hooks throw. The provider sets `data-theme` on `<html>` (default resolves from system; the brand look is `data-theme="dark"`), which is what activates the token values. The page background should be `var(--color-background)`.
+
+## Styling idiom — Tailwind utilities + semantic theme-token classes
+
+Style with Tailwind utility classes. Colors come from **semantic token utilities** (not raw hex, not generic Tailwind palette) so they track the active theme. Use these real class families:
+
+| Purpose | Semantic utility classes (these exist in the shipped CSS) |
+|---|---|
+| Text | `text-primary` (main body text — white), `text-secondary`, `text-tertiary`, `text-muted` |
+| Surfaces (bg) | `bg-background` (page), `bg-surface`, `bg-surface-muted` |
+| Borders | `border-primary`, `border-secondary`, `border-muted` |
+
+**Accent colors and fonts have no plain utility class** — apply them via the CSS variables (inline `style` or Tailwind arbitrary values):
+
+- Accents: `--color-primary` (neon green), `--color-secondary`, `--color-accent`, `--color-highlight` — e.g. `style={{ color: 'var(--color-primary)' }}` or `className="text-[var(--color-primary)]"`.
+- Display/heading font is **Fraunces** via `--font-family-display`: `style={{ fontFamily: 'var(--font-family-display)' }}` or `font-[family-name:var(--font-family-display)]`. Body text is already **Montserrat Variable** (set globally on `html,body` — no class needed).
+
+Full token set: `--color-<background|surface|surface-muted|primary|secondary|accent|highlight|text-primary|text-secondary|text-tertiary|text-muted|border-primary|border-secondary|border-muted>`. Layout/spacing use ordinary Tailwind utilities (`flex`, `gap-4`, `rounded-2xl`, `px-5`, `grid`, `sm:grid-cols-2`).
+
+## Where the truth lives
+
+- **Styles**: the bound `styles.css` and its `@import` closure (compiled tokens + the semantic utilities above) — read it before styling.
+- **Per component**: each component ships `<Name>.d.ts` (the exact prop contract) and `<Name>.prompt.md` (usage + examples). Read those for any component before composing it — props are specific (e.g. `ToolCard` needs `icon` (a lucide-react icon), `accent`, `title`, `description`, `href`).
+
+## One idiomatic example
+
+```jsx
+import { Crop } from 'lucide-react';
+import { ToolCard, StatusAlert } from '@dorkroom/ui';
+
+<div className="bg-background text-primary p-6 grid gap-4">
+  <h1 className="text-2xl" style={{ fontFamily: 'var(--font-family-display)' }}>Darkroom tools</h1>
+  <div className="grid gap-4 sm:grid-cols-2">
+    <ToolCard category="Printing" title="Border Calculator"
+      description="Print borders & trim guides" href="/border" icon={Crop} accent="indigo" />
+  </div>
+  <StatusAlert action="warning" message="Aspect ratios don't match — adjust to taste." />
+</div>
+```

--- a/.design-sync/preview-provider.mjs
+++ b/.design-sync/preview-provider.mjs
@@ -1,0 +1,68 @@
+// design-sync preview provider — wraps every preview card in the full
+// @dorkroom/ui context-provider chain AND forces the brand DARK theme.
+//
+// Why seed the theme: ThemeProvider reads `localStorage['dorkroom-theme']` on
+// init and otherwise resolves 'system', which in headless Chromium reports
+// light. Dorkroom is dark-first (the app's `@theme` defaults are the
+// near-black/neon-green look), so we seed 'dark' BEFORE the provider mounts
+// and set the attribute for the very first paint.
+//
+// Wired via cfg.provider.component = "DesignSyncPreviewRoot" + cfg.extraEntries
+// (this file). extraEntries are merged into the SAME esbuild graph as the
+// package, so this ThemeProvider shares the components' React context.
+//
+// Plain JS + React.createElement (no JSX) so no tsconfig/jsx-runtime config is
+// needed for a file outside the package's tsconfig scope.
+import * as React from 'react';
+import {
+  MeasurementProvider,
+  TemperatureProvider,
+  ThemeProvider,
+  ToastProvider,
+  VolumeProvider,
+} from '@dorkroom/ui';
+
+if (typeof localStorage !== 'undefined') {
+  localStorage.setItem('dorkroom-theme', 'dark');
+}
+
+// Paint the brand-dark canvas. The preview template hardcodes
+// `body{background:#fff}` (an unlayered <style> rule); base.css's dark
+// `background: var(--color-background)` lives in `@layer base` and loses to
+// it. Setting the body's *element* inline style beats the template rule, so
+// dark-theme components (light text/elements) render on their intended dark
+// page instead of light-on-white.
+function paintDarkCanvas() {
+  if (typeof document === 'undefined') return;
+  document.documentElement.setAttribute('data-theme', 'dark');
+  const apply = () => {
+    if (!document.body) return;
+    document.body.style.background = 'var(--color-background, #09090b)';
+    document.body.style.color = 'var(--color-text-primary, #ffffff)';
+  };
+  if (document.body) apply();
+  else if (typeof document.addEventListener === 'function') {
+    document.addEventListener('DOMContentLoaded', apply);
+  }
+}
+paintDarkCanvas();
+
+export function DesignSyncPreviewRoot({ children }) {
+  return React.createElement(
+    ThemeProvider,
+    null,
+    React.createElement(
+      MeasurementProvider,
+      null,
+      React.createElement(
+        TemperatureProvider,
+        null,
+        React.createElement(
+          VolumeProvider,
+          null,
+          React.createElement(ToastProvider, null, children),
+        ),
+      ),
+    ),
+  );
+}

--- a/.design-sync/previews/CollapsibleSection.tsx
+++ b/.design-sync/previews/CollapsibleSection.tsx
@@ -1,0 +1,46 @@
+import { CollapsibleSection, ResultRow } from '@dorkroom/ui';
+import { useState } from 'react';
+
+// Expanded section revealing a development recipe summary.
+export const Expanded = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div style={{ maxWidth: 360 }}>
+      <CollapsibleSection
+        title="Development"
+        subtitle="Kodak HC-110 · Dilution B"
+        isExpanded={open}
+        onToggle={() => setOpen((v) => !v)}
+      >
+        <div
+          className="rounded-lg p-3"
+          style={{ backgroundColor: 'var(--color-surface)' }}
+        >
+          <ResultRow label="Dilution" value="1+31" />
+          <ResultRow label="Temperature" value="20°C / 68°F" />
+          <ResultRow label="Time" value="7 min 30 s" />
+          <ResultRow label="Agitation" value="Every 30 s" />
+        </div>
+      </CollapsibleSection>
+    </div>
+  );
+};
+
+// Collapsed section showing only the title/subtitle header.
+export const Collapsed = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{ maxWidth: 360 }}>
+      <CollapsibleSection
+        title="Notes"
+        subtitle="Push processing & handling"
+        isExpanded={open}
+        onToggle={() => setOpen((v) => !v)}
+      >
+        <p className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+          Rate at EI 800 and extend development by ~40% for one stop of push.
+        </p>
+      </CollapsibleSection>
+    </div>
+  );
+};

--- a/.design-sync/previews/ConfirmModal.tsx
+++ b/.design-sync/previews/ConfirmModal.tsx
@@ -1,0 +1,58 @@
+import { ConfirmModal } from '@dorkroom/ui';
+import { useState } from 'react';
+
+// Destructive confirm — the canonical "delete preset" flow with a warning icon.
+export const Destructive = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div style={{ maxWidth: 420 }}>
+      <ConfirmModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        onConfirm={() => setOpen(false)}
+        title="Delete preset?"
+        message="“Portrait 5×7 with 0.5″ border” will be permanently removed. This can’t be undone."
+        confirmText="Delete"
+        cancelText="Keep"
+        isDestructive
+      />
+    </div>
+  );
+};
+
+// Non-destructive confirmation — warning-toned, used to gate a discard action.
+export const NonDestructive = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div style={{ maxWidth: 420 }}>
+      <ConfirmModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        onConfirm={() => setOpen(false)}
+        title="Discard unsaved changes?"
+        message="You have unsaved edits to this development recipe. Leaving now discards your changes to the dilution and time."
+        confirmText="Discard"
+        cancelText="Stay"
+      />
+    </div>
+  );
+};
+
+// In-progress state — confirm button shows the processing label and is disabled.
+export const Processing = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div style={{ maxWidth: 420 }}>
+      <ConfirmModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        onConfirm={() => setOpen(false)}
+        title="Delete preset?"
+        message="“Tri-X 400 @ EI 800 push” is being removed from your saved presets."
+        confirmText="Delete"
+        isDestructive
+        isProcessing
+      />
+    </div>
+  );
+};

--- a/.design-sync/previews/DetailPanel.tsx
+++ b/.design-sync/previews/DetailPanel.tsx
@@ -1,0 +1,94 @@
+import { DetailPanel, ResultRow } from '@dorkroom/ui';
+
+const FilmDetail = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+    <div>
+      <div
+        className="text-xs uppercase tracking-wide"
+        style={{ color: 'var(--color-text-muted)' }}
+      >
+        Kodak
+      </div>
+      <h2
+        className="text-xl font-semibold"
+        style={{ color: 'var(--color-text-primary)' }}
+      >
+        Tri-X 400
+      </h2>
+      <p className="mt-1 text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+        A classic high-speed black & white negative film with a distinctive
+        grain structure and wide exposure latitude.
+      </p>
+    </div>
+    <div
+      className="rounded-xl border p-4"
+      style={{
+        borderColor: 'var(--color-border-secondary)',
+        backgroundColor: 'var(--color-border-muted)',
+      }}
+    >
+      <ResultRow label="Box speed" value="ISO 400" />
+      <ResultRow label="Process" value="Black & White" />
+      <ResultRow label="Grain" value="Fine to medium" />
+      <ResultRow label="Format" value="35mm · 120 · Sheet" />
+      <ResultRow label="Status" value="In production" />
+    </div>
+  </div>
+);
+
+// The desktop sidebar — sticky detail panel with close + expand buttons and a
+// real film detail body.
+export const FilmSidebar = () => (
+  <div style={{ maxWidth: 420 }}>
+    <DetailPanel
+      isOpen
+      isMobile={false}
+      onClose={() => {}}
+      ariaLabel="Tri-X 400 details"
+    >
+      <FilmDetail />
+    </DetailPanel>
+  </div>
+);
+
+// A developer recipe detail, with the expand button hidden.
+export const DeveloperSidebar = () => (
+  <div style={{ maxWidth: 420 }}>
+    <DetailPanel
+      isOpen
+      isMobile={false}
+      onClose={() => {}}
+      showExpandButton={false}
+      ariaLabel="HC-110 dilution B details"
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <div>
+          <div
+            className="text-xs uppercase tracking-wide"
+            style={{ color: 'var(--color-text-muted)' }}
+          >
+            Kodak HC-110
+          </div>
+          <h2
+            className="text-xl font-semibold"
+            style={{ color: 'var(--color-text-primary)' }}
+          >
+            Dilution B
+          </h2>
+        </div>
+        <div
+          className="rounded-xl border p-4"
+          style={{
+            borderColor: 'var(--color-border-secondary)',
+            backgroundColor: 'var(--color-border-muted)',
+          }}
+        >
+          <ResultRow label="Dilution" value="1+31" />
+          <ResultRow label="Temperature" value="20°C / 68°F" />
+          <ResultRow label="Time" value="7 min 30 s" />
+          <ResultRow label="Agitation" value="Every 30 s" />
+        </div>
+      </div>
+    </DetailPanel>
+  </div>
+);

--- a/.design-sync/previews/DetailPanelCloseButton.tsx
+++ b/.design-sync/previews/DetailPanelCloseButton.tsx
@@ -1,0 +1,52 @@
+import { DetailPanel, DetailPanelCloseButton, ResultRow } from '@dorkroom/ui';
+
+// In context: the close button lives in the top-right of a DetailPanel header.
+// Here it sits in a real film detail sidebar (the panel renders its own close
+// button in the same slot).
+export const InPanel = () => (
+  <div style={{ maxWidth: 420 }}>
+    <DetailPanel
+      isOpen
+      isMobile={false}
+      onClose={() => {}}
+      showExpandButton={false}
+      ariaLabel="Ilford HP5 Plus details"
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <h2
+          className="text-xl font-semibold"
+          style={{ color: 'var(--color-text-primary)' }}
+        >
+          Ilford HP5 Plus
+        </h2>
+        <div
+          className="rounded-xl border p-4"
+          style={{
+            borderColor: 'var(--color-border-secondary)',
+            backgroundColor: 'var(--color-border-muted)',
+          }}
+        >
+          <ResultRow label="Box speed" value="ISO 400" />
+          <ResultRow label="Process" value="Black & White" />
+        </div>
+      </div>
+    </DetailPanel>
+  </div>
+);
+
+// The button on its own, against the panel surface it normally sits on.
+export const Standalone = () => (
+  <div
+    style={{
+      maxWidth: 80,
+      display: 'flex',
+      justifyContent: 'center',
+      padding: 12,
+      borderRadius: 12,
+      backgroundColor: 'var(--color-surface)',
+      border: '1px solid var(--color-border-secondary)',
+    }}
+  >
+    <DetailPanelCloseButton onClick={() => {}} />
+  </div>
+);

--- a/.design-sync/previews/DetailPanelExpandButton.tsx
+++ b/.design-sync/previews/DetailPanelExpandButton.tsx
@@ -1,0 +1,52 @@
+import { DetailPanel, DetailPanelExpandButton, ResultRow } from '@dorkroom/ui';
+
+// In context: the expand button sits beside the close button in a DetailPanel
+// header (the panel renders it automatically when showExpandButton is true).
+export const InPanel = () => (
+  <div style={{ maxWidth: 420 }}>
+    <DetailPanel
+      isOpen
+      isMobile={false}
+      onClose={() => {}}
+      ariaLabel="Fujifilm Acros 100 II details"
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <h2
+          className="text-xl font-semibold"
+          style={{ color: 'var(--color-text-primary)' }}
+        >
+          Fujifilm Acros 100 II
+        </h2>
+        <div
+          className="rounded-xl border p-4"
+          style={{
+            borderColor: 'var(--color-border-secondary)',
+            backgroundColor: 'var(--color-border-muted)',
+          }}
+        >
+          <ResultRow label="Box speed" value="ISO 100" />
+          <ResultRow label="Reciprocity" value="Excellent" />
+        </div>
+      </div>
+    </DetailPanel>
+  </div>
+);
+
+// Both states standalone: collapse (expanded) and expand (collapsed).
+export const States = () => (
+  <div
+    style={{
+      maxWidth: 140,
+      display: 'flex',
+      gap: 8,
+      justifyContent: 'center',
+      padding: 12,
+      borderRadius: 12,
+      backgroundColor: 'var(--color-surface)',
+      border: '1px solid var(--color-border-secondary)',
+    }}
+  >
+    <DetailPanelExpandButton isExpanded={false} onClick={() => {}} />
+    <DetailPanelExpandButton isExpanded onClick={() => {}} />
+  </div>
+);

--- a/.design-sync/previews/DimensionInputGroup.tsx
+++ b/.design-sync/previews/DimensionInputGroup.tsx
@@ -1,0 +1,44 @@
+import { DimensionInputGroup } from '@dorkroom/ui';
+import { useState } from 'react';
+
+// Canonical paired width/height field — custom paper size for the border calculator.
+// `showUnits` appends the active measurement unit (from context) to each label.
+export const CustomPaperSize = () => {
+  const [width, setWidth] = useState('8');
+  const [height, setHeight] = useState('10');
+  return (
+    <div style={{ maxWidth: 360 }}>
+      <DimensionInputGroup
+        widthValue={width}
+        onWidthChange={setWidth}
+        heightValue={height}
+        onHeightChange={setHeight}
+        widthLabel="Width"
+        heightLabel="Height"
+        widthPlaceholder="Width"
+        heightPlaceholder="Height"
+      />
+    </div>
+  );
+};
+
+// Custom aspect ratio — units hidden, empty with placeholders.
+export const CustomAspectRatio = () => {
+  const [width, setWidth] = useState('');
+  const [height, setHeight] = useState('');
+  return (
+    <div style={{ maxWidth: 360 }}>
+      <DimensionInputGroup
+        widthValue={width}
+        onWidthChange={setWidth}
+        heightValue={height}
+        onHeightChange={setHeight}
+        widthLabel="Width:"
+        heightLabel="Height:"
+        widthPlaceholder="Width"
+        heightPlaceholder="Height"
+        showUnits={false}
+      />
+    </div>
+  );
+};

--- a/.design-sync/previews/Drawer.tsx
+++ b/.design-sync/previews/Drawer.tsx
@@ -1,0 +1,115 @@
+import { Drawer, DrawerBody, DrawerContent } from '@dorkroom/ui';
+import { X } from 'lucide-react';
+import { useState } from 'react';
+
+const headerStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  borderBottom: '1px solid var(--color-border-secondary)',
+  padding: '12px 16px',
+} as const;
+
+// Canonical bottom drawer (mobile pattern): titled header + scrollable body.
+export const BottomSheet = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div style={{ maxWidth: 420 }}>
+      <Drawer isOpen={open} onClose={() => setOpen(false)} size="md" anchor="bottom">
+        <DrawerContent>
+          <div style={headerStyle}>
+            <h2
+              style={{
+                fontSize: 16,
+                fontWeight: 600,
+                color: 'var(--color-text-primary)',
+              }}
+            >
+              Recipe details
+            </h2>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close"
+              style={{
+                borderRadius: 999,
+                padding: 8,
+                border: '1px solid var(--color-border-secondary)',
+                color: 'var(--color-text-secondary)',
+                background: 'transparent',
+                cursor: 'pointer',
+              }}
+            >
+              <X className="size-5" />
+            </button>
+          </div>
+          <DrawerBody className="px-4 pb-6 pt-4">
+            <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>
+              Kodak Tri-X 400 in Rodinal 1:50 at 20&deg;C for 13 minutes.
+              Agitate continuously for the first minute, then 4 inversions every
+              3 minutes.
+            </p>
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  );
+};
+
+// Right-anchored drawer (side panel) with a list of filter options.
+export const RightPanel = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div style={{ maxWidth: 480 }}>
+      <Drawer isOpen={open} onClose={() => setOpen(false)} anchor="right">
+        <DrawerContent>
+          <div style={headerStyle}>
+            <h2
+              style={{
+                fontSize: 16,
+                fontWeight: 600,
+                color: 'var(--color-text-primary)',
+              }}
+            >
+              Filter recipes
+            </h2>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              aria-label="Close"
+              style={{
+                borderRadius: 999,
+                padding: 8,
+                border: '1px solid var(--color-border-secondary)',
+                color: 'var(--color-text-secondary)',
+                background: 'transparent',
+                cursor: 'pointer',
+              }}
+            >
+              <X className="size-5" />
+            </button>
+          </div>
+          <DrawerBody className="px-4 py-4">
+            <ul
+              style={{
+                listStyle: 'none',
+                margin: 0,
+                padding: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 10,
+                color: 'var(--color-text-secondary)',
+                fontSize: 14,
+              }}
+            >
+              <li>Black &amp; white film</li>
+              <li>HC-110 developer</li>
+              <li>20&deg;C standard temperature</li>
+              <li>ISO 400 and faster</li>
+            </ul>
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  );
+};

--- a/.design-sync/previews/DrawerBody.tsx
+++ b/.design-sync/previews/DrawerBody.tsx
@@ -1,0 +1,54 @@
+import { Drawer, DrawerBody, DrawerContent } from '@dorkroom/ui';
+import { useState } from 'react';
+
+// DrawerBody is the scrollable, flex-1 region inside a DrawerContent. Shown in
+// true context with a longer list so its overflow-scroll role reads clearly.
+export const ScrollableList = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div style={{ maxWidth: 440 }}>
+      <Drawer isOpen={open} onClose={() => setOpen(false)} size="md" anchor="bottom">
+        <DrawerContent>
+          <div
+            style={{
+              borderBottom: '1px solid var(--color-border-secondary)',
+              padding: '12px 16px',
+            }}
+          >
+            <h2
+              style={{
+                fontSize: 16,
+                fontWeight: 600,
+                color: 'var(--color-text-primary)',
+              }}
+            >
+              Choose a developer
+            </h2>
+          </div>
+          <DrawerBody className="px-4 py-4">
+            <ul
+              style={{
+                listStyle: 'none',
+                margin: 0,
+                padding: 0,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 12,
+                color: 'var(--color-text-secondary)',
+                fontSize: 14,
+              }}
+            >
+              <li>Kodak HC-110</li>
+              <li>Kodak D-76</li>
+              <li>Ilford ID-11</li>
+              <li>Ilford Microphen</li>
+              <li>Adox Rodinal</li>
+              <li>Kodak Xtol</li>
+              <li>Cinestill Df96 Monobath</li>
+            </ul>
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  );
+};

--- a/.design-sync/previews/DrawerContent.tsx
+++ b/.design-sync/previews/DrawerContent.tsx
@@ -1,0 +1,39 @@
+import { Drawer, DrawerBody, DrawerContent } from '@dorkroom/ui';
+import { useState } from 'react';
+
+// DrawerContent is the full-height flex column wrapper inside a Drawer. Shown in
+// its true context: a bottom drawer with a fixed header region and a body below.
+export const InBottomDrawer = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div style={{ maxWidth: 440 }}>
+      <Drawer isOpen={open} onClose={() => setOpen(false)} size="md" anchor="bottom">
+        <DrawerContent>
+          <div
+            style={{
+              borderBottom: '1px solid var(--color-border-secondary)',
+              padding: '12px 16px',
+            }}
+          >
+            <h2
+              style={{
+                fontSize: 16,
+                fontWeight: 600,
+                color: 'var(--color-text-primary)',
+              }}
+            >
+              Paper sizes
+            </h2>
+          </div>
+          <DrawerBody className="px-4 py-4">
+            <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>
+              DrawerContent stretches to fill the drawer as a flex column so its
+              header stays pinned and the body region takes the remaining height
+              and scrolls.
+            </p>
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </div>
+  );
+};

--- a/.design-sync/previews/ErrorBoundary.tsx
+++ b/.design-sync/previews/ErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import { ErrorBoundary } from '@dorkroom/ui';
+
+// Healthy: the boundary renders its children untouched when nothing throws.
+export const Healthy = () => (
+  <div style={{ maxWidth: 420 }}>
+    <ErrorBoundary>
+      <div
+        style={{
+          padding: 16,
+          borderRadius: 16,
+          border: '1px solid var(--color-border-primary)',
+          backgroundColor: 'var(--color-surface)',
+        }}
+      >
+        <p
+          style={{
+            color: 'var(--color-text-primary)',
+            fontWeight: 600,
+            marginBottom: 4,
+          }}
+        >
+          Reciprocity curve loaded
+        </p>
+        <p style={{ color: 'var(--color-text-secondary)', fontSize: 14 }}>
+          Kodak Tri-X 400 · 30s metered → 73s corrected
+        </p>
+      </div>
+    </ErrorBoundary>
+  </div>
+);
+
+// A child that throws on render to trip the boundary.
+function ExplodingChart(): never {
+  throw new Error('Failed to render reciprocity curve: missing factor');
+}
+
+// Fallback: a child throws, so the boundary catches it and shows the default
+// recovery UI ("Something went wrong" + Reload Page).
+export const Fallback = () => (
+  <div style={{ maxWidth: 420 }}>
+    <ErrorBoundary>
+      <ExplodingChart />
+    </ErrorBoundary>
+  </div>
+);

--- a/.design-sync/previews/FilterPanelClearButton.tsx
+++ b/.design-sync/previews/FilterPanelClearButton.tsx
@@ -1,0 +1,52 @@
+import {
+  FilterPanelClearButton,
+  FilterPanelContainer,
+  FilterPanelSection,
+  Select,
+} from '@dorkroom/ui';
+import { useState } from 'react';
+
+// The clear button as it appears in a real section header — top-right of a
+// titled FilterPanelSection (which renders it when showClear is set).
+export const InSection = () => {
+  const [iso, setIso] = useState('400');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <FilterPanelContainer activeFilterCount={1} hasActiveFilters>
+        <FilterPanelSection
+          title="ISO speed"
+          showClear
+          clearLabel="Reset"
+          onClear={() => setIso('')}
+        >
+          <Select
+            label="Box speed"
+            items={[
+              { label: 'Any ISO', value: '' },
+              { label: 'ISO 100', value: '100' },
+              { label: 'ISO 400', value: '400' },
+              { label: 'ISO 3200', value: '3200' },
+            ]}
+            selectedValue={iso}
+            onValueChange={setIso}
+          />
+        </FilterPanelSection>
+      </FilterPanelContainer>
+    </div>
+  );
+};
+
+// The button on its own, with the default and a custom label.
+export const Standalone = () => (
+  <div
+    style={{
+      maxWidth: 220,
+      display: 'flex',
+      gap: 12,
+      alignItems: 'center',
+    }}
+  >
+    <FilterPanelClearButton onClick={() => {}} />
+    <FilterPanelClearButton onClick={() => {}} label="Reset filters" />
+  </div>
+);

--- a/.design-sync/previews/FilterPanelContainer.tsx
+++ b/.design-sync/previews/FilterPanelContainer.tsx
@@ -1,0 +1,90 @@
+import {
+  FilterPanelContainer,
+  FilterPanelHeader,
+  FilterPanelSection,
+  Select,
+} from '@dorkroom/ui';
+import { useState } from 'react';
+
+const FILM_TYPE_OPTIONS = [
+  { label: 'All types', value: '' },
+  { label: 'Black & White', value: 'bw' },
+  { label: 'Color', value: 'color' },
+  { label: 'Slide', value: 'slide' },
+];
+
+const ISO_OPTIONS = [
+  { label: 'Any ISO', value: '' },
+  { label: 'ISO 100', value: '100' },
+  { label: 'ISO 400', value: '400' },
+  { label: 'ISO 3200', value: '3200' },
+];
+
+const BRAND_OPTIONS = [
+  { label: 'All brands', value: '' },
+  { label: 'Kodak', value: 'kodak' },
+  { label: 'Ilford', value: 'ilford' },
+  { label: 'Fujifilm', value: 'fuji' },
+];
+
+// The canonical filter sidebar: provider Container wrapping a Header and two
+// real filter Sections, mirroring the film catalog's filter panel.
+export const Default = () => {
+  const [filmType, setFilmType] = useState('bw');
+  const [iso, setIso] = useState('400');
+  const [brand, setBrand] = useState('ilford');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <FilterPanelContainer activeFilterCount={3} hasActiveFilters>
+        <FilterPanelHeader title="Filters" />
+        <FilterPanelSection
+          title="Film type"
+          showClear
+          onClear={() => setFilmType('')}
+        >
+          <Select
+            label="Process"
+            items={FILM_TYPE_OPTIONS}
+            selectedValue={filmType}
+            onValueChange={setFilmType}
+          />
+          <Select
+            label="ISO speed"
+            items={ISO_OPTIONS}
+            selectedValue={iso}
+            onValueChange={setIso}
+          />
+        </FilterPanelSection>
+        <FilterPanelSection title="Brand">
+          <Select
+            label="Manufacturer"
+            items={BRAND_OPTIONS}
+            selectedValue={brand}
+            onValueChange={setBrand}
+          />
+        </FilterPanelSection>
+      </FilterPanelContainer>
+    </div>
+  );
+};
+
+// Collapsed rail — the Container's compact state with an active-filter badge.
+export const Collapsed = () => (
+  <div style={{ maxWidth: 96 }}>
+    <FilterPanelContainer
+      activeFilterCount={3}
+      hasActiveFilters
+      defaultCollapsed
+    >
+      <FilterPanelHeader title="Filters" />
+      <FilterPanelSection title="Film type">
+        <Select
+          label="Process"
+          items={FILM_TYPE_OPTIONS}
+          selectedValue="bw"
+          onValueChange={() => {}}
+        />
+      </FilterPanelSection>
+    </FilterPanelContainer>
+  </div>
+);

--- a/.design-sync/previews/FilterPanelHeader.tsx
+++ b/.design-sync/previews/FilterPanelHeader.tsx
@@ -1,0 +1,56 @@
+import {
+  FilterPanelContainer,
+  FilterPanelHeader,
+  FilterPanelSection,
+  Select,
+} from '@dorkroom/ui';
+import { useState } from 'react';
+
+const DEVELOPER_OPTIONS = [
+  { label: 'All developers', value: '' },
+  { label: 'Kodak HC-110', value: 'hc110' },
+  { label: 'Ilford ID-11', value: 'id11' },
+  { label: 'Rodinal', value: 'rodinal' },
+];
+
+// The header sits at the top of a filter panel. Rendered inside its Container so
+// the collapse toggle and active-filter badge resolve from context.
+export const Default = () => {
+  const [developer, setDeveloper] = useState('hc110');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <FilterPanelContainer activeFilterCount={2} hasActiveFilters>
+        <FilterPanelHeader title="Filters" />
+        <FilterPanelSection title="Developer">
+          <Select
+            label="Chemistry"
+            items={DEVELOPER_OPTIONS}
+            selectedValue={developer}
+            onValueChange={setDeveloper}
+          />
+        </FilterPanelSection>
+      </FilterPanelContainer>
+    </div>
+  );
+};
+
+// A custom title with no active filters — the badge is hidden.
+export const CustomTitle = () => (
+  <div style={{ maxWidth: 320 }}>
+    <FilterPanelContainer activeFilterCount={0} hasActiveFilters={false}>
+      <FilterPanelHeader title="Recipe filters" />
+      <FilterPanelSection title="Dilution">
+        <Select
+          label="Stock dilution"
+          items={[
+            { label: 'Any dilution', value: '' },
+            { label: '1+31', value: '1+31' },
+            { label: '1+47', value: '1+47' },
+          ]}
+          selectedValue=""
+          onValueChange={() => {}}
+        />
+      </FilterPanelSection>
+    </FilterPanelContainer>
+  </div>
+);

--- a/.design-sync/previews/FilterPanelSection.tsx
+++ b/.design-sync/previews/FilterPanelSection.tsx
@@ -1,0 +1,72 @@
+import {
+  FilterPanelContainer,
+  FilterPanelHeader,
+  FilterPanelSection,
+  Select,
+} from '@dorkroom/ui';
+import { useState } from 'react';
+
+const TEMP_OPTIONS = [
+  { label: 'Any temperature', value: '' },
+  { label: '20°C / 68°F', value: '20' },
+  { label: '24°C / 75°F', value: '24' },
+];
+
+const AGITATION_OPTIONS = [
+  { label: 'Any agitation', value: '' },
+  { label: 'Continuous', value: 'continuous' },
+  { label: 'Every 30s', value: '30s' },
+  { label: 'Every 60s', value: '60s' },
+];
+
+// A section with a title and a clear button, holding two real filter controls.
+export const WithClear = () => {
+  const [temp, setTemp] = useState('20');
+  const [agitation, setAgitation] = useState('30s');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <FilterPanelContainer activeFilterCount={2} hasActiveFilters>
+        <FilterPanelSection
+          title="Process"
+          showClear
+          onClear={() => {
+            setTemp('');
+            setAgitation('');
+          }}
+        >
+          <Select
+            label="Temperature"
+            items={TEMP_OPTIONS}
+            selectedValue={temp}
+            onValueChange={setTemp}
+          />
+          <Select
+            label="Agitation"
+            items={AGITATION_OPTIONS}
+            selectedValue={agitation}
+            onValueChange={setAgitation}
+          />
+        </FilterPanelSection>
+      </FilterPanelContainer>
+    </div>
+  );
+};
+
+// A plain titled section with no clear affordance.
+export const Plain = () => {
+  const [agitation, setAgitation] = useState('continuous');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <FilterPanelContainer activeFilterCount={1} hasActiveFilters>
+        <FilterPanelSection title="Agitation">
+          <Select
+            label="Scheme"
+            items={AGITATION_OPTIONS}
+            selectedValue={agitation}
+            onValueChange={setAgitation}
+          />
+        </FilterPanelSection>
+      </FilterPanelContainer>
+    </div>
+  );
+};

--- a/.design-sync/previews/Greeting.tsx
+++ b/.design-sync/previews/Greeting.tsx
@@ -1,0 +1,8 @@
+import { Greeting } from '@dorkroom/ui';
+
+// The real hero greeting from the home page — the grainy glow brand wordmark.
+export const Hero = () => (
+  <div style={{ maxWidth: 480 }}>
+    <Greeting />
+  </div>
+);

--- a/.design-sync/previews/LabeledSliderInput.tsx
+++ b/.design-sync/previews/LabeledSliderInput.tsx
@@ -1,0 +1,63 @@
+import { LabeledSliderInput } from '@dorkroom/ui';
+import { useState } from 'react';
+
+// Canonical slider+number field — minimum print border, with reference labels.
+export const MinimumBorder = () => {
+  const [value, setValue] = useState(0.5);
+  return (
+    <div style={{ maxWidth: 360 }}>
+      <LabeledSliderInput
+        label="Minimum border (inches)"
+        value={value}
+        onChange={setValue}
+        onSliderChange={setValue}
+        min={0}
+        max={2}
+        step={0.05}
+        labels={['0"', '1"', '2"']}
+        continuousUpdate
+      />
+    </div>
+  );
+};
+
+// Offset slider with a centered zero reference.
+export const HorizontalOffset = () => {
+  const [value, setValue] = useState(0.25);
+  return (
+    <div style={{ maxWidth: 360 }}>
+      <LabeledSliderInput
+        label="Horizontal offset"
+        value={value}
+        onChange={setValue}
+        onSliderChange={setValue}
+        min={-1}
+        max={1}
+        step={0.05}
+        labels={['-1"', '0"', '1"']}
+        continuousUpdate
+      />
+    </div>
+  );
+};
+
+// Warning state — the validation styling axis (yellow border/background).
+export const Warning = () => {
+  const [value, setValue] = useState(0.1);
+  return (
+    <div style={{ maxWidth: 360 }}>
+      <LabeledSliderInput
+        label="Minimum border (inches)"
+        value={value}
+        onChange={setValue}
+        onSliderChange={setValue}
+        min={0}
+        max={2}
+        step={0.05}
+        labels={['0"', '1"', '2"']}
+        warning
+        continuousUpdate
+      />
+    </div>
+  );
+};

--- a/.design-sync/previews/MeasurementUnitToggle.tsx
+++ b/.design-sync/previews/MeasurementUnitToggle.tsx
@@ -1,0 +1,9 @@
+import { MeasurementUnitToggle } from '@dorkroom/ui';
+
+// Context-driven toggle (in | cm) used across the border calculator.
+// Reads/writes the global MeasurementProvider, so it takes no props.
+export const Default = () => (
+  <div style={{ maxWidth: 200 }}>
+    <MeasurementUnitToggle />
+  </div>
+);

--- a/.design-sync/previews/MobileSidebar.tsx
+++ b/.design-sync/previews/MobileSidebar.tsx
@@ -1,0 +1,45 @@
+import { MobileSidebar } from '@dorkroom/ui';
+import { useState } from 'react';
+
+const noop = () => {};
+
+// The open mobile navigation drawer with the app's real sectioned nav
+// (Printing / Film / Camera / Reference) plus the Theme + Settings footer.
+// The component is h-full, so we frame it in a phone-height panel.
+export const Open = () => {
+  const [path, setPath] = useState('/border');
+  return (
+    <div
+      style={{
+        width: 300,
+        height: 560,
+        border: '1px solid var(--color-border-primary)',
+        borderRadius: 16,
+        overflow: 'hidden',
+        backgroundColor: 'var(--color-surface)',
+      }}
+    >
+      <MobileSidebar pathname={path} onNavigate={setPath} onClose={noop} />
+    </div>
+  );
+};
+
+// A different route highlighted — the Films entry is active in the Reference
+// section, showing the active-item treatment.
+export const ReferenceActive = () => {
+  const [path, setPath] = useState('/films');
+  return (
+    <div
+      style={{
+        width: 300,
+        height: 560,
+        border: '1px solid var(--color-border-primary)',
+        borderRadius: 16,
+        overflow: 'hidden',
+        backgroundColor: 'var(--color-surface)',
+      }}
+    >
+      <MobileSidebar pathname={path} onNavigate={setPath} onClose={noop} />
+    </div>
+  );
+};

--- a/.design-sync/previews/Modal.tsx
+++ b/.design-sync/previews/Modal.tsx
@@ -1,0 +1,110 @@
+import { Modal } from '@dorkroom/ui';
+import { useState } from 'react';
+
+// Footer action buttons styled to match the dark surface theme.
+const footerButton = (primary: boolean) =>
+  ({
+    padding: '8px 16px',
+    fontSize: 14,
+    fontWeight: 500,
+    borderRadius: 12,
+    cursor: 'pointer',
+    border: primary
+      ? 'none'
+      : '1px solid var(--color-border-secondary)',
+    backgroundColor: primary
+      ? 'var(--color-primary)'
+      : 'var(--color-surface-muted)',
+    color: primary ? 'white' : 'var(--color-text-secondary)',
+  }) as const;
+
+// Canonical open modal: a titled dialog with body copy and a footer action row.
+export const Default = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div style={{ maxWidth: 520 }}>
+      <Modal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        title="Reset border calculator?"
+        footer={
+          <div style={{ display: 'flex', gap: 12, justifyContent: 'flex-end' }}>
+            <button type="button" style={footerButton(false)}>
+              Cancel
+            </button>
+            <button type="button" style={footerButton(true)}>
+              Reset to defaults
+            </button>
+          </div>
+        }
+      >
+        <p>
+          This clears your current paper size, easel blades and border widths
+          and restores the 8&times;10 default layout. Saved presets are not
+          affected.
+        </p>
+      </Modal>
+    </div>
+  );
+};
+
+// Larger modal with structured body content — a developer/film pairing summary.
+export const WithRichBody = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div style={{ maxWidth: 640 }}>
+      <Modal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        title="Kodak Tri-X 400 in HC-110 (Dilution B)"
+        size="lg"
+      >
+        <p>
+          A classic high-acutance combination. Times below assume continuous
+          agitation for the first 30 seconds, then 3 inversions every minute.
+        </p>
+        <dl
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'auto 1fr',
+            gap: '8px 24px',
+            marginTop: 4,
+          }}
+        >
+          <dt style={{ color: 'var(--color-text-muted)' }}>Dilution</dt>
+          <dd style={{ margin: 0 }}>1:31 (Dilution B)</dd>
+          <dt style={{ color: 'var(--color-text-muted)' }}>Temperature</dt>
+          <dd style={{ margin: 0 }}>20&deg;C / 68&deg;F</dd>
+          <dt style={{ color: 'var(--color-text-muted)' }}>Time</dt>
+          <dd style={{ margin: 0 }}>7 min 30 sec</dd>
+        </dl>
+      </Modal>
+    </div>
+  );
+};
+
+// Compact modal with the header close button hidden (footer-only dismissal).
+export const SmallNoCloseButton = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div style={{ maxWidth: 400 }}>
+      <Modal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        title="Preset saved"
+        size="sm"
+        hideCloseButton
+        footer={
+          <button type="button" style={footerButton(true)}>
+            Done
+          </button>
+        }
+      >
+        <p>
+          &ldquo;Portrait 5&times;7 with 0.5&Prime; border&rdquo; is now in your
+          saved presets and synced to this device.
+        </p>
+      </Modal>
+    </div>
+  );
+};

--- a/.design-sync/previews/NavigationDropdown.tsx
+++ b/.design-sync/previews/NavigationDropdown.tsx
@@ -1,0 +1,37 @@
+import { NavigationDropdown, printingItems, referenceItems } from '@dorkroom/ui';
+import { BookOpen, Printer } from 'lucide-react';
+import { useState } from 'react';
+
+// The desktop nav category trigger, fed the app's real "Printing" items. Closed
+// (resting) state — clicking opens the rich item panel with summaries.
+export const PrintingCategory = () => {
+  const [path, setPath] = useState('/border');
+  return (
+    <div style={{ maxWidth: 280 }}>
+      <NavigationDropdown
+        label="Printing"
+        icon={Printer}
+        items={printingItems}
+        currentPath={path}
+        onNavigate={setPath}
+      />
+    </div>
+  );
+};
+
+// Active state: the trigger fills in when the current route belongs to this
+// category (here /reciprocity lives under a Film/Reference grouping example).
+export const ActiveTrigger = () => {
+  const [path, setPath] = useState('/films');
+  return (
+    <div style={{ maxWidth: 280 }}>
+      <NavigationDropdown
+        label="Reference"
+        icon={BookOpen}
+        items={referenceItems}
+        currentPath={path}
+        onNavigate={setPath}
+      />
+    </div>
+  );
+};

--- a/.design-sync/previews/NumberInput.tsx
+++ b/.design-sync/previews/NumberInput.tsx
@@ -1,0 +1,39 @@
+import { NumberInput } from '@dorkroom/ui';
+import { useState } from 'react';
+
+// Canonical numeric field — a developer dilution volume in ml.
+export const Default = () => {
+  const [value, setValue] = useState('300');
+  return (
+    <div style={{ maxWidth: 200 }}>
+      <NumberInput
+        value={value}
+        onChangeText={setValue}
+        inputTitle="Stock solution"
+        step={5}
+      />
+    </div>
+  );
+};
+
+// Empty with placeholder vs filled — the value-presence axis.
+export const States = () => {
+  const [empty, setEmpty] = useState('');
+  const [iso, setIso] = useState('400');
+  return (
+    <div style={{ maxWidth: 200, display: 'grid', gap: 12 }}>
+      <NumberInput
+        value={empty}
+        onChangeText={setEmpty}
+        placeholder="ISO"
+        inputTitle="Film ISO"
+      />
+      <NumberInput
+        value={iso}
+        onChangeText={setIso}
+        inputTitle="Film ISO"
+        step={100}
+      />
+    </div>
+  );
+};

--- a/.design-sync/previews/PlaceholderPage.tsx
+++ b/.design-sync/previews/PlaceholderPage.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from '@dorkroom/ui';
+
+// The "coming soon" page scaffold for a not-yet-built calculator route.
+export const Default = () => (
+  <div style={{ maxWidth: 480 }}>
+    <PlaceholderPage
+      title="Push / Pull Calculator"
+      summary="Adjust development times for pushed and pulled film. We're dialing in the time tables for every stock and developer combination."
+    />
+  </div>
+);

--- a/.design-sync/previews/PushPullAlert.tsx
+++ b/.design-sync/previews/PushPullAlert.tsx
@@ -1,0 +1,15 @@
+import { PushPullAlert } from '@dorkroom/ui';
+
+// Pushed film — warning/yellow with an up arrow.
+export const Pushed = () => (
+  <div style={{ maxWidth: 460 }}>
+    <PushPullAlert shootingIso={1600} pushPull={2} />
+  </div>
+);
+
+// Pulled film — info/blue with a down arrow.
+export const Pulled = () => (
+  <div style={{ maxWidth: 460 }}>
+    <PushPullAlert shootingIso={200} pushPull={-1} />
+  </div>
+);

--- a/.design-sync/previews/ReciprocityChart.tsx
+++ b/.design-sync/previews/ReciprocityChart.tsx
@@ -1,0 +1,27 @@
+import { ReciprocityChart } from '@dorkroom/ui';
+
+// Canonical reciprocity curve for a classic B&W film. The chart plots metered
+// vs. corrected exposure time using adjusted = original^factor.
+export const Default = () => (
+  <div style={{ maxWidth: 420 }}>
+    <ReciprocityChart
+      filmName="Kodak Tri-X 400"
+      originalTime={30}
+      adjustedTime={73}
+      factor={1.26}
+    />
+  </div>
+);
+
+// A film with a steeper reciprocity factor — longer correction at the same
+// metered time, so the curve climbs faster.
+export const SteepFactor = () => (
+  <div style={{ maxWidth: 420 }}>
+    <ReciprocityChart
+      filmName="Ilford HP5 Plus"
+      originalTime={60}
+      adjustedTime={210}
+      factor={1.31}
+    />
+  </div>
+);

--- a/.design-sync/previews/ResponsiveModal.tsx
+++ b/.design-sync/previews/ResponsiveModal.tsx
@@ -1,0 +1,72 @@
+import { ResponsiveModal } from '@dorkroom/ui';
+import { useState } from 'react';
+
+const footerButton = (primary: boolean) =>
+  ({
+    padding: '8px 16px',
+    fontSize: 14,
+    fontWeight: 500,
+    borderRadius: 12,
+    cursor: 'pointer',
+    border: primary ? 'none' : '1px solid var(--color-border-secondary)',
+    backgroundColor: primary
+      ? 'var(--color-primary)'
+      : 'var(--color-surface-muted)',
+    color: primary ? 'white' : 'var(--color-text-secondary)',
+  }) as const;
+
+// Desktop layout (isMobile=false) renders as a centered Modal — the canonical case.
+export const Desktop = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div style={{ maxWidth: 560 }}>
+      <ResponsiveModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        title="Edit development recipe"
+        isMobile={false}
+        footer={
+          <div style={{ display: 'flex', gap: 12, justifyContent: 'flex-end' }}>
+            <button type="button" style={footerButton(false)}>
+              Cancel
+            </button>
+            <button type="button" style={footerButton(true)}>
+              Save recipe
+            </button>
+          </div>
+        }
+      >
+        <p>
+          Adjust the dilution, temperature and time for your Ilford HP5 Plus
+          recipe. Changes apply the next time you load this combination.
+        </p>
+      </ResponsiveModal>
+    </div>
+  );
+};
+
+// Mobile layout (isMobile=true) renders the same content as a bottom Drawer.
+export const MobileDrawer = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <div style={{ maxWidth: 420 }}>
+      <ResponsiveModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        title="Recipe details"
+        isMobile
+        mobileSize="md"
+        footer={
+          <button type="button" style={footerButton(true)}>
+            Use this recipe
+          </button>
+        }
+      >
+        <p>
+          Kodak Tri-X 400 in Rodinal 1:50, 20&deg;C, 13 minutes. Agitate gently
+          for the first minute, then 4 inversions every 3 minutes.
+        </p>
+      </ResponsiveModal>
+    </div>
+  );
+};

--- a/.design-sync/previews/ResultRow.tsx
+++ b/.design-sync/previews/ResultRow.tsx
@@ -1,0 +1,25 @@
+import { ResultRow } from '@dorkroom/ui';
+
+// A stack of result rows as they appear in a calculator's result card —
+// the reciprocity calculator output.
+export const Reciprocity = () => (
+  <div
+    style={{ maxWidth: 360 }}
+    className="rounded-xl border p-4"
+    // inline style to mirror the calculator result card surface
+  >
+    <div className="space-y-2">
+      <ResultRow label="Film selection" value="Kodak Tri-X 400" />
+      <ResultRow label="Original time" value="30 s" />
+      <ResultRow label="Adjustment factor" value="1.52" />
+      <ResultRow label="Corrected time" value="45 s" />
+    </div>
+  </div>
+);
+
+// A single key/value row — the exposure calculator's stop adjustment.
+export const Single = () => (
+  <div style={{ maxWidth: 360 }}>
+    <ResultRow label="Stop adjustment" value="+1.0 stops" />
+  </div>
+);

--- a/.design-sync/previews/SaveBeforeShareModal.tsx
+++ b/.design-sync/previews/SaveBeforeShareModal.tsx
@@ -1,0 +1,70 @@
+import { SaveBeforeShareModal } from '@dorkroom/ui';
+import { useState } from 'react';
+
+const noop = () => {};
+
+// This modal renders a non-portal `fixed inset-0` overlay centered in a
+// `min-h-screen` flex container. A wrapper with `transform` establishes a
+// containing block for `position: fixed`, so the overlay is trapped inside
+// this frame (and therefore captured) instead of escaping to the viewport.
+function Frame({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: 640,
+        transform: 'translateZ(0)',
+        overflow: 'hidden',
+        borderRadius: 12,
+        border: '1px solid var(--color-border-secondary)',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// Canonical state: prompt to name and save a preset before sharing.
+export const Default = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <Frame>
+      <SaveBeforeShareModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        onSaveAndShare={noop}
+      />
+    </Frame>
+  );
+};
+
+// Error state: an external error message surfaced beneath the name field.
+export const WithError = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <Frame>
+      <SaveBeforeShareModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        onSaveAndShare={noop}
+        error="A preset with this name already exists. Choose a different name."
+      />
+    </Frame>
+  );
+};
+
+// Loading state: saving in progress, inputs disabled, spinner on the action.
+export const Saving = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <Frame>
+      <SaveBeforeShareModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        onSaveAndShare={noop}
+        isLoading
+      />
+    </Frame>
+  );
+};

--- a/.design-sync/previews/SearchableSelect.tsx
+++ b/.design-sync/previews/SearchableSelect.tsx
@@ -1,0 +1,52 @@
+import { SearchableSelect } from '@dorkroom/ui';
+import { useState } from 'react';
+
+const developers = [
+  { label: 'Kodak D-76', value: 'd76' },
+  { label: 'Ilford ID-11', value: 'id11' },
+  { label: 'Kodak HC-110', value: 'hc110' },
+  { label: 'Ilfotec DD-X', value: 'ddx' },
+  { label: 'Rodinal (Adox)', value: 'rodinal' },
+  { label: 'Xtol', value: 'xtol' },
+  { label: 'Pyrocat-HD', value: 'pyrocat-hd' },
+];
+
+const films = [
+  { label: 'Kodak Tri-X 400', value: 'tri-x-400' },
+  { label: 'Ilford HP5 Plus', value: 'hp5-plus' },
+  { label: 'Kodak Portra 400', value: 'portra-400' },
+  { label: 'Fuji Acros 100 II', value: 'acros-100' },
+];
+
+// Canonical: a labelled searchable select with a developer chosen. The clear (x)
+// affordance appears because a value is selected and allowClear defaults on.
+export const WithSelection = () => {
+  const [value, setValue] = useState('hc110');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <SearchableSelect
+        label="Developer"
+        selectedValue={value}
+        onValueChange={setValue}
+        items={developers}
+        placeholder="Search developers…"
+      />
+    </div>
+  );
+};
+
+// Empty state: shows the placeholder prompt and no clear button.
+export const Empty = () => {
+  const [value, setValue] = useState('');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <SearchableSelect
+        label="Film stock"
+        selectedValue={value}
+        onValueChange={setValue}
+        items={films}
+        placeholder="Search film stocks…"
+      />
+    </div>
+  );
+};

--- a/.design-sync/previews/Select.tsx
+++ b/.design-sync/previews/Select.tsx
@@ -1,0 +1,65 @@
+import { Select } from '@dorkroom/ui';
+import { useState } from 'react';
+
+const filmStocks = [
+  { label: 'Kodak Tri-X 400', value: 'tri-x-400' },
+  { label: 'Ilford HP5 Plus', value: 'hp5-plus' },
+  { label: 'Kodak T-Max 100', value: 'tmax-100' },
+  { label: 'Fuji Acros 100 II', value: 'acros-100' },
+  { label: 'Ilford Delta 3200', value: 'delta-3200' },
+];
+
+const formatOptions = [
+  { label: 'Full Frame (35mm)', value: 'ff' },
+  { label: 'APS-C', value: 'aps-c' },
+  { label: 'Medium Format (6x6)', value: '6x6' },
+  { label: 'Large Format (4x5)', value: '4x5' },
+];
+
+// Canonical labelled select with a chosen film stock.
+export const WithLabel = () => {
+  const [value, setValue] = useState('tri-x-400');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <Select
+        label="Film stock"
+        selectedValue={value}
+        onValueChange={setValue}
+        items={filmStocks}
+        ariaLabel="Film stock"
+      />
+    </div>
+  );
+};
+
+// Unselected state shows the placeholder option.
+export const Placeholder = () => {
+  const [value, setValue] = useState('');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <Select
+        label="Source format"
+        selectedValue={value}
+        onValueChange={setValue}
+        items={formatOptions}
+        placeholder="Choose a format…"
+        ariaLabel="Source format"
+      />
+    </div>
+  );
+};
+
+// No label — a compact inline control with a selected format.
+export const Bare = () => {
+  const [value, setValue] = useState('6x6');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <Select
+        selectedValue={value}
+        onValueChange={setValue}
+        items={formatOptions}
+        ariaLabel="Target format"
+      />
+    </div>
+  );
+};

--- a/.design-sync/previews/SensorSizeVisualization.tsx
+++ b/.design-sync/previews/SensorSizeVisualization.tsx
@@ -1,0 +1,49 @@
+import { SensorSizeVisualization } from '@dorkroom/ui';
+
+// Real format presets from the lens-equivalency calculator.
+const fullFrame = {
+  id: 'full-frame',
+  name: 'Full Frame (35mm)',
+  shortName: 'Full Frame',
+  category: 'digital' as const,
+  width: 36,
+  height: 24,
+  diagonal: 43.27,
+  cropFactor: 1,
+};
+
+const apsC = {
+  id: 'aps-c-nikon',
+  name: 'APS-C (Nikon/Sony)',
+  shortName: 'APS-C',
+  category: 'digital' as const,
+  width: 23.5,
+  height: 15.6,
+  diagonal: 28.2,
+  cropFactor: 1.53,
+};
+
+const medium67 = {
+  id: 'film-6x7',
+  name: '6×7',
+  shortName: '6×7',
+  category: 'film-medium' as const,
+  width: 70,
+  height: 56,
+  diagonal: 89.6,
+  cropFactor: 0.48,
+};
+
+// 35mm full frame nested against APS-C — the common digital crop comparison.
+export const FullFrameVsApsC = () => (
+  <div style={{ maxWidth: 320 }}>
+    <SensorSizeVisualization sourceFormat={fullFrame} targetFormat={apsC} />
+  </div>
+);
+
+// Full frame nested inside 6×7 medium format — a large area ratio.
+export const FullFrameVsMediumFormat = () => (
+  <div style={{ maxWidth: 320 }}>
+    <SensorSizeVisualization sourceFormat={fullFrame} targetFormat={medium67} />
+  </div>
+);

--- a/.design-sync/previews/SettingsButton.tsx
+++ b/.design-sync/previews/SettingsButton.tsx
@@ -1,0 +1,58 @@
+import { SettingsButton } from '@dorkroom/ui';
+import { Ruler, Thermometer } from 'lucide-react';
+
+const noop = () => {};
+
+// Canonical settings row: label + current value + chevron, as used on the
+// Settings page for a tappable preference.
+export const LabelAndValue = () => (
+  <div style={{ maxWidth: 320 }}>
+    <SettingsButton
+      label="Measurement units"
+      value="Inches"
+      icon={Ruler}
+      onPress={noop}
+    />
+  </div>
+);
+
+// An option-picker row that is currently selected (ring + tinted surface),
+// centered label, no chevron.
+export const Selected = () => (
+  <div style={{ maxWidth: 320 }}>
+    <SettingsButton
+      value="Celsius"
+      icon={Thermometer}
+      isSelected
+      centerLabel
+      showChevron={false}
+      onPress={noop}
+    />
+  </div>
+);
+
+// A small grid of selectable choices — the temperature-unit picker pattern.
+export const ChoiceGrid = () => (
+  <div
+    style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(2, 1fr)',
+      gap: 8,
+      maxWidth: 320,
+    }}
+  >
+    <SettingsButton
+      value="Celsius"
+      isSelected
+      centerLabel
+      showChevron={false}
+      onPress={noop}
+    />
+    <SettingsButton
+      value="Fahrenheit"
+      centerLabel
+      showChevron={false}
+      onPress={noop}
+    />
+  </div>
+);

--- a/.design-sync/previews/ShareButton.tsx
+++ b/.design-sync/previews/ShareButton.tsx
@@ -1,0 +1,54 @@
+import { ShareButton } from '@dorkroom/ui';
+
+const noop = () => {};
+
+// The three button variants, each with a recipe-sharing label.
+export const Variants = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 240 }}>
+    <ShareButton variant="primary" onClick={noop}>
+      Share recipe
+    </ShareButton>
+    <ShareButton variant="secondary" onClick={noop}>
+      Share recipe
+    </ShareButton>
+    <ShareButton variant="outline" onClick={noop}>
+      Share recipe
+    </ShareButton>
+  </div>
+);
+
+// Size scale, primary variant.
+export const Sizes = () => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: 12, maxWidth: 360 }}>
+    <ShareButton size="sm" onClick={noop}>
+      Share
+    </ShareButton>
+    <ShareButton size="md" onClick={noop}>
+      Share
+    </ShareButton>
+    <ShareButton size="lg" onClick={noop}>
+      Share
+    </ShareButton>
+  </div>
+);
+
+// Compact icon-only buttons (used in tight toolbars) across the variants.
+export const IconOnly = () => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+    <ShareButton iconOnly variant="primary" onClick={noop} />
+    <ShareButton iconOnly variant="secondary" onClick={noop} />
+    <ShareButton iconOnly variant="outline" onClick={noop} />
+  </div>
+);
+
+// Loading and disabled states.
+export const States = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 12, maxWidth: 240 }}>
+    <ShareButton isLoading onClick={noop}>
+      Share recipe
+    </ShareButton>
+    <ShareButton disabled onClick={noop}>
+      Share recipe
+    </ShareButton>
+  </div>
+);

--- a/.design-sync/previews/ShareModal.tsx
+++ b/.design-sync/previews/ShareModal.tsx
@@ -1,0 +1,76 @@
+import { ShareModal } from '@dorkroom/ui';
+import { useState } from 'react';
+
+const noop = async () => {};
+
+// This modal renders a non-portal `fixed inset-0` overlay centered in a
+// `min-h-screen` flex container. A wrapper with `transform` establishes a
+// containing block for `position: fixed`, so the overlay is trapped inside
+// this frame (and therefore captured) instead of escaping to the viewport.
+function Frame({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: 640,
+        transform: 'translateZ(0)',
+        overflow: 'hidden',
+        borderRadius: 12,
+        border: '1px solid var(--color-border-secondary)',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// Canonical share modal: web link with a copy control, info icon header.
+export const Default = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <Frame>
+      <ShareModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        presetName="Portrait 5×7 with 0.5″ border"
+        webUrl="https://dorkroom.art/border?preset=portrait-5x7-half-inch"
+        onCopyToClipboard={noop}
+      />
+    </Frame>
+  );
+};
+
+// Native share enabled — adds the "Share via system" action above the web link.
+export const WithNativeShare = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <Frame>
+      <ShareModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        presetName="Tri-X 400 in HC-110 (Dilution B)"
+        webUrl="https://dorkroom.art/development?recipe=trix-400-hc110-b"
+        onCopyToClipboard={noop}
+        onNativeShare={noop}
+        canShareNatively
+      />
+    </Frame>
+  );
+};
+
+// Error state: no valid web URL available to share.
+export const ErrorState = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <Frame>
+      <ShareModal
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        presetName="Resize 8×10 → 11×14"
+        webUrl=""
+        onCopyToClipboard={noop}
+      />
+    </Frame>
+  );
+};

--- a/.design-sync/previews/Skeleton.tsx
+++ b/.design-sync/previews/Skeleton.tsx
@@ -1,0 +1,32 @@
+import { Skeleton } from '@dorkroom/ui';
+
+// A single shimmer block — the primitive loading placeholder.
+export const Block = () => (
+  <div style={{ maxWidth: 360 }}>
+    <Skeleton className="h-6 w-full" />
+  </div>
+);
+
+// Stacked lines approximating a loading text block / list row.
+export const TextLines = () => (
+  <div
+    style={{ display: 'flex', flexDirection: 'column', gap: 10, maxWidth: 360 }}
+  >
+    <Skeleton className="h-4 w-3/4" />
+    <Skeleton className="h-4 w-full" />
+    <Skeleton className="h-4 w-1/2" />
+  </div>
+);
+
+// Mixed shapes — an avatar with two lines, a common list-item placeholder.
+export const ListItem = () => (
+  <div
+    style={{ display: 'flex', gap: 12, alignItems: 'center', maxWidth: 360 }}
+  >
+    <Skeleton className="h-12 w-12 rounded-full" />
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <Skeleton className="h-4 w-2/3" />
+      <Skeleton className="h-3 w-1/3" />
+    </div>
+  </div>
+);

--- a/.design-sync/previews/SkeletonCard.tsx
+++ b/.design-sync/previews/SkeletonCard.tsx
@@ -1,0 +1,24 @@
+import { SkeletonCard } from '@dorkroom/ui';
+
+// The loading placeholder for a film/recipe card — a bordered card with a
+// title block and a 2x2 grid of stat shimmer blocks.
+export const Default = () => (
+  <div style={{ maxWidth: 320 }}>
+    <SkeletonCard />
+  </div>
+);
+
+// How a grid of cards looks while a results page is loading.
+export const Grid = () => (
+  <div
+    style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(2, minmax(220px, 1fr))',
+      gap: 16,
+      maxWidth: 520,
+    }}
+  >
+    <SkeletonCard />
+    <SkeletonCard />
+  </div>
+);

--- a/.design-sync/previews/SkeletonTableRow.tsx
+++ b/.design-sync/previews/SkeletonTableRow.tsx
@@ -1,0 +1,27 @@
+import { SkeletonTableRow } from '@dorkroom/ui';
+
+// SkeletonTableRow renders a <tr> of six shimmer cells, so it must live inside
+// a table. This mirrors the development-recipes table while it loads.
+export const Default = () => (
+  <div style={{ maxWidth: 560 }}>
+    <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+      <tbody>
+        <SkeletonTableRow />
+      </tbody>
+    </table>
+  </div>
+);
+
+// Several loading rows stacked — the full table-loading state.
+export const Stacked = () => (
+  <div style={{ maxWidth: 560 }}>
+    <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+      <tbody>
+        <SkeletonTableRow />
+        <SkeletonTableRow />
+        <SkeletonTableRow />
+        <SkeletonTableRow />
+      </tbody>
+    </table>
+  </div>
+);

--- a/.design-sync/previews/StatCard.tsx
+++ b/.design-sync/previews/StatCard.tsx
@@ -1,0 +1,72 @@
+import { StatCard } from '@dorkroom/ui';
+import { FlaskConical, Film, Users } from 'lucide-react';
+
+// Canonical vertical stat — the home-page library counter.
+export const Vertical = () => (
+  <div style={{ maxWidth: 280 }}>
+    <StatCard
+      icon={FlaskConical}
+      label="Development recipes"
+      value="1,240"
+      iconColorKey="emerald"
+      variant="vertical"
+    />
+  </div>
+);
+
+// Horizontal layout with a different accent.
+export const Horizontal = () => (
+  <div style={{ maxWidth: 320 }}>
+    <StatCard
+      icon={Film}
+      label="Film stocks"
+      value="318"
+      iconColorKey="indigo"
+      variant="horizontal"
+    />
+  </div>
+);
+
+// The accent palette swept across the real home-page stats.
+export const Accents = () => (
+  <div
+    style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(3, minmax(150px, 1fr))',
+      gap: 16,
+      maxWidth: 520,
+    }}
+  >
+    <StatCard
+      icon={FlaskConical}
+      label="Recipes"
+      value="1,240"
+      iconColorKey="emerald"
+    />
+    <StatCard
+      icon={Film}
+      label="Developers"
+      value="86"
+      iconColorKey="rose"
+    />
+    <StatCard
+      icon={Users}
+      label="Contributors"
+      value="42"
+      iconColorKey="indigo"
+    />
+  </div>
+);
+
+// Loading skeleton state.
+export const Loading = () => (
+  <div style={{ maxWidth: 280 }}>
+    <StatCard
+      icon={Film}
+      label="Film stocks"
+      value="318"
+      iconColorKey="indigo"
+      loading
+    />
+  </div>
+);

--- a/.design-sync/previews/StatusAlert.tsx
+++ b/.design-sync/previews/StatusAlert.tsx
@@ -1,0 +1,20 @@
+import { StatusAlert } from '@dorkroom/ui';
+
+// The component's two visual states are `warning` (default) and `error`.
+export const Warning = () => (
+  <div style={{ maxWidth: 460 }}>
+    <StatusAlert
+      action="warning"
+      message="The aspect ratios of the original and target prints do not match. Match them as closely as possible."
+    />
+  </div>
+);
+
+export const Error = () => (
+  <div style={{ maxWidth: 460 }}>
+    <StatusAlert
+      action="error"
+      message="Check inputs. The outer mat must be positive and the borders must leave a window larger than zero on both axes."
+    />
+  </div>
+);

--- a/.design-sync/previews/Tag.tsx
+++ b/.design-sync/previews/Tag.tsx
@@ -1,0 +1,38 @@
+import { Tag } from '@dorkroom/ui';
+
+// Brand/source tags — color is derived from the tag text (official-* + community).
+export const BrandTags = () => (
+  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, maxWidth: 360 }}>
+    <Tag>official-ilford</Tag>
+    <Tag>official-kodak</Tag>
+    <Tag>official-fuji</Tag>
+    <Tag>official-cinestill</Tag>
+    <Tag>official-rollei</Tag>
+    <Tag>community</Tag>
+  </div>
+);
+
+// Film-type tags — bw / color / slide each map to their own palette.
+export const FilmTypeTags = () => (
+  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, maxWidth: 360 }}>
+    <Tag>bw</Tag>
+    <Tag>color</Tag>
+    <Tag>slide</Tag>
+  </div>
+);
+
+// The explicit variant axis: discontinued (semantic error) and info (muted).
+export const Variants = () => (
+  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, maxWidth: 360 }}>
+    <Tag variant="discontinued">discontinued</Tag>
+    <Tag variant="info">35mm</Tag>
+  </div>
+);
+
+// Size axis — xs (default, 10px) vs sm (12px).
+export const Sizes = () => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: 8, maxWidth: 360 }}>
+    <Tag size="xs">official-kodak</Tag>
+    <Tag size="sm">official-kodak</Tag>
+  </div>
+);

--- a/.design-sync/previews/TemperatureAlert.tsx
+++ b/.design-sync/previews/TemperatureAlert.tsx
@@ -1,0 +1,15 @@
+import { TemperatureAlert } from '@dorkroom/ui';
+
+// Higher-than-standard development temperature — warning/yellow with a flame.
+export const Higher = () => (
+  <div style={{ maxWidth: 460 }}>
+    <TemperatureAlert temperatureF={75} />
+  </div>
+);
+
+// Lower-than-standard development temperature — info/blue with a snowflake.
+export const Lower = () => (
+  <div style={{ maxWidth: 460 }}>
+    <TemperatureAlert temperatureC={18} />
+  </div>
+);

--- a/.design-sync/previews/TextInput.tsx
+++ b/.design-sync/previews/TextInput.tsx
@@ -1,0 +1,41 @@
+import { TextInput } from '@dorkroom/ui';
+import { useState } from 'react';
+
+export const WithLabel = () => {
+  const [value, setValue] = useState('Kodak Tri-X 400');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <TextInput
+        label="Preset name"
+        value={value}
+        onValueChange={setValue}
+        placeholder="Preset name"
+      />
+    </div>
+  );
+};
+
+export const WithDescription = () => {
+  const [value, setValue] = useState('');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <TextInput
+        label="Exposure time"
+        value={value}
+        onValueChange={setValue}
+        placeholder="Try 30s, 1m30s, or 2h"
+        description="Supports natural durations like 1m30s."
+        inputMode="search"
+      />
+    </div>
+  );
+};
+
+export const Filled = () => {
+  const [value, setValue] = useState('Ilford HP5 Plus');
+  return (
+    <div style={{ maxWidth: 320 }}>
+      <TextInput value={value} onValueChange={setValue} />
+    </div>
+  );
+};

--- a/.design-sync/previews/ThemeToggle.tsx
+++ b/.design-sync/previews/ThemeToggle.tsx
@@ -1,0 +1,31 @@
+import { ThemeToggle } from '@dorkroom/ui';
+
+// The default desktop nav toggle: a round icon button showing the active
+// theme's icon. Clicking opens a theme menu (Dark / Light / High Contrast /
+// Darkroom / System).
+export const Icon = () => (
+  <div style={{ maxWidth: 80 }}>
+    <ThemeToggle variant="icon" />
+  </div>
+);
+
+// The labelled pill variant with a chevron, used in settings-style menus.
+export const Button = () => (
+  <div style={{ maxWidth: 220 }}>
+    <ThemeToggle variant="button" />
+  </div>
+);
+
+// The stacked tile variant for the mobile grid.
+export const Grid = () => (
+  <div style={{ maxWidth: 120 }}>
+    <ThemeToggle variant="grid" />
+  </div>
+);
+
+// The sidebar footer variant — a full-width labelled control.
+export const Sidebar = () => (
+  <div style={{ maxWidth: 160 }}>
+    <ThemeToggle variant="sidebar" />
+  </div>
+);

--- a/.design-sync/previews/Toast.tsx
+++ b/.design-sync/previews/Toast.tsx
@@ -1,0 +1,38 @@
+import { Toast } from '@dorkroom/ui';
+
+// Toast is position:fixed (top-right of its viewport) and auto-dismisses after
+// `duration` ms. We give it a very long duration so it stays on screen for the
+// static capture, and relative-position the wrapper so the toast anchors here.
+
+// Success — surface card with a green border and a check icon.
+export const Success = () => (
+  <div style={{ maxWidth: 380, position: 'relative', minHeight: 64 }}>
+    <Toast
+      message="Recipe saved to your favorites"
+      type="success"
+      duration={600000}
+    />
+  </div>
+);
+
+// Error — red border, X icon.
+export const Error = () => (
+  <div style={{ maxWidth: 380, position: 'relative', minHeight: 64 }}>
+    <Toast
+      message="Couldn't reach the database. Try again."
+      type="error"
+      duration={600000}
+    />
+  </div>
+);
+
+// Info — neutral border, no icon.
+export const Info = () => (
+  <div style={{ maxWidth: 380, position: 'relative', minHeight: 64 }}>
+    <Toast
+      message="Link copied to clipboard"
+      type="info"
+      duration={600000}
+    />
+  </div>
+);

--- a/.design-sync/previews/ToggleSwitch.tsx
+++ b/.design-sync/previews/ToggleSwitch.tsx
@@ -1,0 +1,36 @@
+import { ToggleSwitch } from '@dorkroom/ui';
+import { useState } from 'react';
+
+// Canonical settings toggle — controlled, starts on.
+export const EnableAnimations = () => {
+  const [on, setOn] = useState(true);
+  return (
+    <div style={{ maxWidth: 280 }}>
+      <ToggleSwitch
+        label="Enable animations"
+        value={on}
+        onValueChange={setOn}
+      />
+    </div>
+  );
+};
+
+// Off and on side by side — the primary on/off visual axis.
+export const States = () => {
+  const [enableOffset, setEnableOffset] = useState(true);
+  const [ignoreMinBorder, setIgnoreMinBorder] = useState(false);
+  return (
+    <div style={{ maxWidth: 280, display: 'grid', gap: 14 }}>
+      <ToggleSwitch
+        label="Enable offsets"
+        value={enableOffset}
+        onValueChange={setEnableOffset}
+      />
+      <ToggleSwitch
+        label="Ignore min border"
+        value={ignoreMinBorder}
+        onValueChange={setIgnoreMinBorder}
+      />
+    </div>
+  );
+};

--- a/.design-sync/previews/ToolCard.tsx
+++ b/.design-sync/previews/ToolCard.tsx
@@ -1,0 +1,61 @@
+import { ToolCard } from '@dorkroom/ui';
+import { Crop, FlaskConical, Gauge, Ruler, Timer } from 'lucide-react';
+
+// A single tool entry — the canonical home-page composition.
+export const Default = () => (
+  <div style={{ maxWidth: 280 }}>
+    <ToolCard
+      category="Printing"
+      title="Border Calculator"
+      description="Print borders & trim guides"
+      href="/border"
+      icon={Crop}
+      accent="indigo"
+    />
+  </div>
+);
+
+// The accent axis swept across a few real calculators.
+export const Accents = () => (
+  <div
+    style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(2, minmax(220px, 1fr))',
+      gap: 16,
+      maxWidth: 520,
+    }}
+  >
+    <ToolCard
+      category="Printing"
+      title="Stops Calculator"
+      description="F-stop & time math"
+      href="/stops"
+      icon={Gauge}
+      accent="blue"
+    />
+    <ToolCard
+      category="Printing"
+      title="Resize Calculator"
+      description="Scale prints, no wasting test strips"
+      href="/resize"
+      icon={Ruler}
+      accent="teal"
+    />
+    <ToolCard
+      category="Film"
+      title="Reciprocity"
+      description="Film long exposure correction"
+      href="/reciprocity"
+      icon={Timer}
+      accent="amber"
+    />
+    <ToolCard
+      category="Film"
+      title="Film Development Recipes"
+      description="B&W film development database"
+      href="/development"
+      icon={FlaskConical}
+      accent="rose"
+    />
+  </div>
+);

--- a/.design-sync/previews/Tooltip.tsx
+++ b/.design-sync/previews/Tooltip.tsx
@@ -1,0 +1,40 @@
+import { Tooltip } from '@dorkroom/ui';
+import { Github, Settings } from 'lucide-react';
+
+// Tooltip reveals its label only on hover / focus (CSS group-hover), so a static
+// capture shows the trigger; the bubble appears on interaction. We compose it
+// around realistic icon-button triggers, mirroring the app's top-nav usage.
+
+const triggerStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 40,
+  height: 40,
+  borderRadius: 10,
+  border: '1px solid var(--color-border-secondary)',
+  backgroundColor: 'var(--color-surface)',
+  color: 'var(--color-text-secondary)',
+};
+
+// Bottom-positioned tooltip (default) around a GitHub icon button.
+export const Bottom = () => (
+  <div style={{ maxWidth: 280, padding: '8px 0' }}>
+    <Tooltip label="Contribute on GitHub" position="bottom">
+      <span style={triggerStyle}>
+        <Github className="size-5" />
+      </span>
+    </Tooltip>
+  </div>
+);
+
+// Top-positioned tooltip around a Settings icon button.
+export const Top = () => (
+  <div style={{ maxWidth: 280, padding: '8px 0' }}>
+    <Tooltip label="Settings" position="top">
+      <span style={triggerStyle}>
+        <Settings className="size-5" />
+      </span>
+    </Tooltip>
+  </div>
+);

--- a/.design-sync/previews/UnitToggle.tsx
+++ b/.design-sync/previews/UnitToggle.tsx
@@ -1,0 +1,48 @@
+import { UnitToggle } from '@dorkroom/ui';
+import { useState } from 'react';
+
+// Canonical generic two-option toggle — measurement units (in | cm).
+export const Measurement = () => {
+  const [unit, setUnit] = useState('imperial');
+  return (
+    <div style={{ maxWidth: 200 }}>
+      <UnitToggle
+        currentUnit={unit}
+        onToggle={() =>
+          setUnit((u) => (u === 'imperial' ? 'metric' : 'imperial'))
+        }
+        options={[
+          { value: 'imperial', label: 'in' },
+          { value: 'metric', label: 'cm' },
+        ]}
+        ariaLabel="Measurement unit"
+      />
+    </div>
+  );
+};
+
+// The selection axis: left option active vs right option active.
+export const Selected = () => {
+  return (
+    <div style={{ maxWidth: 220, display: 'grid', gap: 12 }}>
+      <UnitToggle
+        currentUnit="ml"
+        onToggle={() => {}}
+        options={[
+          { value: 'ml', label: 'ml' },
+          { value: 'floz', label: 'fl oz' },
+        ]}
+        ariaLabel="Volume unit"
+      />
+      <UnitToggle
+        currentUnit="floz"
+        onToggle={() => {}}
+        options={[
+          { value: 'ml', label: 'ml' },
+          { value: 'floz', label: 'fl oz' },
+        ]}
+        ariaLabel="Volume unit"
+      />
+    </div>
+  );
+};

--- a/.design-sync/previews/VolumeUnitToggle.tsx
+++ b/.design-sync/previews/VolumeUnitToggle.tsx
@@ -1,0 +1,9 @@
+import { VolumeUnitToggle } from '@dorkroom/ui';
+
+// Context-driven toggle (ml | fl oz) used in the development-recipe volume mixer.
+// Reads/writes the global VolumeProvider, so it takes no props.
+export const Default = () => (
+  <div style={{ maxWidth: 200 }}>
+    <VolumeUnitToggle />
+  </div>
+);

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,10 @@ og-previews/
 
 **/*.tsbuildinfo
 .mcp.json
+
+# design-sync (claude.ai/design import)
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules


### PR DESCRIPTION
Imports the **@dorkroom/ui** design system to [Claude Design](https://claude.ai/design) (project: [Dorkroom UI](https://claude.ai/design/p/66b5be48-c524-47a9-a36f-da0157032914)), so Claude's design agent builds UI with our real, compiled components.

## What's in this PR
Sync **inputs only** (no app/runtime code changes). Build output (`ds-bundle/`, `.ds-sync/`, generated CSS) and campaign state (`.design-sync/.cache/`) are gitignored.

- **`.design-sync/config.json`** — package-shape converter config: TS-source bundle entry, dark-theme preview provider, compiled Tailwind CSS as `cssEntry`, `@fontsource-variable` fonts, and `cardMode` overrides for modals/drawers/wide cards.
- **`.design-sync/preview-provider.mjs`** — wraps previews in the full context chain (Theme/Measurement/Temperature/Volume/Toast) and forces the brand **dark** theme + dark canvas.
- **`.design-sync/build-ds-css.mjs`** — compiles the app's Tailwind CSS 4 stylesheet (tokens + utilities) into a single file the bundle consumes.
- **`.design-sync/conventions.md`** — header injected into the design agent: provider setup, the semantic token/utility vocabulary, and an idiomatic example (validated against the build).
- **`.design-sync/NOTES.md`** — re-sync gotchas, the reusable authoring playbook, and known-benign render warnings.
- **`.design-sync/previews/*.tsx`** — 48 hand-authored, graded preview compositions built from the app's real content.

## Result
- 53 components imported (48 with rich preview cards, 108 cells all graded good; 5 providers on floor cards by design).
- Render check 53/53 clean; `package-validate` exits 0.
- Re-syncs reuse these inputs (plus the uploaded `_ds_sync.json` anchor) and are fast/deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)