### PR TITLE
chore(deps): adopt TypeScript 7 RC (typescript@rc) for typecheck/build

### DIFF
--- a/apps/dorkroom/package.json
+++ b/apps/dorkroom/package.json
@@ -8,6 +8,6 @@
     "build": "vite build",
     "lint": "oxlint && biome check --linter-enabled=false .",
     "test": "vitest run",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "node ../../node_modules/typescript-7/bin/tsc --noEmit"
   }
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,7 +11,7 @@
     "lint": "oxlint && biome check --linter-enabled=false --css-linter-enabled=false .",
     "test": "vitest run",
     "build": "echo 'no-op: native app builds run via expo/EAS, not turbo'",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "node ../../node_modules/typescript-7/bin/tsc --noEmit",
     "postinstall": "node scripts/link-nativewind-tailwind.mjs",
     "eas-build-post-install": "node scripts/link-nativewind-tailwind.mjs"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -47,7 +47,6 @@
         "@types/node": "^24.0.0",
         "@types/react": "19.2.7",
         "@types/react-dom": "19.2.3",
-        "@typescript/native-preview": "7.0.0-dev.20260604.1",
         "@vercel/speed-insights": "^2.0.0",
         "@vitejs/plugin-legacy": "8.0.2",
         "@vitejs/plugin-react": "6.0.2",
@@ -69,6 +68,7 @@
         "turbo": "^2.9.18",
         "turbo-ignore": "2.9.14",
         "typescript": "^6.0.3",
+        "typescript-7": "npm:typescript@rc",
         "vite": "8.0.16",
         "vitest": "4.1.7",
       },
