### PR TITLE
perf(dorkroom): decouple First Contentful Paint from the JS bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The iOS app has its own changelog: [`apps/mobile/CHANGELOG.md`](apps/mobile/CHAN
 
 This project uses [CalVer](https://calver.org/) date-based versioning: `YYYY.MM.DD`.
 
+## [2026.07.04]
+
+### Changed
+
+- Faster initial render (First Contentful Paint): the app now paints a lightweight inline shell (a centered spinner) straight from `index.html`, so first paint is no longer gated on downloading and executing the full JavaScript entry bundle — React swaps the shell out on mount. In addition, `@dorkroom/ui` and `@dorkroom/logic` are now marked side-effect-free (`"sideEffects": false`) so the bundler can tree-shake the shared barrel; form, table, and virtualization code no longer lands in the initial critical-path chunk on routes that don't use it. Together these cut the eager critical-path JS by roughly 30% and decouple first paint from bundle execution, without any layout shift (CLS stays 0).
+
 ## [2026.07.03]
 
 ### Added

--- a/apps/dorkroom/index.html
+++ b/apps/dorkroom/index.html
@@ -39,9 +39,46 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="stylesheet" href="/src/styles.css" />
+    <style>
+      /* Pre-React app shell. The #root is otherwise empty until the ~216 KB JS
+         entry bundle downloads, parses, and executes, so First Contentful Paint
+         is gated entirely on that bundle. This inline spinner paints as soon as
+         the (much smaller) CSS parses, decoupling FCP from the JS. React's
+         createRoot().render() clears #root on mount, so the shell is swapped out
+         wholesale the moment the app renders — the same pattern as the in-app
+         Suspense fallbacks, so it introduces no layout shift (CLS stays 0).
+         Colors match the default dark theme (:root:not([data-theme])). */
+      #app-shell {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100dvh;
+      }
+      #app-shell .app-shell-spinner {
+        width: 2rem;
+        height: 2rem;
+        border-radius: 9999px;
+        border-bottom: 2px solid #6ef3a4;
+        animation: app-shell-spin 1s linear infinite;
+      }
+      @keyframes app-shell-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #app-shell .app-shell-spinner {
+          animation: none;
+        }
+      }
+    </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <output id="app-shell" aria-label="Loading" aria-live="polite">
+        <div class="app-shell-spinner"></div>
+      </output>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/logic/package.json
+++ b/packages/logic/package.json
@@ -4,6 +4,7 @@
   "license": "AGPL-3.0-only",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,7 @@
   "license": "AGPL-3.0-only",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./src/index.ts",


### PR DESCRIPTION
## Summary

Vercel Speed Insights flagged **First Contentful Paint at P75 ≈ 1.86s** ("Needs Improvement", the >1.8s band). The app is a pure client-side SPA: `index.html` ships an empty `<div id="root">` and nothing paints until the CSS **and** the full JS entry bundle download, parse, and execute and React mounts. TTFB is a healthy 0.36s, so essentially all of the ~1.5s to FCP is client-side render path gated on that bundle.

This PR decouples first paint from the JS bundle and trims the eager critical path.

## Related Issues

Investigation of the Speed Insights FCP metric (no tracking issue). First PR in a 3-PR stack — see **Additional Notes**.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue) — addresses the FCP > 1.8s regression (performance optimization; no API/behavior change)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Data addition (film, developer, or recipe entries)

## Changes Made

- **Inline app shell in `apps/dorkroom/index.html`** — a lightweight centered spinner (self-contained inline `<style>` + markup inside `#root`) that paints as soon as the CSS parses, so FCP no longer waits on the ~216 KB gzip JS entry bundle. `createRoot().render()` clears `#root` and replaces the shell on mount — the same wholesale-swap pattern as the existing in-app Suspense fallbacks, so **CLS stays 0** (no layout shift). Colors match the default dark theme (`:root:not([data-theme])`), and it honors `prefers-reduced-motion`.
- **`"sideEffects": false` on `@dorkroom/ui` and `@dorkroom/logic`** — neither package has non-CSS import side effects, so this is safe (matches `@dorkroom/api`, which already declares it). It lets the bundler tree-shake the 80-export `@dorkroom/ui` barrel: importing `ROUTE_TITLES`/providers no longer drags `@tanstack/react-table`/`react-virtual` (and pulls back `react-form`) into the eager entry chunk on routes that don't use them.
- **CHANGELOG.md** — new `[2026.07.04]` entry.

### Measured impact (production build)

| | Before | After |
|---|---|---|
| JS entry chunk | 286 KB (81 KB gz) | **100 KB (29 KB gz)** |
| Modern eager critical-path JS | ~216 KB gz | **~148 KB gz** (−31%) |
| `tanstack-table-virtual` in eager path | yes | **removed** |
| FCP gated on JS execution | yes | **no — shell paints at CSS-parse** |

## Testing

- [x] I have run `bun run test` and all checks pass — **1628 tests pass**, lint + build + typecheck green across all `@dorkroom/*`.
- [ ] I have added tests that prove my fix/feature works — no unit tests (this is a render-path/build change); verified in a real browser instead (below).
- [x] I have tested manually in the development environment — served the production build in Chrome: home page and `/development` (the heaviest route: `zod` + the now-lazy table/virtualization) both render fully with **zero console errors**; React cleanly replaces the shell.
- React Doctor: **100/100** on all four projects (`source`, `mobile`, `logic`, `ui`).

## Checklist

- [x] My code follows the project's code style
- [x] I have formatted my code (`biome check` passes on all changed files)
- [x] I have made corresponding changes to documentation (CHANGELOG.md)
- [x] My changes generate no new warnings
- [x] I have checked that there are no circular dependencies between packages

## Additional Notes

**Stack (Graphite):** `main → #131 (this) → #132 (Biome ignore) → #133 (TypeScript 7 RC)`. Each is independently reviewable.

**Note on the Speed Insights per-route numbers:** the dashboard showed `/stops` (2.84s) and `/lenses` (2.04s) slower than `/` (0.8s), but those routes had only 1–3 samples each and line up with a couple of slow/distant visits (Australia, Vietnam) — i.e. connection/geography, not intrinsic route weight. Route **page bodies** are already correctly lazy-loaded behind Suspense and don't gate FCP. The real, fixable lever was the shared eager critical path addressed here.

**Not yet removed from the eager path:** `zod` and `tanstack-form` remain, because TanStack Router's generated route tree statically imports all route *definitions* and a few (`development.tsx`, `films.tsx`) top-level-import `zod` for `validateSearch`. Fully removing them needs `createLazyFileRoute` / moving search schemas out — a larger follow-up not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
