### PR TITLE
feat(mobile): iOS Shortcuts support — quick actions, App Intents, dedicated light meter

### DIFF
--- a/apps/mobile/CHANGELOG.md
+++ b/apps/mobile/CHANGELOG.md
@@ -24,6 +24,8 @@ This project uses [CalVer](https://calver.org/) date-based versioning: `YYYY.MM.
   summary-row → bottom-sheet layout. Preview geometry, blade-reading
   positioning, and formatting are pure, unit-tested modules; sliders use
   `@react-native-community/slider`.
+- iOS home screen quick actions: long-pressing the app icon now shows shortcuts
+  that jump straight to the Light Meter, Border, Exposure, and Reciprocity pages.
 
 ### Changed
 

--- a/apps/mobile/CHANGELOG.md
+++ b/apps/mobile/CHANGELOG.md
@@ -26,6 +26,11 @@ This project uses [CalVer](https://calver.org/) date-based versioning: `YYYY.MM.
   `@react-native-community/slider`.
 - iOS home screen quick actions: long-pressing the app icon now shows shortcuts
   that jump straight to the Light Meter, Border, Exposure, and Reciprocity pages.
+- iOS Siri / Spotlight / Shortcuts-app support (App Intents): "Open Light Meter
+  in Dorkroom" and the equivalent for Border, Exposure, and Reciprocity now work
+  by voice, in Spotlight, and as Shortcuts-app actions. A "Calculate Reciprocity"
+  action is present as a placeholder ("coming soon") ahead of functional
+  calculator intents.
 
 ### Changed
 

--- a/apps/mobile/CHANGELOG.md
+++ b/apps/mobile/CHANGELOG.md
@@ -31,6 +31,9 @@ This project uses [CalVer](https://calver.org/) date-based versioning: `YYYY.MM.
   by voice, in Spotlight, and as Shortcuts-app actions. A "Calculate Reciprocity"
   action is present as a placeholder ("coming soon") ahead of functional
   calculator intents.
+- A dedicated "Open Light Meter" Shortcuts/Siri action (separate from the generic
+  open-page shortcuts) so the light meter can be assigned to the iPhone Action
+  Button for one-press access.
 
 ### Changed
 

--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -1,0 +1,219 @@
+# CLAUDE.md — `@dorkroom/mobile` (iOS app)
+
+The native iOS app (Expo / React Native). It reuses `@dorkroom/logic` and
+`@dorkroom/api` from the monorepo and renders them with a dark, Liquid-Glass UI.
+
+> Read the root `/CLAUDE.md` first — monorepo-wide rules (no `any`, no internal
+> package paths, CalVer, toolchain) apply here too. This file covers what is
+> **specific to the mobile app**. `apps/mobile/README.md` has the full build /
+> credentials / code-sharing reference; this file is the day-to-day conventions
+> and the build-vs-reload decision guide.
+
+## Before you start
+
+1. **Use Context7** for Expo, Expo Router, NativeWind, React Native, and
+   `react-native-vision-camera` docs before changing how they're used.
+2. This app is **iOS-only**, **dark-only**, targets **iOS 26**, and runs on the
+   **New Architecture**.
+
+## Structure
+
+```
+app/                     # expo-router file-based routes (typed routes on)
+  _layout.tsx            # root Stack — installs polyfills, forces dark, providers
+  (tabs)/
+    _layout.tsx          # NativeTabs + SF Symbol icons; useQuickActionRouting lives HERE
+    index.tsx            # Border   exposure.tsx  reciprocity.tsx  resize.tsx  meter.tsx
+src/
+  components/            # PascalCase exports, kebab-case files; feature folders (border/, meter/)
+  hooks/                 # mobile-only hooks (camera, calibration)
+  lib/                   # MMKV-backed stores, native helpers
+  theme/tokens.ts        # palette mirrored from web, for non-className values
+  providers/             # query-client
+  polyfills/             # MMKV localStorage shim, Hermes polyfills (loaded from index.js)
+```
+
+Path alias: `@/*` → `src/*` (see `tsconfig.json`).
+
+## Conventions
+
+### Routing & screens
+
+- **expo-router v6** with file-based, **typed routes** (`experiments.typedRoutes`).
+  Tabs use `expo-router/unstable-native-tabs` (`NativeTabs`), each `Trigger` with
+  an `<Icon sf="…">` SF Symbol and `<Label>`.
+- **Dark only.** Don't add light-mode branches. `app/_layout.tsx` forces
+  `Appearance.setColorScheme('dark')`, uses `DarkTheme`, `StatusBar style="light"`,
+  and `headerShown: false`. `app.json` sets `userInterfaceStyle: "dark"`.
+- **Screens are thin view layers.** A screen is a default-exported
+  `PascalCaseScreen`, pulls all state/logic from a shared `@dorkroom/logic` hook
+  (e.g. `useExposureCalculator`), and composes `<Screen>` + `GlassCard` + row
+  components. Don't put calculator math in a screen — it belongs in `@dorkroom/logic`.
+- **No in-page title header.** The tab bar already labels the screen, so don't
+  render a redundant `<Text>Reciprocity</Text>` heading. Newer screens (Border,
+  Meter) follow this; `exposure.tsx`, `reciprocity.tsx`, `resize.tsx` predate it
+  and still carry a `text-2xl` title — match the newer screens for new work, and
+  drop those titles if you touch those files.
+- Wrap normal content in `<Screen>` (scrolls, padding 16, gap 16, bg `#0b0b0c`).
+  Full-bleed screens (the camera meter) skip it.
+
+### Styling
+
+- **NativeWind v4 with Tailwind v3 syntax** via `className`. This is **Tailwind
+  v3**, not the web app's v4 — don't use v4-only utilities. (A `postinstall`
+  script symlinks v3 into NativeWind; see README "How code is shared".)
+- Palette in practice: bg `#0b0b0c`, text `text-white` / `text-white/60..80`,
+  accent `bg-rose-600` / `text-rose-400`, pills `rounded-full`, cards
+  `rounded-2xl`/`rounded-xl`. For values that can't be a class (sizes passed to
+  native props, computed colors) use `theme/tokens.ts`.
+- Prefer `GlassCard` for surfaces — Liquid Glass on iOS 26, translucent
+  `bg-white/10` fallback elsewhere. Capability checks are computed **once at
+  import**, never per render (see `glass-card.tsx`).
+
+### Components
+
+- PascalCase names, kebab-case files; props interface named `ComponentNameProps`;
+  accept an optional `className`. Generic when it removes duplication
+  (`OptionRow<T>`).
+- Co-locate a feature's pieces in a subfolder with their **pure** helpers and
+  `*.test.ts` beside them (`components/border/geometry.ts` + `geometry.test.ts`).
+  Keep geometry/format/layout math pure and tested; keep the `.tsx` a thin renderer.
+
+### Persistence & data
+
+- Storage is **synchronous MMKV**. Two patterns:
+  - Shared `@dorkroom/logic` hooks read/write `globalThis.localStorage` — backed
+    by the MMKV shim installed in `app/_layout.tsx` via `installLocalStorage()`.
+    That call **must** stay first, before anything reads persisted state.
+  - Mobile-only state uses `new MMKV({ id: '…' })` directly with a named id
+    (`meter-settings.ts`, `meter-calibration.ts`). Pull defaults from
+    `@dorkroom/logic` constants and guard reads with `Number.isFinite`.
+- Server data goes through TanStack Query (`providers/query-client.ts`:
+  no window-focus refetch, retry 2, 5-min `staleTime`).
+
+### Shared code (the sharp edges)
+
+- Import only from `@dorkroom/logic` / `@dorkroom/api` — **never** internal paths.
+  Metro resolves these from each package's **`src`** (no `turbo build` needed) and
+  picks up `.native.ts` overrides.
+- `react`/`react-dom` are hard-pinned to the app's copy in `metro.config.js`;
+  MMKV needs `react-native-nitro-modules` or the app **segfaults** on first use;
+  Hermes is missing `Array.prototype.toSorted` (polyfilled in `index.js`). Don't
+  "fix" these by editing the resolver without understanding the README notes.
+
+### Quality gate (run from `apps/mobile`)
+
+```bash
+bun run test        # vitest — pure modules only (see Testing)
+bun run typecheck   # tsc --noEmit, strict, no `any`
+bun run lint        # oxlint (lint) + biome (formatting only)
+```
+
+- **Testing reality:** only **pure** modules are unit-tested (geometry, format,
+  layout, and the EV/solver math that lives in `@dorkroom/logic`). Camera, native
+  modules, navigation, config plugins, and quick actions are **not** unit-testable
+  here — verify those **on device** (see below). Don't write fake tests that mock
+  native behavior to manufacture coverage.
+
+### Versioning
+
+- The mobile app versions **independently** from the web app: its own
+  `apps/mobile/CHANGELOG.md` and its own CalVer in `apps/mobile/package.json`.
+  Web-app changes go in the root `CHANGELOG.md`. Don't mix them.
+
+---
+
+## Build vs. reload — decide by what changed
+
+Three workflows, cheapest first. Pick the **cheapest one that covers your
+change**. Full commands and credential setup are in `apps/mobile/README.md`.
+
+### 1. Just reload Metro — for JS/TS-only changes
+
+Use when you changed **only** JavaScript/TypeScript: components, screens, hooks,
+styling (`className`), types, or shared logic in `@dorkroom/logic` /
+`@dorkroom/api`. The installed dev client picks it up over Fast Refresh — no
+rebuild.
+
+```bash
+cd apps/mobile
+bunx expo start --dev-client --host lan        # phone on same Wi-Fi; save → hot reload
+```
+
+Restart Metro with `--clear` (not a native rebuild) when the **bundler** config
+changes or its cache goes stale: edits to `metro.config.js`, `babel.config.js`,
+`global.css`/Tailwind config, adding/removing a **JS-only** dependency, or weird
+stale-module errors.
+
+```bash
+bunx expo start --dev-client --host lan --clear
+```
+
+### 2. New **development build** — for native changes (dev client over Metro)
+
+Rebuild the native dev client when the change touches **native code or native
+config**, because Metro can't hot-reload native:
+
+- adding / removing / upgrading a dependency with **native iOS code** (e.g.
+  `expo-quick-actions`, `react-native-vision-camera`, anything with a config plugin)
+- editing the **`plugins`** array in `app.json` or a plugin's options
+- changing native iOS config: `Info.plist` keys, **permission/usage strings**,
+  the **URL scheme**, bundle id, **deployment target**, app icon / splash
+- **home-screen quick actions / SF Symbol shortcut items**, entitlements
+
+```bash
+source ~/.app-store-connect/eas-asc.env
+cd apps/mobile
+eas build --local --profile development --platform ios --non-interactive \
+  --output /tmp/dorkroom-dev.ipa
+```
+
+Then install + launch on the connected device, and have Metro running so it
+loads JS at runtime:
+
+```bash
+DEV=$(xcrun devicectl list devices | awk '/connected/ && /iPhone/ {print $3; exit}')
+xcrun devicectl device install app --device "$DEV" /tmp/dorkroom-dev.ipa
+xcrun devicectl device process launch --device "$DEV" art.dorkroom.mobile
+```
+
+Sanity-check that a config-plugin change actually landed by reading the built
+plist before installing, e.g.:
+
+```bash
+unzip -o -q /tmp/dorkroom-dev.ipa "Payload/Dorkroom.app/Info.plist" -d /tmp/dr-check
+plutil -p /tmp/dr-check/Payload/Dorkroom.app/Info.plist | grep -A20 ShortcutItems
+```
+
+### 3. **Standalone (non-Metro) build** — self-contained, no Mac/Metro
+
+Use the **preview** profile when the build must run on the phone **without** a
+dev machine or Metro — the JS is bundled in (release mode):
+
+- testing on-device away from your machine, or handing a build to someone else
+- demos, field testing, internal distribution
+- verifying the **production-like release bundle** (minified JS, no dev menu)
+  behaves the same as dev
+
+```bash
+source ~/.app-store-connect/eas-asc.env
+cd apps/mobile
+eas build --local --profile preview --platform ios --non-interactive \
+  --output /tmp/dorkroom-preview.ipa
+# install/launch with the same devicectl commands as above
+```
+
+### Which one for a given request?
+
+| Your change / request | Workflow |
+| --- | --- |
+| "Tweak this screen / calculator / style / shared hook" | **1. Reload Metro** |
+| "I changed metro/babel/tailwind config" or cache is stale | **1. Reload with `--clear`** |
+| "Add a native module / change app.json plugins / permissions / icon / shortcuts" | **2. Dev build** + reinstall |
+| "Test on my phone without Metro / share a build / demo / check the release bundle" | **3. Preview build** |
+
+When in doubt: if Metro Fast Refresh shows the change, you didn't need a build;
+if it doesn't and the change was native, you needed **#2**.
+
+> One-time prerequisites for #2/#3 (Expo login, App Store Connect API key because
+> Apple 2FA is YubiKey-only, device registration): see `apps/mobile/README.md`.

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -24,6 +24,37 @@
             "deploymentTarget": "26.0"
           }
         }