@@ -1217,21 +1217,45 @@
 
     "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
 
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260604.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260604.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260604.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260604.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260604.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260604.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260604.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260604.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-A3/9yZTt2V5NlDURcVJ4mN2YjfeQTXCRyLuENKrNdGhO+y59mC/2UDr7UvpB3Li+83TRAuhDN8SBoM+7gkHdzQ=="],
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.1-rc", "", { "os": "aix", "cpu": "ppc64" }, "sha512-oqq2ZfEJ7BQuufcC3QBQndZLPNyamYNHLao8lKRBeeSkZKypBqxPSgkzrcFZtbYcIaBvpiyUnQP9MT7DEYHWbw=="],
 
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260604.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zs616um9UuaODLsNlCu5Aw95rFcTV4u3hVt090r6k0lVvTxfaJOv8HKA6BpIotcEYlZlMQowrMSYCCdedo7iyA=="],
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.1-rc", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Slc0yTftT2F/uGDmtPst8ijydneL6uZaLEyr2UjahxZpbhTjHFBJ5agXtVz/TL4A+ldxzjzj+E8QtLZlh/5mXw=="],
 
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260604.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-pOdNAf2pwc9JBjo8gUsvLs5uqg7d0AhYXfE8/3zvPKBlIZG+mTcvEWW1hPawlWxXzf/vxnP4dgYwUHAMDghhKA=="],
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.1-rc", "", { "os": "darwin", "cpu": "x64" }, "sha512-h68iFW/LbA1/BsGgSRGFw981/3s1f/rY27YrmeZNuN+ly7dI+fiDduwT9ZT9866x2onoKNRq7PTyxSKyKDzfAQ=="],
 
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260604.1", "", { "os": "linux", "cpu": "arm" }, "sha512-IKaZL3i5HKmKqwb2IZEXW1j68fVg1HsvAaXkbrkOIG/J5Eyksu5tEnTzucrIY1oPdzgHT+y2HpDIYp2sGeHFvw=="],
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.1-rc", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-DE+ppd8Ix2c6OMuRkKY4PJ4hngMGJ9M95OQUP17p9xL/1IKXof7npIeuusMN/bgL5o5JzMfSGh+N+5scTYRg0Q=="],
 
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260604.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-GjIrt6YHP3bbOWBCCE08SlBSDf84Lnjn3Td822/lOX9nm6ODlA/HI7rtGh7KzS/fxehep2Vy4dXU4Il12X1s5A=="],
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.1-rc", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ST1ozHMw0u+CLOnWkcTyWDMV4Qn9osZ6fd1V1lnKDM1t0hZIp81mdGpdHxyHJjd7jdGrb6Gb/QXcZ1uqZ0t5zw=="],
 
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260604.1", "", { "os": "linux", "cpu": "x64" }, "sha512-twQ7XDjsmaHIevN1MjeRYIVLUPL0fBm8A0jg1FhGYPckhTxEBiHIpJf9E//eFidAdrEHjeTSBP1jJw3GNAensg=="],
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.1-rc", "", { "os": "linux", "cpu": "arm" }, "sha512-gHmHwT5Naq5CKM8g9bbaGeEpnwQEvWCLn3fwP4K2m61VQdDKkPk0Dhab/OoZ4LV2SrMddmclYXTzpyg23YGt5g=="],
 
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260604.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-QBRxaVT3SFiNfOhwYb/56ddpHWPMFdfiJ4zkFJIjaAXeZ/ssWNHM9lH7yR++GrE9VTsUZ4eVSZfOmQbzRERhgw=="],
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.1-rc", "", { "os": "linux", "cpu": "arm64" }, "sha512-N46pRihK3t5zD5MUtTQcdmQUqr1WI4U2nxno1gLwOtRSsB4krFkRjPHcQNG7h2DtRkX64rQiReX6WKwg2wprMA=="],
 
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260604.1", "", { "os": "win32", "cpu": "x64" }, "sha512-hR7YHoRpm88Q86gK6/IMayWUA+ROdHGzOPKK8EBp1xD/Cg2Bh5AXbut8HcyUDx/bcGQvnuht/XsW47bT3to9mg=="],
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.1-rc", "", { "os": "linux", "cpu": "none" }, "sha512-G17Sao312rgiPBTh2F4nOpLpa3CcnBSaNhqNghZk2LNhnsp1RaMO5HMq2me21gqu9xLpc6CIgHtOzU6JBgNlfg=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.1-rc", "", { "os": "linux", "cpu": "none" }, "sha512-0FQspOb5UsQ4tQKvWgUO3pS9OIWkP7/8dPRWq+CRazJUeQZ4LBjtYK52jg5iIOrvItrVl2CwvRtrU3/9OihwJg=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.1-rc", "", { "os": "linux", "cpu": "ppc64" }, "sha512-SUmwfVBEv6A2Ld0eWfcvW0FqrgemfQL8jFGOmV1qYxsDqumjE5DekHXqbstgmbE4SHr4rrjHjvmuGCY+kTH/vw=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.1-rc", "", { "os": "linux", "cpu": "none" }, "sha512-rxeqnNnGiYzv/LlPHi/3+4p0ooR1cNJLjRIHXKovtiVmxXGJq6gtw8VSpbHuWPekyFMXgIAoLCZN0SQ51rAALQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.1-rc", "", { "os": "linux", "cpu": "s390x" }, "sha512-RYWCHCiPypxajdRHM2CNK/eM22e4Ex5TTjV2pXf7PTtBowGr0xX8i8kIMknyZS0LX2QfleYHouaoMVsFDSle3g=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.1-rc", "", { "os": "linux", "cpu": "x64" }, "sha512-PfLJSu0JzroDkqw2m4nqflPEcn8yev0m/vHFQlY9EzHorzjR6QG0wL8AJHvnD1e6h1s76AZngJ5u+z1K/D/HKw=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.1-rc", "", { "os": "none", "cpu": "arm64" }, "sha512-FfbPxH3dTfp8yVIaNM7bdWTixXuyxpzoemluqcqMROSIz+ImpCG3Q9HO9Ptzp9/giv+P9YYEnCMSXh61migj2w=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.1-rc", "", { "os": "none", "cpu": "x64" }, "sha512-FzdTfSzhRYb6hlav6K3cI5RVgcvCTvNAu/vc+t7B6AmZkThQ+t/1ntnvT5fnHmY1Az2RIBw7/b+qtCEG61HJTQ=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.1-rc", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-PQGhlxfNig+0YQ9Wwzd0USPBkt6w/ZqkBQWsU7G/0JkTzunJel+jSWwhKw4947pak/m7hGSeYiI04xReDLGZww=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.1-rc", "", { "os": "openbsd", "cpu": "x64" }, "sha512-WJ7NYgO2mHmLUkI/tZ+hl8lFd26QPJqO8ONOHNuYbdsybLvSB6B6sep222JIVrOfPRDGvFinbGGB+l3m1FWRWA=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.1-rc", "", { "os": "sunos", "cpu": "x64" }, "sha512-UYjDeUxd765V9qcwlUPk4pEXyL0i3G76CJm9baK4i99u1pGO1psf3nXDw4MMmElVOPvGbZag99ZR/O59E2OX6w=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.1-rc", "", { "os": "win32", "cpu": "arm64" }, "sha512-KzXzFSXZOm7zvEt2Aw0MsB2LbTL88znAiVqTDNAOHdlEb7brgmUQh/X2wM/8Be+N0fjEqWKl65cBKNwpWEbJiw=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.1-rc", "", { "os": "win32", "cpu": "x64" }, "sha512-98R3+OqDr/r0/PLWEoXu88AE0lGVLNd335Ew8ONgzK1JWkNs4ou/5BGt3Or1ij4iXjH+c7PRL+jFjCbtWze+EA=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
@@ -2594,6 +2618,8 @@
     "type-fest": ["type-fest@0.7.1", "", {}, "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "typescript-7": ["typescript@7.0.1-rc", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.1-rc", "@typescript/typescript-darwin-arm64": "7.0.1-rc", "@typescript/typescript-darwin-x64": "7.0.1-rc", "@typescript/typescript-freebsd-arm64": "7.0.1-rc", "@typescript/typescript-freebsd-x64": "7.0.1-rc", "@typescript/typescript-linux-arm": "7.0.1-rc", "@typescript/typescript-linux-arm64": "7.0.1-rc", "@typescript/typescript-linux-loong64": "7.0.1-rc", "@typescript/typescript-linux-mips64el": "7.0.1-rc", "@typescript/typescript-linux-ppc64": "7.0.1-rc", "@typescript/typescript-linux-riscv64": "7.0.1-rc", "@typescript/typescript-linux-s390x": "7.0.1-rc", "@typescript/typescript-linux-x64": "7.0.1-rc", "@typescript/typescript-netbsd-arm64": "7.0.1-rc", "@typescript/typescript-netbsd-x64": "7.0.1-rc", "@typescript/typescript-openbsd-arm64": "7.0.1-rc", "@typescript/typescript-openbsd-x64": "7.0.1-rc", "@typescript/typescript-sunos-x64": "7.0.1-rc", "@typescript/typescript-win32-arm64": "7.0.1-rc", "@typescript/typescript-win32-x64": "7.0.1-rc" }, "bin": { "tsc": "bin/tsc" } }, "sha512-drEP77wK7CCDlPfXZH4e008UUQOsw1DFmHmZOZjuNA+yoDLLnSNMZRXi90NbV/1LVo7SbNLq1bs3jjvk49TEqQ=="],
 
     "typescript5": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -4,3 +4,7 @@
 # versions being pulled in before anyone notices. See:
 # https://bun.sh/docs/runtime/bunfig#install-minimumreleaseage
 minimumReleaseAge = 604800 # 7 days, in seconds
+# The TypeScript 7 RC (typescript-7 = npm:typescript@rc) is a deliberately
+# adopted pre-release and is exempt from the release-age gate so fresh installs
+# (CI, teammates) resolve it without the --minimum-release-age 0 flag.
+minimumReleaseAgeExcludes = ["typescript-7", "typescript"]

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@types/node": "^24.0.0",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
-    "@typescript/native-preview": "7.0.0-dev.20260604.1",
     "@vercel/speed-insights": "^2.0.0",
     "@vitejs/plugin-legacy": "8.0.2",
     "@vitejs/plugin-react": "6.0.2",
@@ -93,6 +92,7 @@
     "turbo": "^2.9.18",
     "turbo-ignore": "2.9.14",
     "typescript": "^6.0.3",
+    "typescript-7": "npm:typescript@rc",
     "vite": "8.0.16",
     "vitest": "4.1.7"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -43,10 +43,10 @@
   },
   "type": "module",
   "scripts": {
-    "build": "tsgo --project tsconfig.lib.json",
+    "build": "node ../../node_modules/typescript-7/bin/tsc --project tsconfig.lib.json",
     "lint": "oxlint && biome check --linter-enabled=false .",
     "test": "vitest run",
-    "typecheck": "tsgo --noEmit --project tsconfig.json"
+    "typecheck": "node ../../node_modules/typescript-7/bin/tsc --noEmit --project tsconfig.json"
   },
   "devDependencies": {
     "@types/node": "^24.0.0"

--- a/packages/logic/package.json
+++ b/packages/logic/package.json
@@ -14,10 +14,10 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsgo --project tsconfig.lib.json",
+    "build": "node ../../node_modules/typescript-7/bin/tsc --project tsconfig.lib.json",
     "lint": "oxlint && biome check --linter-enabled=false .",
     "test": "vitest run",
-    "typecheck": "tsgo --noEmit --project tsconfig.json"
+    "typecheck": "node ../../node_modules/typescript-7/bin/tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@dorkroom/api": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,10 +39,10 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsgo --project tsconfig.lib.json",
+    "build": "node ../../node_modules/typescript-7/bin/tsc --project tsconfig.lib.json",
     "lint": "oxlint && biome check --linter-enabled=false .",
     "test": "vitest run",
-    "typecheck": "tsgo --noEmit --project tsconfig.json"
+    "typecheck": "node ../../node_modules/typescript-7/bin/tsc --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@dorkroom/api": "workspace:*",


### PR DESCRIPTION
## Summary

Move typecheck/build off the pinned `@typescript/native-preview` dev snapshot (`tsgo`, `7.0.0-dev.20260604.1`) onto the official **TypeScript 7.0.1-rc** ([announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-rc/)) — the native Go compiler.

**Approach: coexist.** The RC has **no stable programmatic API until 7.1** (per the announcement), and the repo keeps `typescript@6` for editor/Vite/Vitest and peer-dep satisfaction. So rather than replacing `typescript`, the RC is added as a `typescript-7` alias and the toolchain scripts point at its native `tsc`. This mirrors the coexistence pattern Microsoft recommends.

## Related Issues

None. Top of the stack — see **Additional Notes**.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes) — build-toolchain/deps only; **no app runtime or behavior change**
- [ ] Data addition (film, developer, or recipe entries)