+      ],
+      [
+        "expo-quick-actions",
+        {
+          "iosActions": [
+            {
+              "id": "meter",
+              "title": "Light Meter",
+              "icon": "symbol:camera.aperture",
+              "params": { "href": "/meter" }
+            },
+            {
+              "id": "border",
+              "title": "Border",
+              "icon": "symbol:square.dashed",
+              "params": { "href": "/" }
+            },
+            {
+              "id": "exposure",
+              "title": "Exposure",
+              "icon": "symbol:plusminus",
+              "params": { "href": "/exposure" }
+            },
+            {
+              "id": "reciprocity",
+              "title": "Reciprocity",
+              "icon": "symbol:timer",
+              "params": { "href": "/reciprocity" }
+            }
+          ]
+        }
       ]
     ],
     "experiments": {

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -55,7 +55,8 @@
             }
           ]
         }
-      ]
+      ],
+      "./plugins/with-app-intents"
     ],
     "experiments": {
       "typedRoutes": true

--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -1,6 +1,12 @@
+import { useQuickActionRouting } from 'expo-quick-actions/router';
 import { Icon, Label, NativeTabs } from 'expo-router/unstable-native-tabs';
 
 export default function TabsLayout() {
+  // Route home-screen quick action taps to the action's `params.href`. The
+  // library requires this in a sub-layout (not the root layout) so the target
+  // navigator is mounted before the cold-launch action navigates.
+  useQuickActionRouting();
+
   return (
     <NativeTabs>
       <NativeTabs.Trigger name="index">

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -5,6 +5,7 @@ installLocalStorage();
 
 import { DarkTheme, ThemeProvider } from '@react-navigation/native';
 import { QueryClientProvider } from '@tanstack/react-query';
+import { useQuickActionRouting } from 'expo-quick-actions/router';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { Appearance } from 'react-native';
@@ -17,6 +18,9 @@ import { queryClient } from '@/providers/query-client';
 Appearance.setColorScheme('dark');
 
 export default function RootLayout() {
+  // Route home-screen quick action taps to the action's `params.href`.
+  useQuickActionRouting();
+
   return (
     <SafeAreaProvider>
       <QueryClientProvider client={queryClient}>

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -5,7 +5,6 @@ installLocalStorage();
 
 import { DarkTheme, ThemeProvider } from '@react-navigation/native';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { useQuickActionRouting } from 'expo-quick-actions/router';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { Appearance } from 'react-native';
@@ -18,9 +17,6 @@ import { queryClient } from '@/providers/query-client';
 Appearance.setColorScheme('dark');
 
 export default function RootLayout() {
-  // Route home-screen quick action taps to the action's `params.href`.
-  useQuickActionRouting();
-
   return (
     <SafeAreaProvider>
       <QueryClientProvider client={queryClient}>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -29,6 +29,7 @@
     "expo-glass-effect": "^0.1.0",
     "expo-haptics": "~15.0.8",
     "expo-linear-gradient": "~15.0.8",
+    "expo-quick-actions": "^6.0.2",
     "expo-router": "^6.0.0",
     "expo-status-bar": "^3.0.0",
     "expo-symbols": "~1.0.8",

--- a/apps/mobile/plugins/with-app-intents/index.js
+++ b/apps/mobile/plugins/with-app-intents/index.js
@@ -1,0 +1,57 @@
+const { withDangerousMod, withXcodeProject } = require('@expo/config-plugins');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// The Swift App Intents sources (in ./swift), copied into ios/AppIntents/ and
+// compiled into the app target. Order is irrelevant; all go to the same target.
+const SWIFT_FILES = [
+  'OpenPageIntent.swift',
+  'DorkroomShortcuts.swift',
+  'CalculateReciprocityIntent.swift',
+];
+
+const GROUP = 'AppIntents';
+
+// Stage 1 — copy the Swift files into ios/AppIntents/ at prebuild.
+function withAppIntentsFiles(config) {
+  return withDangerousMod(config, [
+    'ios',
+    (cfg) => {
+      const srcDir = path.join(__dirname, 'swift');
+      const dstDir = path.join(cfg.modRequest.platformProjectRoot, GROUP);
+      fs.mkdirSync(dstDir, { recursive: true });
+      for (const file of SWIFT_FILES) {
+        fs.copyFileSync(path.join(srcDir, file), path.join(dstDir, file));
+      }
+      return cfg;
+    },
+  ]);
+}
+
+// Stage 2 — add the copied files to the app target's compile sources.
+// Idempotent: a re-run of prebuild must not add duplicate references.
+function withAppIntentsBuildPhase(config) {
+  return withXcodeProject(config, (cfg) => {
+    const project = cfg.modResults;
+    const target = project.getFirstTarget().uuid;
+
+    if (!project.pbxGroupByName(GROUP)) {
+      project.addPbxGroup([], GROUP, GROUP);
+    }
+
+    for (const file of SWIFT_FILES) {
+      const relPath = `${GROUP}/${file}`;
+      if (project.hasFile(relPath)) {
+        continue; // already referenced — keep prebuild idempotent
+      }
+      project.addSourceFile(relPath, { target }, GROUP);
+    }
+    return cfg;
+  });
+}
+
+module.exports = function withAppIntents(config) {
+  config = withAppIntentsFiles(config);
+  config = withAppIntentsBuildPhase(config);
+  return config;
+};

--- a/apps/mobile/plugins/with-app-intents/index.js
+++ b/apps/mobile/plugins/with-app-intents/index.js
@@ -34,17 +34,19 @@ function withAppIntentsBuildPhase(config) {
   return withXcodeProject(config, (cfg) => {
     const project = cfg.modResults;
     const target = project.getFirstTarget().uuid;
-
-    if (!project.pbxGroupByName(GROUP)) {
-      project.addPbxGroup([], GROUP, GROUP);
-    }
+    // addSourceFile's 3rd arg is a group KEY (uuid), not a name. Add the files
+    // to the project's existing main group with their `AppIntents/<file>` path
+    // (sourceTree '<group>' resolves it under SOURCE_ROOT → ios/AppIntents/…).
+    const mainGroup = project.getFirstProject().firstProject.mainGroup;
 
     for (const file of SWIFT_FILES) {
       const relPath = `${GROUP}/${file}`;
+      // hasFile matches the stored PBXFileReference path, which is this same
+      // `AppIntents/<file>` string — so re-running prebuild stays idempotent.
       if (project.hasFile(relPath)) {
-        continue; // already referenced — keep prebuild idempotent
+        continue;
       }
-      project.addSourceFile(relPath, { target }, GROUP);
+      project.addSourceFile(relPath, { target }, mainGroup);
     }
     return cfg;
   });

--- a/apps/mobile/plugins/with-app-intents/index.js
+++ b/apps/mobile/plugins/with-app-intents/index.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 // compiled into the app target. Order is irrelevant; all go to the same target.
 const SWIFT_FILES = [
   'OpenPageIntent.swift',
+  'OpenLightMeterIntent.swift',
   'DorkroomShortcuts.swift',
   'CalculateReciprocityIntent.swift',
 ];

--- a/apps/mobile/plugins/with-app-intents/swift/CalculateReciprocityIntent.swift
+++ b/apps/mobile/plugins/with-app-intents/swift/CalculateReciprocityIntent.swift
@@ -1,0 +1,21 @@
+import AppIntents
+
+// Phase 2b seed: a functional calculator intent. This is a STUB — it returns a
+// "coming soon" dialog. Wiring it to the real reciprocity math in @dorkroom/logic
+// requires sharing data with the JS layer (App Group + a native bridge), which is
+// intentionally out of scope for Phase 2. It is deliberately NOT listed in
+// DorkroomShortcuts, so it is discoverable as an action in the Shortcuts app but
+// is not advertised as a Siri phrase.
+struct CalculateReciprocityIntent: AppIntent {
+    static var title: LocalizedStringResource = "Calculate Reciprocity"
+    static var description = IntentDescription(
+        "Adjust a metered exposure time for reciprocity failure. (Coming soon.)"
+    )
+
+    @Parameter(title: "Metered seconds")
+    var meteredSeconds: Double
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        return .result(dialog: "Calculator Shortcuts are coming soon to Dorkroom.")
+    }
+}

--- a/apps/mobile/plugins/with-app-intents/swift/DorkroomShortcuts.swift
+++ b/apps/mobile/plugins/with-app-intents/swift/DorkroomShortcuts.swift
@@ -1,0 +1,45 @@
+import AppIntents
+
+/// Auto-registers the open-page App Shortcuts with Siri, Spotlight, and the
+/// Shortcuts app. Every phrase includes `\(.applicationName)` (required, or the
+/// shortcut is dropped at build-time indexing).
+struct DorkroomShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: OpenPageIntent(page: .meter),
+            phrases: [
+                "Open Light Meter in \(.applicationName)",
+                "Open \(.applicationName) Light Meter",
+            ],
+            shortTitle: "Light Meter",
+            systemImageName: "camera.aperture"
+        )
+        AppShortcut(
+            intent: OpenPageIntent(page: .border),
+            phrases: [
+                "Open Border in \(.applicationName)",
+                "Open \(.applicationName) Border calculator",
+            ],
+            shortTitle: "Border",
+            systemImageName: "square.dashed"
+        )
+        AppShortcut(
+            intent: OpenPageIntent(page: .exposure),
+            phrases: [
+                "Open Exposure in \(.applicationName)",
+                "Open \(.applicationName) Exposure calculator",
+            ],
+            shortTitle: "Exposure",
+            systemImageName: "plusminus"
+        )
+        AppShortcut(
+            intent: OpenPageIntent(page: .reciprocity),
+            phrases: [
+                "Open Reciprocity in \(.applicationName)",
+                "Open \(.applicationName) Reciprocity calculator",
+            ],
+            shortTitle: "Reciprocity",
+            systemImageName: "timer"
+        )
+    }
+}

--- a/apps/mobile/plugins/with-app-intents/swift/DorkroomShortcuts.swift
+++ b/apps/mobile/plugins/with-app-intents/swift/DorkroomShortcuts.swift
@@ -6,6 +6,16 @@ import AppIntents
 struct DorkroomShortcuts: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {
         AppShortcut(
+            intent: OpenLightMeterIntent(),
+            phrases: [
+                "Open the light meter in \(.applicationName)",
+                "Start \(.applicationName) light meter",
+                "Meter the light with \(.applicationName)",
+            ],
+            shortTitle: "Light Meter",
+            systemImageName: "camera.aperture"
+        )
+        AppShortcut(
             intent: OpenPageIntent(page: .meter),
             phrases: [
                 "Open Light Meter in \(.applicationName)",

--- a/apps/mobile/plugins/with-app-intents/swift/OpenLightMeterIntent.swift
+++ b/apps/mobile/plugins/with-app-intents/swift/OpenLightMeterIntent.swift
@@ -1,0 +1,15 @@
+import AppIntents
+import UIKit
+
+/// A dedicated, parameter-free intent to open the light meter — the natural pick
+/// for the Action Button, Control Center, or a one-tap Siri/Spotlight shortcut.
+struct OpenLightMeterIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Light Meter"
+    static var openAppWhenRun = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        await UIApplication.shared.open(URL(string: "dorkroom://meter")!)
+        return .result()
+    }
+}

--- a/apps/mobile/plugins/with-app-intents/swift/OpenPageIntent.swift
+++ b/apps/mobile/plugins/with-app-intents/swift/OpenPageIntent.swift
@@ -1,0 +1,50 @@
+import AppIntents
+import UIKit
+
+/// The Dorkroom pages reachable from an App Shortcut.
+enum DorkroomPage: String, AppEnum {
+    case meter
+    case border
+    case exposure
+    case reciprocity
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation = "Dorkroom Page"
+
+    static var caseDisplayRepresentations: [DorkroomPage: DisplayRepresentation] = [
+        .meter: "Light Meter",
+        .border: "Border",
+        .exposure: "Exposure",
+        .reciprocity: "Reciprocity",
+    ]
+
+    /// The `dorkroom://` deep link that opens this page. expo-router routes it.
+    var url: URL {
+        switch self {
+        case .meter: return URL(string: "dorkroom://meter")!
+        case .border: return URL(string: "dorkroom://")!
+        case .exposure: return URL(string: "dorkroom://exposure")!
+        case .reciprocity: return URL(string: "dorkroom://reciprocity")!
+        }
+    }
+}
+
+/// Opens the app on a specific page. Backs every open-page App Shortcut.
+struct OpenPageIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Dorkroom Page"
+    static var openAppWhenRun = true
+
+    @Parameter(title: "Page")
+    var page: DorkroomPage
+
+    init() {}
+
+    init(page: DorkroomPage) {
+        self.page = page
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        await UIApplication.shared.open(page.url)
+        return .result()
+    }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -82,7 +82,7 @@
     },
     "apps/mobile": {
       "name": "@dorkroom/mobile",
-      "version": "2026.6.21",
+      "version": "2026.6.22",
       "dependencies": {
         "@dorkroom/api": "workspace:*",
         "@dorkroom/logic": "workspace:*",
@@ -97,6 +97,7 @@
         "expo-glass-effect": "^0.1.0",
         "expo-haptics": "~15.0.8",
         "expo-linear-gradient": "~15.0.8",
+        "expo-quick-actions": "^6.0.2",
         "expo-router": "^6.0.0",
         "expo-status-bar": "^3.0.0",
         "expo-symbols": "~1.0.8",
@@ -1768,6 +1769,8 @@
     "expo-modules-autolinking": ["expo-modules-autolinking@3.0.26", "", { "dependencies": { "@expo/spawn-async": "^1.7.2", "chalk": "^4.1.0", "commander": "^7.2.0", "require-from-string": "^2.0.2", "resolve-from": "^5.0.0" }, "bin": { "expo-modules-autolinking": "bin/expo-modules-autolinking.js" } }, "sha512-WOaud6UKg16ciCOj8raKcMOoKFMHLXKI29U29yhgu1lf+Y7VxJyCktUcYo6AM+ccZ7zLD1uWZdMtgnpf+95OXA=="],
 
     "expo-modules-core": ["expo-modules-core@3.0.30", "", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-a6IrpAn/Jbmwxi9L+hMmXKpNqnkUpoF7WHOpn02rVLyax2J0gB1vvCVE5rNydplEnt41Q6WxQwvcOjZaIkcSUg=="],
+
+    "expo-quick-actions": ["expo-quick-actions@6.0.2", "", { "dependencies": { "@expo/image-utils": "^0.8.7", "schema-utils": "^4.3.2", "sf-symbols-typescript": "^2.1.0" }, "peerDependencies": { "expo": "*" } }, "sha512-IVoTMCx55MjSnPqUEb5jhePpOAUdOTonifY3QXM/DBFxc6qMzBy5iJWEkfDZcFAzFzahK1ZW9tFaNv4pi2AAvQ=="],
 
     "expo-router": ["expo-router@6.0.24", "", { "dependencies": { "@expo/metro-runtime": "^6.1.2", "@expo/schema-utils": "^0.1.8", "@radix-ui/react-slot": "1.2.0", "@radix-ui/react-tabs": "^1.1.12", "@react-navigation/bottom-tabs": "^7.4.0", "@react-navigation/native": "^7.1.8", "@react-navigation/native-stack": "^7.3.16", "client-only": "^0.0.1", "debug": "^4.3.4", "escape-string-regexp": "^4.0.0", "expo-server": "^1.0.7", "fast-deep-equal": "^3.1.3", "invariant": "^2.2.4", "nanoid": "^3.3.8", "query-string": "^7.1.3", "react-fast-compare": "^3.2.2", "react-native-is-edge-to-edge": "^1.1.6", "semver": "~7.6.3", "server-only": "^0.0.1", "sf-symbols-typescript": "^2.1.0", "shallowequal": "^1.1.0", "use-latest-callback": "^0.2.1", "vaul": "^1.1.2" }, "peerDependencies": { "@react-navigation/drawer": "^7.5.0", "@testing-library/react-native": ">= 12.0.0", "expo": "*", "expo-constants": "^18.0.13", "expo-linking": "^8.0.12", "react": "*", "react-dom": "*", "react-native": "*", "react-native-gesture-handler": "*", "react-native-reanimated": "*", "react-native-safe-area-context": ">= 5.4.0", "react-native-screens": "*", "react-native-web": "*", "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4" }, "optionalPeers": ["@react-navigation/drawer", "@testing-library/react-native", "react-dom", "react-native-gesture-handler", "react-native-reanimated", "react-native-web", "react-server-dom-webpack"] }, "sha512-KIssKXnwjrdCxPWC8GsMTfKTwng40VrCsO16O9x6fKlfUwBW8itxY9PpCGyQeMJkiEADa+DUhtrDgl+uHg4/DA=="],
 

--- a/docs/superpowers/plans/2026-06-22-ios-app-intents.md
+++ b/docs/superpowers/plans/2026-06-22-ios-app-intents.md
@@ -1,0 +1,446 @@
+# iOS Shortcuts / Siri (App Intents) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose Dorkroom's four pages to Siri, Spotlight, and the Shortcuts app via App Intents, and stub one functional calculator intent to seed Phase 2b.
+
+**Architecture:** A self-contained local Expo config plugin (`apps/mobile/plugins/with-app-intents/`) injects Swift App Intents into the iOS app target at prebuild — `withDangerousMod` copies `swift/*.swift` into `ios/AppIntents/`, then `withXcodeProject` adds them to the app target's compile sources. Open-page intents open the existing `dorkroom://` deep links, so navigation reuses expo-router's deep-linking with no new JS.
+
+**Tech Stack:** Expo SDK 54, Expo Router 6, `@expo/config-plugins`, Apple App Intents (Swift, iOS 16+ APIs), iOS 26 deployment target.
+
+## Global Constraints
+
+- Package manager is **`bun`** (`bun run …`). No new npm dependency is added in this plan.
+- **Swift files live at the iOS project root** (`ios/AppIntents/`), injected by the plugin — never inside an Expo module (breaks `AppShortcutsProvider` auto-registration).
+- **Every Siri phrase must include the `\(.applicationName)` macro** or the shortcut is dropped at build-time intent indexing.
+- **No entitlement and no `NSSiriUsageDescription`** are added — App Shortcuts (iOS 16+) need neither.
+- Deployment target is **iOS 26**, so `@available` annotations are unnecessary.
+- The config plugin must be **idempotent** — re-running prebuild must not create duplicate source build refs.
+- **No Swift/native or config-plugin unit tests** — consistent with the app convention; native behavior is verified by a real build + on-device test (see Integration Verification), not mocked. Do not invent such tests.
+- `apps/mobile/package.json` version is already today's CalVer — **do not bump it**; add a `apps/mobile/CHANGELOG.md` entry only.
+- `apps/mobile/ios/` is **not** git-tracked; prebuild output is never committed.
+
+---
+
+### Task 1: Swift App Intents sources
+
+**Files:**
+- Create: `apps/mobile/plugins/with-app-intents/swift/OpenPageIntent.swift`
+- Create: `apps/mobile/plugins/with-app-intents/swift/DorkroomShortcuts.swift`
+- Create: `apps/mobile/plugins/with-app-intents/swift/CalculateReciprocityIntent.swift`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: three Swift files that Task 2's plugin copies and compiles. The plugin depends on these **exact filenames**: `OpenPageIntent.swift`, `DorkroomShortcuts.swift`, `CalculateReciprocityIntent.swift`. `OpenPageIntent(page:)` is instantiated by `DorkroomShortcuts`. The open-page deep links are `dorkroom://meter`, `dorkroom://` (border/index), `dorkroom://exposure`, `dorkroom://reciprocity`.
+
+There is no automated test for Swift here (it compiles only in a real iOS build — see Integration Verification). Author the three files exactly as below.
+
+- [ ] **Step 1: Create `OpenPageIntent.swift`**
+
+`apps/mobile/plugins/with-app-intents/swift/OpenPageIntent.swift`:
+
+```swift
+import AppIntents
+import UIKit
+
+/// The Dorkroom pages reachable from an App Shortcut.
+enum DorkroomPage: String, AppEnum {
+    case meter
+    case border
+    case exposure
+    case reciprocity
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation = "Dorkroom Page"
+
+    static var caseDisplayRepresentations: [DorkroomPage: DisplayRepresentation] = [
+        .meter: "Light Meter",
+        .border: "Border",
+        .exposure: "Exposure",
+        .reciprocity: "Reciprocity",
+    ]
+
+    /// The `dorkroom://` deep link that opens this page. expo-router routes it.
+    var url: URL {
+        switch self {
+        case .meter: return URL(string: "dorkroom://meter")!
+        case .border: return URL(string: "dorkroom://")!
+        case .exposure: return URL(string: "dorkroom://exposure")!
+        case .reciprocity: return URL(string: "dorkroom://reciprocity")!
+        }
+    }
+}
+
+/// Opens the app on a specific page. Backs every open-page App Shortcut.
+struct OpenPageIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Dorkroom Page"
+    static var openAppWhenRun = true
+
+    @Parameter(title: "Page")
+    var page: DorkroomPage
+
+    init() {}
+
+    init(page: DorkroomPage) {
+        self.page = page
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        await UIApplication.shared.open(page.url)
+        return .result()
+    }
+}
+```
+
+- [ ] **Step 2: Create `DorkroomShortcuts.swift`**
+
+`apps/mobile/plugins/with-app-intents/swift/DorkroomShortcuts.swift`:
+
+```swift
+import AppIntents
+
+/// Auto-registers the open-page App Shortcuts with Siri, Spotlight, and the
+/// Shortcuts app. Every phrase includes `\(.applicationName)` (required, or the
+/// shortcut is dropped at build-time indexing).
+struct DorkroomShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: OpenPageIntent(page: .meter),
+            phrases: [
+                "Open Light Meter in \(.applicationName)",
+                "Open \(.applicationName) Light Meter",
+            ],
+            shortTitle: "Light Meter",
+            systemImageName: "camera.aperture"
+        )
+        AppShortcut(
+            intent: OpenPageIntent(page: .border),
+            phrases: [
+                "Open Border in \(.applicationName)",
+                "Open \(.applicationName) Border calculator",
+            ],
+            shortTitle: "Border",
+            systemImageName: "square.dashed"
+        )
+        AppShortcut(
+            intent: OpenPageIntent(page: .exposure),
+            phrases: [
+                "Open Exposure in \(.applicationName)",
+                "Open \(.applicationName) Exposure calculator",
+            ],
+            shortTitle: "Exposure",
+            systemImageName: "plusminus"
+        )
+        AppShortcut(
+            intent: OpenPageIntent(page: .reciprocity),
+            phrases: [
+                "Open Reciprocity in \(.applicationName)",
+                "Open \(.applicationName) Reciprocity calculator",
+            ],
+            shortTitle: "Reciprocity",
+            systemImageName: "timer"
+        )
+    }
+}
+```
+
+- [ ] **Step 3: Create `CalculateReciprocityIntent.swift` (stub)**
+
+`apps/mobile/plugins/with-app-intents/swift/CalculateReciprocityIntent.swift`:
+
+```swift
+import AppIntents
+
+// Phase 2b seed: a functional calculator intent. This is a STUB — it returns a
+// "coming soon" dialog. Wiring it to the real reciprocity math in @dorkroom/logic
+// requires sharing data with the JS layer (App Group + a native bridge), which is
+// intentionally out of scope for Phase 2. It is deliberately NOT listed in
+// DorkroomShortcuts, so it is discoverable as an action in the Shortcuts app but
+// is not advertised as a Siri phrase.
+struct CalculateReciprocityIntent: AppIntent {
+    static var title: LocalizedStringResource = "Calculate Reciprocity"
+    static var description = IntentDescription(
+        "Adjust a metered exposure time for reciprocity failure. (Coming soon.)"
+    )
+
+    @Parameter(title: "Metered seconds")
+    var meteredSeconds: Double
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        return .result(dialog: "Calculator Shortcuts are coming soon to Dorkroom.")
+    }
+}
+```
+
+- [ ] **Step 4: Verify the three files exist**
+
+Run:
+
+```bash
+ls apps/mobile/plugins/with-app-intents/swift/
+```
+
+Expected output (exactly these three):
+
+```
+CalculateReciprocityIntent.swift
+DorkroomShortcuts.swift
+OpenPageIntent.swift
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mobile/plugins/with-app-intents/swift/
+git commit -m "feat(mobile): add iOS App Intents Swift sources"
+```
+
+---
+
+### Task 2: Config plugin + register in `app.json`
+
+**Files:**
+- Create: `apps/mobile/plugins/with-app-intents/index.js`
+- Modify: `apps/mobile/app.json` (add the plugin to `plugins`)
+
+**Interfaces:**
+- Consumes: the three Swift filenames from Task 1 (listed in `SWIFT_FILES`).
+- Produces: a default-exported Expo config plugin `withAppIntents(config)` that, at prebuild, copies the Swift files to `ios/AppIntents/` and adds them to the app target's sources. Registered in `app.json` as `"./plugins/with-app-intents"`.
+
+- [ ] **Step 1: Create the config plugin `index.js`**
+
+`apps/mobile/plugins/with-app-intents/index.js`:
+
+```js
+const { withDangerousMod, withXcodeProject } = require('@expo/config-plugins');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// The Swift App Intents sources (in ./swift), copied into ios/AppIntents/ and
+// compiled into the app target. Order is irrelevant; all go to the same target.
+const SWIFT_FILES = [
+  'OpenPageIntent.swift',
+  'DorkroomShortcuts.swift',
+  'CalculateReciprocityIntent.swift',
+];
+
+const GROUP = 'AppIntents';
+
+// Stage 1 — copy the Swift files into ios/AppIntents/ at prebuild.
+function withAppIntentsFiles(config) {
+  return withDangerousMod(config, [
+    'ios',
+    (cfg) => {
+      const srcDir = path.join(__dirname, 'swift');
+      const dstDir = path.join(cfg.modRequest.platformProjectRoot, GROUP);
+      fs.mkdirSync(dstDir, { recursive: true });
+      for (const file of SWIFT_FILES) {
+        fs.copyFileSync(path.join(srcDir, file), path.join(dstDir, file));
+      }
+      return cfg;
+    },
+  ]);
+}
+
+// Stage 2 — add the copied files to the app target's compile sources.
+// Idempotent: a re-run of prebuild must not add duplicate references.
+function withAppIntentsBuildPhase(config) {
+  return withXcodeProject(config, (cfg) => {
+    const project = cfg.modResults;
+    const target = project.getFirstTarget().uuid;
+
+    if (!project.pbxGroupByName(GROUP)) {
+      project.addPbxGroup([], GROUP, GROUP);
+    }
+
+    for (const file of SWIFT_FILES) {
+      const relPath = `${GROUP}/${file}`;
+      if (project.hasFile(relPath)) {
+        continue; // already referenced — keep prebuild idempotent
+      }
+      project.addSourceFile(relPath, { target }, GROUP);
+    }
+    return cfg;
+  });
+}
+
+module.exports = function withAppIntents(config) {
+  config = withAppIntentsFiles(config);
+  config = withAppIntentsBuildPhase(config);
+  return config;
+};
+```
+
+- [ ] **Step 2: Register the plugin in `app.json`**
+
+In `apps/mobile/app.json`, the `plugins` array currently ends with the
+`expo-quick-actions` entry. Add `"./plugins/with-app-intents"` as the final
+element. The array should read:
+
+```json
+    "plugins": [
+      "expo-router",
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "deploymentTarget": "26.0"
+          }
+        }
+      ],
+      [
+        "expo-quick-actions",
+        {
+          "iosActions": [
+            {
+              "id": "meter",
+              "title": "Light Meter",
+              "icon": "symbol:camera.aperture",
+              "params": { "href": "/meter" }
+            },
+            {
+              "id": "border",
+              "title": "Border",
+              "icon": "symbol:square.dashed",
+              "params": { "href": "/" }
+            },
+            {
+              "id": "exposure",
+              "title": "Exposure",
+              "icon": "symbol:plusminus",
+              "params": { "href": "/exposure" }
+            },
+            {
+              "id": "reciprocity",
+              "title": "Reciprocity",
+              "icon": "symbol:timer",
+              "params": { "href": "/reciprocity" }
+            }
+          ]
+        }
+      ],
+      "./plugins/with-app-intents"
+    ],
+```
+
+- [ ] **Step 3: Verify `app.json` is valid JSON**
+
+Run:
+
+```bash
+cd apps/mobile && node -e "JSON.parse(require('fs').readFileSync('app.json','utf8')); console.log('app.json OK')"
+```
+
+Expected output:
+
+```
+app.json OK
+```
+
+- [ ] **Step 4: Smoke-test that the plugin module loads and is a function**
+
+Run:
+
+```bash
+cd apps/mobile && node -e "const p=require('./plugins/with-app-intents'); if(typeof p!=='function'){throw new Error('plugin export is not a function')} console.log('plugin loads OK')"
+```
+
+Expected output:
+
+```
+plugin loads OK
+```
+
+(This catches syntax errors and a bad `@expo/config-plugins` require without running a full prebuild.)
+
+- [ ] **Step 5: Lint**
+
+Run:
+
+```bash
+cd apps/mobile && bun run lint
+```
+
+Expected: exits 0 (no new oxlint/biome findings for `index.js`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mobile/plugins/with-app-intents/index.js apps/mobile/app.json
+git commit -m "feat(mobile): config plugin to wire App Intents into the iOS target"
+```
+
+> Note: do **not** run `expo prebuild` in this task — that is the controller-run Integration Verification step, which regenerates the untracked `ios/` directory.
+
+---
+
+### Task 3: Changelog entry
+
+**Files:**
+- Modify: `apps/mobile/CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: nothing. Produces: nothing (documentation only).
+
+- [ ] **Step 1: Add the entry under the current version's `### Added` section**
+
+In `apps/mobile/CHANGELOG.md`, under `## [2026.06.22]` → `### Added`, append this
+bullet as the last item of that list:
+
+```markdown
+- iOS Siri / Spotlight / Shortcuts-app support (App Intents): "Open Light Meter
+  in Dorkroom" and the equivalent for Border, Exposure, and Reciprocity now work
+  by voice, in Spotlight, and as Shortcuts-app actions. A "Calculate Reciprocity"
+  action is present as a placeholder ("coming soon") ahead of functional
+  calculator intents.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/mobile/CHANGELOG.md
+git commit -m "docs(mobile): changelog for iOS App Intents"
+```
+
+---
+
+## Integration Verification (controller + user — not a subagent task)
+
+Swift compiles and App Shortcuts register only in a real build, and the main
+implementation risk (pbxproj wiring vs. Xcode "synchronized" file groups) can
+only be confirmed by an actual prebuild. Run this after Task 3:
+
+1. **Prebuild** (regenerates the untracked `ios/`):
+   ```bash
+   cd apps/mobile && bunx expo prebuild --clean --platform ios
+   ```
+   Confirm `ios/AppIntents/` contains the three `.swift` files and that
+   `ios/Dorkroom.xcodeproj/project.pbxproj` references them (grep for
+   `OpenPageIntent.swift`). If the template uses synchronized file groups and the
+   files are auto-included but **not** via `addSourceFile`, adjust the plugin
+   (the file-copy stage may suffice on its own); if `addSourceFile` double-adds,
+   the `hasFile` guard should prevent it — verify no duplicate `PBXBuildFile`.
+2. **Development build + install** (per `apps/mobile/CLAUDE.md` workflow #2):
+   ```bash
+   source ~/.app-store-connect/eas-asc.env
+   cd apps/mobile
+   eas build --local --profile development --platform ios --non-interactive \
+     --output /tmp/dorkroom-dev.ipa
+   DEV=$(xcrun devicectl list devices | awk '/connected/ && /iPhone/ {print $3; exit}')
+   xcrun devicectl device install app --device "$DEV" /tmp/dorkroom-dev.ipa
+   xcrun devicectl device process launch --device "$DEV" art.dorkroom.mobile
+   ```
+   A successful build confirms the Swift compiled.
+3. **On-device (user):**
+   - **Spotlight:** search "Light Meter" → a Dorkroom shortcut appears → opens the Meter tab.
+   - **Siri:** "Open Light Meter in Dorkroom" → opens the Meter tab. Repeat per page.
+   - **Shortcuts app:** the four open-page actions appear, plus "Calculate Reciprocity", which returns the "coming soon" dialog.
+   - Confirm the **border** action lands on the Border (index) tab; if `dorkroom://` does not, change `DorkroomPage.border.url` to an explicit path and rebuild.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** config plugin 2-stage (Task 2) ✓; `OpenPageIntent` + `DorkroomPage` (Task 1 Step 1) ✓; `DorkroomShortcuts` 4 shortcuts with `\(.applicationName)` phrases + SF Symbols (Task 1 Step 2) ✓; stub `CalculateReciprocityIntent` returning a dialog, no Siri phrase (Task 1 Step 3) ✓; `app.json` registration (Task 2 Step 2) ✓; changelog (Task 3) ✓; no deps / no entitlements ✓; verification = lint/smoke + prebuild + dev build + device (Task 2 + Integration Verification) ✓. Phase 2b items are out of scope per spec — no task, intentional.
+- **Placeholder scan:** every code step shows complete file content or an exact command + expected output; no TBD/TODO.
+- **Type/name consistency:** `SWIFT_FILES` in Task 2 lists the exact three filenames created in Task 1. `OpenPageIntent(page:)` is defined in Task 1 Step 1 and used in Task 1 Step 2. The deep-link URLs (`dorkroom://meter`, `dorkroom://`, `dorkroom://exposure`, `dorkroom://reciprocity`) match the spec's mapping table. The `GROUP`/`AppIntents` directory name is consistent between the copy stage and the build-phase stage.

--- a/docs/superpowers/plans/2026-06-22-ios-light-meter-shortcut.md
+++ b/docs/superpowers/plans/2026-06-22-ios-light-meter-shortcut.md
@@ -1,0 +1,211 @@
+# Dedicated "Open Light Meter" Intent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated, parameter-free `OpenLightMeterIntent` and surface it as the first App Shortcut, so the light meter is the clean one-tap pick for the Action Button / Siri / Spotlight.
+
+**Architecture:** A new Swift `AppIntent` opens the existing `dorkroom://meter` deep link; it is added as the first entry in the existing `DorkroomShortcuts` provider and wired through the existing `with-app-intents` config plugin (one more filename in `SWIFT_FILES`). Additive — the existing meter open-page shortcut stays.
+
+**Tech Stack:** Apple App Intents (Swift), Expo config plugin (`@expo/config-plugins`), Expo SDK 54, iOS 26 target.
+
+## Global Constraints
+
+- Package manager is **`bun`**. No new npm dependency.
+- **Additive:** do not remove or change the existing `OpenPageIntent` / `DorkroomPage` / the four existing `AppShortcut` entries.
+- The new `AppShortcut` is the **first** entry in `DorkroomShortcuts.appShortcuts`.
+- Its Siri phrases must be **distinct** from the existing meter shortcut's ("Open Light Meter in Dorkroom" / "Open Dorkroom Light Meter") and **every phrase must include `\(.applicationName)`**.
+- Deployment target iOS 26 → no `@available` annotations.
+- The config plugin stays idempotent; `SWIFT_FILES` simply gains the new filename.
+- No Swift/config unit tests by design — verified by build + on-device test (Integration Verification). Do not invent such tests.
+- Do not bump `apps/mobile/package.json` version; add a `apps/mobile/CHANGELOG.md` entry only.
+- `apps/mobile/ios/` is not git-tracked.
+
+---
+
+### Task 1: Dedicated `OpenLightMeterIntent` + register it
+
+**Files:**
+- Create: `apps/mobile/plugins/with-app-intents/swift/OpenLightMeterIntent.swift`
+- Modify: `apps/mobile/plugins/with-app-intents/swift/DorkroomShortcuts.swift`
+- Modify: `apps/mobile/plugins/with-app-intents/index.js`
+
+**Interfaces:**
+- Consumes: the existing `dorkroom://meter` deep link and the existing `DorkroomShortcuts` provider / `with-app-intents` plugin.
+- Produces: `OpenLightMeterIntent` (parameter-free `AppIntent`), surfaced as the first `AppShortcut`. The plugin's `SWIFT_FILES` now lists four files.
+
+- [ ] **Step 1: Create `OpenLightMeterIntent.swift`**
+
+`apps/mobile/plugins/with-app-intents/swift/OpenLightMeterIntent.swift`:
+
+```swift
+import AppIntents
+import UIKit
+
+/// A dedicated, parameter-free intent to open the light meter — the natural pick
+/// for the Action Button, Control Center, or a one-tap Siri/Spotlight shortcut.
+struct OpenLightMeterIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Light Meter"
+    static var openAppWhenRun = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        await UIApplication.shared.open(URL(string: "dorkroom://meter")!)
+        return .result()
+    }
+}
+```
+
+- [ ] **Step 2: Add the App Shortcut as the first entry in `DorkroomShortcuts.swift`**
+
+In `apps/mobile/plugins/with-app-intents/swift/DorkroomShortcuts.swift`, replace:
+
+```swift
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: OpenPageIntent(page: .meter),
+```
+
+with (inserts the dedicated shortcut as the first entry, before the existing meter open-page shortcut):
+
+```swift
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: OpenLightMeterIntent(),
+            phrases: [
+                "Open the light meter in \(.applicationName)",
+                "Start \(.applicationName) light meter",
+                "Meter the light with \(.applicationName)",
+            ],
+            shortTitle: "Light Meter",
+            systemImageName: "camera.aperture"
+        )
+        AppShortcut(
+            intent: OpenPageIntent(page: .meter),
+```
+
+(The rest of the file — the four existing `AppShortcut` entries — is unchanged.)
+
+- [ ] **Step 3: Add the new file to `SWIFT_FILES` in the plugin**
+
+In `apps/mobile/plugins/with-app-intents/index.js`, replace:
+
+```js
+const SWIFT_FILES = [
+  'OpenPageIntent.swift',
+  'DorkroomShortcuts.swift',
+  'CalculateReciprocityIntent.swift',
+];
+```
+
+with:
+
+```js
+const SWIFT_FILES = [
+  'OpenPageIntent.swift',
+  'OpenLightMeterIntent.swift',
+  'DorkroomShortcuts.swift',
+  'CalculateReciprocityIntent.swift',
+];
+```
+
+- [ ] **Step 4: Smoke-test the plugin still loads and lint passes**
+
+Run:
+
+```bash
+cd apps/mobile && node -e "const p=require('./plugins/with-app-intents'); if(typeof p!=='function'){throw new Error('plugin export is not a function')} console.log('plugin loads OK')" && bun run lint
+```
+
+Expected: prints `plugin loads OK`, then lint exits 0 with no new findings.
+
+- [ ] **Step 5: Verify the four Swift files are present**
+
+Run:
+
+```bash
+ls apps/mobile/plugins/with-app-intents/swift/
+```
+
+Expected (four files):
+
+```
+CalculateReciprocityIntent.swift
+DorkroomShortcuts.swift
+OpenLightMeterIntent.swift
+OpenPageIntent.swift
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mobile/plugins/with-app-intents/
+git commit -m "feat(mobile): dedicated Open Light Meter App Intent"
+```
+
+> Do **not** run `expo prebuild` here — that is the controller-run Integration Verification step.
+
+---
+
+### Task 2: Changelog entry
+
+**Files:**
+- Modify: `apps/mobile/CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: nothing. Produces: nothing (documentation only).
+
+- [ ] **Step 1: Add the entry under the current version's `### Added` section**
+
+In `apps/mobile/CHANGELOG.md`, under `## [2026.06.22]` → `### Added`, append this
+bullet as the last item of that list (after the App Intents bullet added in the
+previous phase):
+
+```markdown
+- A dedicated "Open Light Meter" Shortcuts/Siri action (separate from the generic
+  open-page shortcuts) so the light meter can be assigned to the iPhone Action
+  Button for one-press access.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/mobile/CHANGELOG.md
+git commit -m "docs(mobile): changelog for dedicated light meter shortcut"
+```
+
+---
+
+## Integration Verification (controller + user — not a subagent task)
+
+Run after Task 2 (mirrors the Phase 2 verification):
+
+1. **Prebuild** — confirm the plugin now injects **four** Swift files and stays idempotent:
+   ```bash
+   cd apps/mobile && bunx expo prebuild --platform ios --clean --no-install
+   ls ios/AppIntents/   # expect 4 .swift files incl OpenLightMeterIntent.swift
+   for f in OpenPageIntent OpenLightMeterIntent DorkroomShortcuts CalculateReciprocityIntent; do
+     echo "$f: $(grep -cE "PBXBuildFile.*$f\\.swift" ios/*.xcodeproj/project.pbxproj)"
+   done   # each must be 1
+   ```
+2. **Development build + install** (per `apps/mobile/CLAUDE.md` workflow #2):
+   ```bash
+   source ~/.app-store-connect/eas-asc.env
+   cd apps/mobile
+   eas build --local --profile development --platform ios --non-interactive --output /tmp/dorkroom-dev.ipa
+   DEV=$(xcrun devicectl list devices | awk '/connected/ && /iPhone/ {print $3; exit}')
+   xcrun devicectl device install app --device "$DEV" /tmp/dorkroom-dev.ipa
+   xcrun devicectl device process launch --device "$DEV" art.dorkroom.mobile
+   ```
+   A successful build confirms the new Swift compiled; confirm `Metadata.appintents/` is present in the IPA.
+3. **On-device (user):**
+   - Settings → Action Button → Shortcut → **Open Light Meter**; press the Action Button → app opens on the Meter tab.
+   - "Open Light Meter" also appears in Spotlight / Siri / the Shortcuts app as a distinct action.
+   - The dedicated Siri phrases ("Open the light meter in Dorkroom", etc.) work and don't clash with the existing meter shortcut.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** new parameter-free `OpenLightMeterIntent` opening `dorkroom://meter` (Task 1 Step 1) ✓; first `AppShortcut` with distinct `\(.applicationName)` phrases (Task 1 Step 2) ✓; wired through plugin `SWIFT_FILES` (Task 1 Step 3) ✓; additive — existing entries untouched (Task 1 Step 2 note) ✓; changelog (Task 2) ✓; verification = lint/smoke + prebuild(×4, idempotent) + dev build + device (Task 1 + Integration Verification) ✓.
+- **Placeholder scan:** every code step shows full file content or an exact command + expected output; no TBD/TODO.
+- **Type/name consistency:** `OpenLightMeterIntent` (Step 1) is the exact type instantiated in `DorkroomShortcuts` (Step 2) and the filename `OpenLightMeterIntent.swift` matches the `SWIFT_FILES` entry (Step 3) and the `ls`/grep checks. The deep link `dorkroom://meter` matches the existing meter mapping. Phrases differ from the existing meter shortcut's, per the constraint.

--- a/docs/superpowers/plans/2026-06-22-ios-quick-actions.md
+++ b/docs/superpowers/plans/2026-06-22-ios-quick-actions.md
@@ -1,0 +1,272 @@
+# iOS Home Screen Quick Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add home-screen quick actions (long-press the iOS app icon) that deep-link to the Light Meter, Border, Exposure, and Reciprocity pages.
+
+**Architecture:** Declare four static iOS quick actions via the `expo-quick-actions` config plugin in `app.json` (so they appear before first launch), and call the library's `useQuickActionRouting()` hook in the root layout so a tapped action navigates Expo Router to that action's `params.href`. No new routing or scheme work — the `dorkroom://` scheme and tab routes already exist.
+
+**Tech Stack:** Expo SDK 54, Expo Router 6, React Native 0.81 (New Architecture), `expo-quick-actions@^6.0.2`, iOS 26 deployment target.
+
+## Global Constraints
+
+- Package manager is **`bun`** (`bun add`, `bun run …`). The repo uses Turborepo + workspaces.
+- `bunfig.toml` enforces a **7-day `minimumReleaseAge`** on installs. `expo-quick-actions@6.0.2` was published 2026-05-27, so it clears the gate; no override flag needed.
+- **Never use `any`** — use specific types or `unknown`.
+- **Never import internal package paths** — use `@dorkroom/ui`, `@dorkroom/logic`, `@dorkroom/api` (not relevant to this plan's files, but holds).
+- Mobile app uses its **own changelog** (`apps/mobile/CHANGELOG.md`) and independent CalVer. `apps/mobile/package.json` is already `2026.06.22` (today) — **do not bump it**; only add a changelog entry.
+- Quick actions **cannot be exercised by the Vitest unit suite** — they require a native build. Verification is typecheck/lint + `expo prebuild` + manual device/simulator check. Do **not** invent JS unit tests for native behavior.
+- iOS shows a **maximum of 4** quick actions. The list is exactly four, ordered Light Meter → Border → Exposure → Reciprocity.
+
+---
+
+### Task 1: Install `expo-quick-actions` and declare the four static iOS actions
+
+**Files:**
+- Modify: `apps/mobile/package.json` (adds the dependency — written by `bun add`)
+- Modify: `apps/mobile/app.json` (add plugin entry with `iosActions`)
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: a configured `expo-quick-actions` plugin whose four actions each carry `params.href` — the route strings `"/meter"`, `"/"`, `"/exposure"`, `"/reciprocity"` that Task 2's hook will navigate to. The action `id`s are `meter`, `border`, `exposure`, `reciprocity`.
+
+- [ ] **Step 1: Install the dependency**
+
+Run (from the mobile app directory):
+
+```bash
+cd apps/mobile && bun add expo-quick-actions@^6.0.2
+```
+
+Expected: `package.json` gains `"expo-quick-actions": "^6.0.2"` under `dependencies`, and the install completes without a `minimumReleaseAge` error.
+
+- [ ] **Step 2: Verify the version landed**
+
+Run:
+
+```bash
+cd apps/mobile && grep expo-quick-actions package.json
+```
+
+Expected output (a line like):
+
+```
+    "expo-quick-actions": "^6.0.2",
+```
+
+- [ ] **Step 3: Add the config plugin with the four actions to `app.json`**
+
+In `apps/mobile/app.json`, replace the existing `plugins` array:
+
+```json
+    "plugins": [
+      "expo-router",
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "deploymentTarget": "26.0"
+          }
+        }
+      ]
+    ],
+```
+
+with this (adds the `expo-quick-actions` entry after `expo-build-properties`):
+
+```json
+    "plugins": [
+      "expo-router",
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "deploymentTarget": "26.0"
+          }
+        }
+      ],
+      [
+        "expo-quick-actions",
+        {
+          "iosActions": [
+            {
+              "id": "meter",
+              "title": "Light Meter",
+              "icon": "symbol:camera.aperture",
+              "params": { "href": "/meter" }
+            },
+            {
+              "id": "border",
+              "title": "Border",
+              "icon": "symbol:square.dashed",
+              "params": { "href": "/" }
+            },
+            {
+              "id": "exposure",
+              "title": "Exposure",
+              "icon": "symbol:plusminus",
+              "params": { "href": "/exposure" }
+            },
+            {
+              "id": "reciprocity",
+              "title": "Reciprocity",
+              "icon": "symbol:timer",
+              "params": { "href": "/reciprocity" }
+            }
+          ]
+        }
+      ]
+    ],
+```
+
+- [ ] **Step 4: Verify `app.json` is still valid JSON**
+
+Run:
+
+```bash
+cd apps/mobile && node -e "JSON.parse(require('fs').readFileSync('app.json','utf8')); console.log('app.json OK')"
+```
+
+Expected output:
+
+```
+app.json OK
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/mobile/package.json apps/mobile/app.json
+git commit -m "feat(mobile): declare iOS home screen quick actions"
+```
+
+---
+
+### Task 2: Wire `useQuickActionRouting()` into the root layout and regenerate native config
+
+**Files:**
+- Modify: `apps/mobile/app/_layout.tsx` (import + hook call in `RootLayout`)
+
+**Interfaces:**
+- Consumes: the four actions' `params.href` route strings declared in Task 1.
+- Produces: runtime handling — tapping a quick action navigates Expo Router to `params.href`. No exported symbols.
+
+- [ ] **Step 1: Add the import**
+
+In `apps/mobile/app/_layout.tsx`, add this import alongside the other `expo-*` imports (e.g. right after the `expo-status-bar` import on line 9):
+
+```tsx
+import { useQuickActionRouting } from 'expo-quick-actions/router';
+```
+
+- [ ] **Step 2: Call the hook inside `RootLayout`**
+
+In the same file, change the `RootLayout` function so the hook runs before the `return`. Replace:
+
+```tsx
+export default function RootLayout() {
+  return (
+    <SafeAreaProvider>
+```
+
+with:
+
+```tsx
+export default function RootLayout() {
+  // Route home-screen quick action taps to the action's `params.href`.
+  useQuickActionRouting();
+
+  return (
+    <SafeAreaProvider>
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run:
+
+```bash
+cd apps/mobile && bun run typecheck
+```
+
+Expected: exits 0 with no errors. (Confirms `expo-quick-actions/router` resolves and the hook is typed.)
+
+- [ ] **Step 4: Lint**
+
+Run:
+
+```bash
+cd apps/mobile && bun run lint
+```
+
+Expected: exits 0 (no new oxlint/biome findings).
+
+- [ ] **Step 5: Regenerate native iOS config and confirm the actions are emitted**
+
+Run:
+
+```bash
+cd apps/mobile && bun run native:prebuild
+```
+
+Expected: prebuild completes without error. Then confirm the plugin wrote the actions into the generated Info.plist:
+
+```bash
+cd apps/mobile && grep -A2 UIApplicationShortcutItemType ios/Dorkroom/Info.plist | head
+```
+
+Expected: the output contains the action types (e.g. `meter`, `border`, `exposure`, `reciprocity`) under `UIApplicationShortcutItems`. If `UIApplicationShortcutItems` is absent, the plugin did not apply — stop and recheck Task 1 Step 3.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/mobile/app/_layout.tsx
+git commit -m "feat(mobile): route quick action taps via useQuickActionRouting"
+```
+
+> Note: `bun run native:prebuild` regenerates files under `apps/mobile/ios/`. Stage those only if the repo already tracks the `ios/` directory (check `git status`); if `ios/` is gitignored, leave it untracked. Do not hand-edit generated files.
+
+---
+
+### Task 3: Add the changelog entry
+
+**Files:**
+- Modify: `apps/mobile/CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing (documentation only).
+
+- [ ] **Step 1: Add the entry under the current version's `### Added` section**
+
+In `apps/mobile/CHANGELOG.md`, under the existing `## [2026.06.22]` → `### Added` list, append this bullet as the last item of that list:
+
+```markdown
+- iOS home screen quick actions: long-pressing the app icon now shows shortcuts
+  that jump straight to the Light Meter, Border, Exposure, and Reciprocity pages.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/mobile/CHANGELOG.md
+git commit -m "docs(mobile): changelog for iOS quick actions"
+```
+
+---
+
+## Manual Verification (after all tasks)
+
+These steps need a real build and a human/simulator — they are not automated:
+
+1. Build & run the app on a device or simulator (`bun run ios` from `apps/mobile`, or an EAS build).
+2. Long-press the Dorkroom home-screen icon.
+3. Confirm four actions appear, top-to-bottom: **Light Meter, Border, Exposure, Reciprocity**, each with the expected SF Symbol icon.
+4. Tap each action in turn and confirm it launches the app on the correct tab (Light Meter → Meter tab, Border → Border/index tab, Exposure → Exposure tab, Reciprocity → Reciprocity tab).
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Library choice + static config (Task 1) ✓; four actions with exact icons/hrefs (Task 1 Step 3) ✓; `useQuickActionRouting()` in `_layout.tsx` (Task 2) ✓; dependency added (Task 1 Step 1) ✓; changelog (Task 3) ✓; verification = typecheck/lint/prebuild + manual (Task 2 + Manual Verification) ✓. Phase 2 (App Intents) is out of scope per spec — no task, intentionally.
+- **Placeholder scan:** No TBD/TODO; every code step shows the full code or exact command + expected output.
+- **Type consistency:** Action `id`s (`meter`/`border`/`exposure`/`reciprocity`) and `href`s (`/meter`, `/`, `/exposure`, `/reciprocity`) are identical between Task 1's declaration and Task 2's consumer description. `useQuickActionRouting` import path (`expo-quick-actions/router`) matches the verified library API.

--- a/docs/superpowers/specs/2026-06-22-ios-app-intents-design.md
+++ b/docs/superpowers/specs/2026-06-22-ios-app-intents-design.md
@@ -1,0 +1,184 @@
+# iOS Shortcuts / Siri (App Intents) — Design
+
+**Date:** 2026-06-22
+**App:** `apps/mobile` (Expo / React Native, iOS)
+**Status:** Approved
+**Relationship:** Phase 2 of iOS shortcuts work. Phase 1 (home-screen quick
+actions) shipped on `feat/ios-quick-actions`; this phase continues on the same
+branch.
+
+## Goal
+
+Expose Dorkroom's pages to **Siri, Spotlight, and the Shortcuts app** via Apple's
+App Intents framework. Phase 2 ships **open-page** App Shortcuts for the four
+Phase-1 pages (Light Meter, Border, Exposure, Reciprocity) and **stubs** one
+functional calculator intent to seed Phase 2b — without building the native↔JS
+bridge that functional intents require.
+
+## Scope
+
+**In scope:**
+
+- A local Expo config plugin that injects Swift App Intents into the iOS app
+  target at prebuild.
+- One parameterized `OpenPageIntent` + a `DorkroomPage` app-enum.
+- An `AppShortcutsProvider` with four open-page App Shortcuts (Siri phrases,
+  short titles, SF Symbols) that auto-register to Siri / Spotlight / Shortcuts app.
+- One **stubbed** functional intent (`CalculateReciprocityIntent`) that returns a
+  "coming soon" dialog — discoverable in the Shortcuts app, no Siri phrase.
+
+**Out of scope (Phase 2b):**
+
+- Functional calculator intents that actually compute.
+- App Group + native↔JS bridge for sharing data/results with React Native.
+- `AppEntity` queries, donations, Spotlight result entities, Control Center
+  controls, Focus filters.
+
+## Approach
+
+A self-contained **local config plugin** (`apps/mobile/plugins/with-app-intents/`)
+owns everything. **No new npm dependency.** Chosen over `@bacons/apple-targets`
+(needs a dedicated target; App Shortcuts behave best in the main app target) and
+over four separate intents (4× boilerplate vs. one enum-parameterized intent).
+
+The plugin runs in two stages at prebuild — **both are required** or the intents
+silently fail to register:
+
+1. `withDangerousMod` (`ios`) — copy `swift/*.swift` into
+   `<platformProjectRoot>/AppIntents/`.
+2. `withXcodeProject` — add each copied file to the app target's compile sources
+   (`project.addSourceFile('AppIntents/<file>', { target: firstTarget.uuid })`),
+   **idempotently** so a re-run of prebuild does not create duplicate build refs.
+
+Swift files live at the **iOS project root** (`ios/AppIntents/`), never inside an
+Expo module — nesting breaks `AppShortcutsProvider` auto-registration.
+
+**No entitlement and no `NSSiriUsageDescription`** are required: App Shortcuts
+(iOS 16+) need neither (that's legacy SiriKit). The iOS 26 deployment target
+covers all App Intents APIs used.
+
+## File structure
+
+```
+apps/mobile/plugins/with-app-intents/
+  index.js                            # the config plugin (2 stages, idempotent)
+  swift/
+    OpenPageIntent.swift              # OpenPageIntent + DorkroomPage app-enum
+    DorkroomShortcuts.swift           # AppShortcutsProvider — 4 open-page shortcuts
+    CalculateReciprocityIntent.swift  # stubbed functional intent (Phase 2b seed)
+```
+
+## Swift components
+
+### `DorkroomPage` (AppEnum)
+
+Cases `meter`, `border`, `exposure`, `reciprocity`, each with a display title.
+Provides `typeDisplayRepresentation` and `caseDisplayRepresentations`.
+
+### `OpenPageIntent` (AppIntent)
+
+- `static var title: LocalizedStringResource = "Open Dorkroom Page"`
+- `static var openAppWhenRun = true`
+- `@Parameter var page: DorkroomPage`
+- `perform()` opens the page's deep link via `UIApplication.shared.open(url)` and
+  returns `.result()`. Navigation is then handled by **existing** expo-router
+  deep-linking — no new JS code.
+
+Route → URL mapping (reusing the registered `dorkroom://` scheme):
+
+| Page        | URL                  | Tab route        |
+| ----------- | -------------------- | ---------------- |
+| meter       | `dorkroom://meter`   | `/meter`         |
+| border      | `dorkroom://`        | `/` (index tab)  |
+| exposure    | `dorkroom://exposure`| `/exposure`      |
+| reciprocity | `dorkroom://reciprocity` | `/reciprocity` |
+
+(The exact border URL — scheme root vs. an explicit path — is confirmed on device
+during verification; the plan notes the fallback.)
+
+### `DorkroomShortcuts` (AppShortcutsProvider)
+
+`static var appShortcuts: [AppShortcut]` returns four entries, each instantiating
+`OpenPageIntent(page:)` with a fixed page plus its phrases, `shortTitle`, and SF
+Symbol. **Every phrase must include the `\(.applicationName)` macro** or the
+shortcut is dropped during build-time intent indexing.
+
+| Page        | shortTitle  | systemImageName  | Example phrases (all include `\(.applicationName)`)      |
+| ----------- | ----------- | ---------------- | -------------------------------------------------------- |
+| meter       | Light Meter | `camera.aperture`| "Open Light Meter in Dorkroom" / "Open Dorkroom Light Meter" |
+| border      | Border      | `square.dashed`  | "Open Border in Dorkroom" / "Open Dorkroom Border calculator" |
+| exposure    | Exposure    | `plusminus`      | "Open Exposure in Dorkroom" / "Open Dorkroom Exposure calculator" |
+| reciprocity | Reciprocity | `timer`          | "Open Reciprocity in Dorkroom" / "Open Dorkroom Reciprocity calculator" |
+
+Icons mirror the tab bar and the Phase-1 quick actions.
+
+### `CalculateReciprocityIntent` (stub)
+
+- `static var title: LocalizedStringResource = "Calculate Reciprocity"`
+- `@Parameter var meteredSeconds: Double`
+- `perform()` returns
+  `.result(dialog: "Calculator Shortcuts are coming soon to Dorkroom.")`.
+- **Not** added to `appShortcuts` (no Siri phrase — we don't advertise a
+  non-working voice command), but discoverable as an action in the Shortcuts app
+  (`isDiscoverable` defaults true).
+- A header comment marks it the Phase 2b seed: it will compute via `@dorkroom/logic`
+  through an App Group / native bridge.
+
+## Config plugin (`index.js`)
+
+A single exported plugin function composing the two stages above. Copies the
+Swift files, adds them to the target idempotently (skip if the source ref already
+exists; optionally group them under an `AppIntents` PBXGroup). Errors loudly if
+`addSourceFile` fails — a silently-disabled intent is worse than a failed build.
+
+## Data flow
+
+```
+Siri / Spotlight / Shortcuts app
+  → OpenPageIntent.perform()
+  → UIApplication.shared.open("dorkroom://<route>")
+  → iOS delivers the URL to the app
+  → expo-router deep-linking navigates to the tab
+```
+
+No new JavaScript — this reuses the deep-link path the app already supports.
+
+## Error handling
+
+- **Plugin:** idempotent copy + add; loud failure on Xcode wiring errors.
+- **Intents:** page URLs are static string literals (safe to construct);
+  `perform()` always returns a result; the stub returns its dialog.
+
+## Testing / verification
+
+- **JS/plugin:** `bun run typecheck` + `bun run lint` (the plugin is JS).
+- **Swift compiles:** `expo prebuild --clean` + a **development build** (native
+  change, per `apps/mobile/CLAUDE.md`). Confirm the `.swift` files are in
+  `ios/AppIntents/`, referenced in `ios/<App>.xcodeproj/project.pbxproj`, and
+  compile cleanly.
+- **On-device (user-run):**
+  - Spotlight: search "Light Meter" → Dorkroom shortcut appears → opens Meter tab.
+  - Siri: "Open Light Meter in Dorkroom" → opens Meter tab. Repeat for each page.
+  - Shortcuts app: the four open-page actions appear, plus "Calculate Reciprocity",
+    which returns the "coming soon" dialog.
+- **No Swift/native unit tests** — consistent with the app convention (native
+  behavior is verified on device, not mocked).
+
+## Files touched
+
+- **Create:** `plugins/with-app-intents/index.js` and the three `swift/*.swift`
+  files.
+- **Modify:** `apps/mobile/app.json` (add `"./plugins/with-app-intents"` to
+  `plugins`), `apps/mobile/CHANGELOG.md`.
+- No dependency changes.
+
+## Risks / notes
+
+- **pbxproj vs. synchronized file groups:** newer Xcode templates can use
+  `PBXFileSystemSynchronizedRootGroup`, where files dropped into the project
+  folder auto-include — which could make `addSourceFile` redundant or conflicting.
+  The plan verifies at prebuild and adjusts the plugin (skip the `addSourceFile`
+  stage if the template auto-includes). This is the main implementation risk.
+- **Border deep-link URL:** the scheme-root vs. explicit-path form for the index
+  tab is confirmed on device; the plan carries a fallback.
+- **Phrases:** the `\(.applicationName)` macro is mandatory in every phrase.

--- a/docs/superpowers/specs/2026-06-22-ios-light-meter-shortcut-design.md
+++ b/docs/superpowers/specs/2026-06-22-ios-light-meter-shortcut-design.md
@@ -1,0 +1,123 @@
+# Dedicated "Open Light Meter" App Intent — Design
+
+**Date:** 2026-06-22
+**App:** `apps/mobile` (Expo / React Native, iOS)
+**Status:** Approved
+**Relationship:** Phase 3, a small increment on the Phase 2 App Intents work.
+Continues on `feat/ios-quick-actions` (combined PR).
+
+## Goal
+
+Add a dedicated, parameter-free **"Open Light Meter"** App Intent so the light
+meter is the obvious one-tap pick for the iPhone **Action Button** (and for
+Control Center / a single Siri or Spotlight shortcut), rather than being one of
+four options behind the generic `OpenPageIntent` / `DorkroomPage` parameter.
+
+## Scope
+
+**In scope:**
+
+- A new parameter-free `OpenLightMeterIntent` (Swift), opening `dorkroom://meter`.
+- A new `AppShortcut` for it, listed **first** in `DorkroomShortcuts` (most
+  prominent), with Siri phrases distinct from the existing meter open-page
+  shortcut.
+- Wire the new Swift file through the existing config plugin.
+
+**Decided:**
+
+- **Additive** — the existing meter entry on `OpenPageIntent`/`DorkroomPage` stays.
+  The light meter is intentionally reachable two ways; the dedicated intent is the
+  prominent, cleanly-named one. (User chose this over replace-and-dedupe.)
+
+**Out of scope:**
+
+- Claiming the Action Button programmatically (not possible — the user binds it in
+  Settings). Control Center widget/control. Any change to the other three pages.
+
+## Approach
+
+The light meter currently surfaces as one `DorkroomPage` case on the generic
+`OpenPageIntent` (title "Open Dorkroom Page"). For the Action Button's Shortcut
+picker and the Shortcuts actions list, a discrete, parameter-free intent named
+"Open Light Meter" reads far better than a generic intent plus a parameter.
+
+Add `OpenLightMeterIntent` alongside the existing intents and register it as the
+first `AppShortcut`. It reuses the proven `dorkroom://meter` deep link, so no new
+navigation code. The new Swift file is injected by the **existing**
+`with-app-intents` config plugin — only its `SWIFT_FILES` list grows by one.
+
+## Files touched
+
+- **Create:** `apps/mobile/plugins/with-app-intents/swift/OpenLightMeterIntent.swift`
+- **Modify:** `apps/mobile/plugins/with-app-intents/swift/DorkroomShortcuts.swift`
+  (add the `AppShortcut`, first), `apps/mobile/plugins/with-app-intents/index.js`
+  (add the filename to `SWIFT_FILES`), `apps/mobile/CHANGELOG.md`.
+
+## The intent
+
+```swift
+import AppIntents
+import UIKit
+
+/// A dedicated, parameter-free intent to open the light meter — the natural pick
+/// for the Action Button, Control Center, or a one-tap Siri/Spotlight shortcut.
+struct OpenLightMeterIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Light Meter"
+    static var openAppWhenRun = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        await UIApplication.shared.open(URL(string: "dorkroom://meter")!)
+        return .result()
+    }
+}
+```
+
+## The App Shortcut (first entry in `DorkroomShortcuts.appShortcuts`)
+
+```swift
+AppShortcut(
+    intent: OpenLightMeterIntent(),
+    phrases: [
+        "Open the light meter in \(.applicationName)",
+        "Start \(.applicationName) light meter",
+        "Meter the light with \(.applicationName)",
+    ],
+    shortTitle: "Light Meter",
+    systemImageName: "camera.aperture"
+)
+```
+
+Phrases are deliberately distinct from the existing meter open-page shortcut
+("Open Light Meter in Dorkroom" / "Open Dorkroom Light Meter") to avoid phrase
+collisions between the two meter shortcuts. Every phrase includes the required
+`\(.applicationName)` macro.
+
+## Data flow
+
+Action Button / Siri / Spotlight / Shortcuts → `OpenLightMeterIntent.perform()`
+→ opens `dorkroom://meter` → expo-router navigates to the Meter tab. Identical to
+the existing meter path; no new JS.
+
+## Error handling
+
+The deep-link URL is a static literal (safe); `perform()` always returns
+`.result()`. `openAppWhenRun = true` foregrounds the app.
+
+## Testing / verification
+
+- **JS/plugin:** `bun run typecheck` + `bun run lint` (the `SWIFT_FILES` edit).
+- **Prebuild:** `expo prebuild` copies and references **four** Swift files now
+  (idempotent — counts stay at 1 per file on re-run).
+- **Dev build:** compiles; `Metadata.appintents/` present in the built app.
+- **On-device (user):** assign Settings → Action Button → Shortcut → "Open Light
+  Meter"; a press opens the Meter tab. The dedicated "Open Light Meter" also
+  appears in Spotlight / Siri / the Shortcuts app. (Two meter entries in Spotlight
+  is expected per the additive choice.)
+- No Swift/native unit tests — consistent with the app convention.
+
+## Risks / notes
+
+- **Phrase collision** between the two meter shortcuts — mitigated by the distinct
+  phrase set above.
+- **Duplicate meter entries** in Spotlight / Shortcuts — accepted (additive choice).

--- a/docs/superpowers/specs/2026-06-22-ios-quick-actions-design.md
+++ b/docs/superpowers/specs/2026-06-22-ios-quick-actions-design.md
@@ -1,0 +1,104 @@
+# iOS Home Screen Quick Actions — Design
+
+**Date:** 2026-06-22
+**App:** `apps/mobile` (Expo / React Native, iOS)
+**Status:** Approved (Phase 1)
+
+## Goal
+
+Let users jump straight to a specific page of the Dorkroom iOS app by
+long-pressing the app icon on the home screen and choosing an action. Phase 1
+ships home-screen quick actions for the four most useful pages, with the **light
+meter** as the headline action. Siri / Shortcuts-app integration (App Intents)
+is a deliberately deferred Phase 2.
+
+## Scope
+
+**In scope (Phase 1):**
+
+- Home-screen quick actions (long-press app icon → action menu) for 4 pages.
+- Tapping an action deep-links to the corresponding tab.
+
+**Out of scope (Phase 2, not built now):**
+
+- App Intents — Siri voice commands, Spotlight, the Shortcuts app, automations.
+  Noted here only because the per-page route mapping established in Phase 1 is
+  the same concept Phase 2 reuses, so none of this work is throwaway.
+
+## Approach
+
+Use **`expo-quick-actions`** (Evan Bacon; actively maintained). It provides the
+two pieces required:
+
+1. **Config plugin** — declares the actions statically in `app.json`. Static
+   actions appear in the long-press menu **immediately on install, before the
+   app's first launch**, requiring no runtime registration code. The plugin
+   supports `symbol:` SF Symbol icons, letting us reuse the exact icons already
+   used in the tab bar.
+2. **`useQuickActionRouting()`** hook (from `expo-quick-actions/router`) —
+   handles the tap and navigates Expo Router to the action's `params.href`.
+
+**Why static (config plugin) over the dynamic `setItems()` API:** these are four
+fixed pages. Static declaration is simpler, needs no runtime registration code,
+and surfaces the actions before first launch. The only runtime addition is the
+single routing hook.
+
+The `dorkroom://` URL scheme and the tab routes already exist, so deep-linking
+to a tab route simply selects that tab — no new routing code beyond the hook.
+
+## The four actions
+
+Declared under the plugin in `app.json`, ordered top-to-bottom as shown in the
+menu (Light Meter first). iOS displays a maximum of four quick actions, so the
+list is exactly four.
+
+| Order | Title       | SF Symbol icon         | href (route)     |
+| ----- | ----------- | ---------------------- | ---------------- |
+| 1     | Light Meter | `symbol:camera.aperture` | `/meter`       |
+| 2     | Border      | `symbol:square.dashed`   | `/` (index tab) |
+| 3     | Exposure    | `symbol:plusminus`       | `/exposure`    |
+| 4     | Reciprocity | `symbol:timer`           | `/reciprocity` |
+
+Icons mirror the existing tab-bar icons in `app/(tabs)/_layout.tsx`.
+
+## Files touched
+
+- **`apps/mobile/package.json`** — add the `expo-quick-actions` dependency.
+- **`apps/mobile/app.json`** — add `expo-quick-actions` to `plugins` with the
+  four `iosActions` above.
+- **`apps/mobile/app/_layout.tsx`** — call `useQuickActionRouting()` inside
+  `RootLayout` so action taps route to `params.href`.
+- **`apps/mobile/CHANGELOG.md`** — add a changelog entry (mobile app uses its own
+  changelog per project convention).
+
+## Data flow
+
+```
+Long-press app icon
+   → iOS reads static UIApplicationShortcutItems (from config plugin / app.json)
+   → user taps an action
+   → expo-quick-actions delivers the action to JS
+   → useQuickActionRouting() reads params.href
+   → Expo Router navigates to the route → correct tab is selected
+```
+
+## Verification
+
+Quick actions require a real native build and cannot be exercised by the Vitest
+unit suite (and snapshotting config-plugin output would be brittle for little
+value). Verification is therefore:
+
+1. `bun run typecheck` and `bun run lint` pass in `apps/mobile`.
+2. `expo prebuild` regenerates iOS native config without error.
+3. A device/simulator build: long-press the app icon, confirm the four actions
+   appear in the correct order with correct icons, and tap each one to confirm
+   it opens the correct tab.
+
+## Risks / notes
+
+- **`expo-quick-actions` compatibility** with Expo 54 + New Architecture
+  (`newArchEnabled: true`) + iOS 26 deployment target must be confirmed at
+  install time. If incompatible, fall back to writing
+  `UIApplicationShortcutItems` directly via an Info.plist config-plugin mod plus
+  handling taps through `expo-linking` / the existing `dorkroom://` scheme.
+- The Border action's href is `/` (the index route within the `(tabs)` group).


### PR DESCRIPTION
## Summary

Adds iOS Shortcuts support for opening Dorkroom pages, built in three phases on this branch:

1. **Home-screen quick actions** — long-pressing the app icon shows shortcuts to the Light Meter, Border, Exposure, and Reciprocity pages (via the `expo-quick-actions` config plugin + `useQuickActionRouting()` in the tabs sub-layout).
2. **Siri / Spotlight / Shortcuts-app support (App Intents)** — a local config plugin (`plugins/with-app-intents/`) injects Swift App Intents at prebuild. `OpenPageIntent` (+ `DorkroomPage` enum) and an `AppShortcutsProvider` register open-page shortcuts for all four pages; a stubbed `CalculateReciprocityIntent` seeds future functional ("coming soon") calculator intents.
3. **Dedicated "Open Light Meter" intent** — a parameter-free intent, surfaced as the first App Shortcut, so the light meter is a clean one-press pick for the iPhone **Action Button** (kept additive alongside the generic open-page meter shortcut, with distinct Siri phrases).

All page navigation reuses the existing `dorkroom://` deep-link scheme + expo-router — no new JS navigation code.

Also included: a new `apps/mobile/CLAUDE.md` documenting the app's conventions and a build-vs-reload decision guide.

## How it works

- Quick actions are static (`app.json`), so they appear before first launch.
- App Intents are injected by a 2-stage config plugin (copy Swift → add to the Xcode app target), idempotent across prebuilds. Swift lives at the iOS project root (`ios/AppIntents/`) so `AppShortcutsProvider` auto-registers.
- No new entitlements, no `NSSiriUsageDescription` (not needed for App Shortcuts), no version bump.

## Testing

- `bun run test` (20/20), `bun run typecheck`, `bun run lint` all pass in `apps/mobile`.
- `expo prebuild` verified: all four Swift files inject with exactly one build-file ref each, idempotent on re-run.
- EAS local dev build compiles the Swift; `Metadata.appintents/` (with NLU data) is baked into the built app.
- **On-device (verified):** home-screen quick actions, Spotlight, Siri phrases, the Shortcuts-app actions, the "coming soon" stub, and the Action Button → Open Light Meter all confirmed on an iPhone 15 Pro Max.

## Notes

- The mobile app versions independently; changelog entries are in `apps/mobile/CHANGELOG.md`.
- Functional calculator intents (real reciprocity/exposure math via a native↔JS bridge) are intentionally out of scope — seeded by the reciprocity stub for a future phase.

Design + plan docs for each phase are under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