## Changes Made

- **Root `package.json`** — remove `@typescript/native-preview`; add `"typescript-7": "npm:typescript@rc"` (resolves to `typescript@7.0.1-rc`, native compiler via `@typescript/typescript-darwin-arm64@7.0.1-rc` et al). `typescript@^6.0.3` stays for editor tsserver, Vite/Vitest, and peers.
- **`bunfig.toml`** — add `minimumReleaseAgeExcludes = ["typescript-7", "typescript"]` so the freshly-published RC resolves on a normal `bun install` without the `--minimum-release-age 0` flag (CI/teammate friendly).
- **Typecheck/build scripts** (`api`, `logic`, `ui`, `dorkroom`, `mobile`) — `tsgo` / `tsc` → `node ../../node_modules/typescript-7/bin/tsc`. The RC's `tsc` bin loses the `.bin/tsc` collision to TS 6 and its `exports` map blocks deep imports, so the scripts call it by hoisted path (all workspaces are depth-2 → root `node_modules`).
- **`bun.lock`** — lockfile update.

### Benchmark — TS 6 (JS, 6.0.3) vs TS 7 RC (native, 7.0.1-rc)

Cold `--noEmit` typecheck, 3 runs each, incremental cache cleared between runs:

| Project | TS 6 | TS 7 RC | Speedup |
|---|---|---|---|
| `@dorkroom/ui` (`tsconfig.lib.json`) | 2.29s | 0.34s | **~6.7×** |
| `@dorkroom/logic` (`tsconfig.lib.json`) | 1.02s | 0.13s | **~7.6×** |
| App graph (`tsc -b`, cross-package) | 4.3s | 0.5s | **~8×** |

## Testing

- [x] I have run `bun run test` and all checks pass — **1628 tests**, plus lint/build/typecheck across all `@dorkroom/*` (including `@dorkroom/mobile` typechecking on the RC).
- [ ] I have added tests that prove my fix/feature works — toolchain change; verified via the existing gate + benchmark.
- [x] I have tested manually in the development environment — ran the RC directly against the real source configs (`tsconfig.lib.json` / `tsconfig.app.json`) for every project: libraries exit 0; app source is clean. React Doctor **100/100** on all four projects. Confirmed a no-flag `bun install` resolves the RC via the release-age exclude.

## Checklist

- [x] My code follows the project's code style
- [x] I have formatted my code (`biome check` passes)
- [x] I have made corresponding changes to documentation (no CHANGELOG entry — consistent with how existing `chore(deps)` changes are handled)
- [x] My changes generate no new warnings
- [x] I have checked that there are no circular dependencies between packages

## Additional Notes

**Stack (Graphite):** `main → #131 (FCP) → #132 (Biome ignore) → #133 (this)`. Depends on #131/#132 only for a clean stack (the `ui`/`logic` `package.json` script hunks sit on top of #131's `sideEffects` hunks in the same files).

**Editor DX:** the RC targets the [TypeScript Native Preview VS Code extension](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-rc/) (LSP). `typescript@6` remains installed, so the classic editor experience is unaffected; the native compiler is used only by the CLI typecheck/build scripts.

**Mobile:** migrated too — Expo SDK 56 supports TS 7 ([changelog](https://expo.dev/changelog/sdk-56)). It keeps its own `typescript@~6` for Expo tooling while typechecking on the RC (exit 0).

**Pre-existing issues surfaced (not fixed here):**
- The `typecheck` scripts target solution `tsconfig.json` files (empty `files`) → they are **no-ops**; real typechecking happens via `build` (`tsconfig.lib.json`). The app is never fully typechecked in the gate (`vite build` transpiles without checking). Worth a follow-up to point the app `typecheck` at `tsconfig.app.json`.
- `apps/dorkroom/tsconfig.app.json` still lists stale `@nx/react/typings/*.d.ts` in `types` (leftover from the pre-Turborepo Nx setup) — the only 2 errors when checking the app graph directly, on both compilers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
