### PR TITLE
chore(ci): fix badge sync for typescript@rc, scope screenshot trigger

### DIFF
--- a/.github/workflows/homepage-screenshot.yml
+++ b/.github/workflows/homepage-screenshot.yml
@@ -6,7 +6,11 @@ on:
     paths:
       - apps/dorkroom/src/app/pages/home-page.tsx
       - apps/dorkroom/src/routes/index.tsx
-      - packages/ui/**
+      # Only rendered UI source affects the screenshot — not package.json bumps,
+      # config, docs, or tests under packages/ui (those triggered needless runs).
+      - packages/ui/src/**
+      - '!packages/ui/src/**/__tests__/**'
+      - '!packages/ui/src/**/*.test.*'
       - scripts/screenshot-homepage.ts
       - .github/workflows/homepage-screenshot.yml
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![Version](https://img.shields.io/badge/Version-2026.07.03-red) [![License](https://img.shields.io/badge/License-AGPL_V3.0-blue)](https://github.com/narrowstacks/dorkroom/blob/main/LICENSE)
 
-![React 19](https://img.shields.io/badge/React-19-61DAFB) ![TypeScript](https://img.shields.io/badge/TypeScript-7.0_beta-3178C6) ![Tailwind CSS](https://img.shields.io/badge/Tailwind-4.3.0-06B6D4) ![TanStack Query](https://img.shields.io/badge/-TanStack%20Query-red?style=flat-square&logo=react-query&logoColor=white) ![Biome](https://img.shields.io/badge/Biome-60A5FA?logo=biome&logoColor=fff)
+![React 19](https://img.shields.io/badge/React-19-61DAFB) ![TypeScript](https://img.shields.io/badge/TypeScript-7.0_rc-3178C6) ![Tailwind CSS](https://img.shields.io/badge/Tailwind-4.3.0-06B6D4) ![TanStack Query](https://img.shields.io/badge/-TanStack%20Query-red?style=flat-square&logo=react-query&logoColor=white) ![Biome](https://img.shields.io/badge/Biome-60A5FA?logo=biome&logoColor=fff)
 
 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m801823706-109991125954deb52b9281b8?logo=vercel&link=https%3A%2F%2Fstats.uptimerobot.com%2FL75VVTPwtz)](https://stats.uptimerobot.com/L75VVTPwtz) [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/narrowstacks/dorkroom/ci.yml?logo=github&label=CI)](https://github.com/narrowstacks/dorkroom/actions/workflows/ci.yml) [![GitHub Issues or Pull Requests](https://img.shields.io/github/issues-pr/narrowstacks/dorkroom)](https://github.com/narrowstacks/dorkroom/pulls) [![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/narrowstacks/dorkroom)](https://github.com/narrowstacks/dorkroom/issues)
 

--- a/scripts/__tests__/sync-readme-badges.test.ts
+++ b/scripts/__tests__/sync-readme-badges.test.ts
@@ -1,34 +1,46 @@
 import { describe, expect, it } from 'vitest';
-import { applyBadgeUpdates, deriveBadgeValues } from '../sync-readme-badges';
+import {
+  applyBadgeUpdates,
+  deriveBadgeValues,
+  parseTypescriptVersion,
+} from '../sync-readme-badges';
+
+describe('parseTypescriptVersion', () => {
+  it('reads the resolved typescript-7 alias version from bun.lock', () => {
+    const lock = [
+      '    "typescript": ["typescript@6.0.3", "", {}, "sha512-aaa=="],',
+      '    "typescript-7": ["typescript@7.0.1-rc", "", {}, "sha512-bbb=="],',
+    ].join('\n');
+    expect(parseTypescriptVersion(lock)).toBe('7.0.1-rc');
+  });
+
+  it('throws when the typescript-7 alias is absent', () => {
+    expect(() => parseTypescriptVersion('{}')).toThrow(/typescript-7/i);
+  });
+});
 
 describe('deriveBadgeValues', () => {
-  it('extracts CalVer, React major, full Tailwind, and TS major.minor + _beta', () => {
+  it('extracts CalVer, React major, full Tailwind, and TS major.minor + prerelease tag', () => {
     const pkg = {
       version: '2026.05.28',
       dependencies: { react: '19.2.3' },
-      devDependencies: {
-        tailwindcss: '4.3.0',
-        '@typescript/native-preview': '7.0.0-dev.20260421.2',
-      },
+      devDependencies: { tailwindcss: '4.3.0' },
     };
-    expect(deriveBadgeValues(pkg)).toEqual({
+    expect(deriveBadgeValues(pkg, '7.0.1-rc')).toEqual({
       version: '2026.05.28',
       react: '19',
       tailwind: '4.3.0',
-      typescript: '7.0_beta',
+      typescript: '7.0_rc',
     });
   });
 
-  it('strips leading ^ and ~ from ranges', () => {
+  it('strips leading ^ and ~ from ranges and honors other prerelease tags', () => {
     const pkg = {
       version: '2026.06.03',
       dependencies: { react: '^20.0.1' },
-      devDependencies: {
-        tailwindcss: '~4.5.0',
-        '@typescript/native-preview': '7.1.0-dev.1',
-      },
+      devDependencies: { tailwindcss: '~4.5.0' },
     };
-    expect(deriveBadgeValues(pkg)).toEqual({
+    expect(deriveBadgeValues(pkg, '7.1.0-beta.1')).toEqual({
       version: '2026.06.03',
       react: '20',
       tailwind: '4.5.0',
@@ -36,36 +48,50 @@ describe('deriveBadgeValues', () => {
     });
   });
 
+  it('omits the suffix for a stable release', () => {
+    const pkg = {
+      version: '2026.06.03',
+      dependencies: { react: '19.2.3' },
+      devDependencies: { tailwindcss: '4.3.0' },
+    };
+    expect(deriveBadgeValues(pkg, '7.0.0').typescript).toBe('7.0');
+  });
+
   it('throws when react is missing', () => {
     expect(() =>
-      deriveBadgeValues({
-        version: '2026.06.03',
-        devDependencies: {
-          tailwindcss: '4.3.0',
-          '@typescript/native-preview': '7.0.0-dev.1',
+      deriveBadgeValues(
+        {
+          version: '2026.06.03',
+          devDependencies: { tailwindcss: '4.3.0' },
         },
-      })
+        '7.0.1-rc'
+      )
     ).toThrow(/react/i);
   });
 
   it('throws when tailwindcss is missing', () => {
     expect(() =>
-      deriveBadgeValues({
-        version: '2026.06.03',
-        dependencies: { react: '19.2.3' },
-        devDependencies: { '@typescript/native-preview': '7.0.0-dev.1' },
-      })
+      deriveBadgeValues(
+        {
+          version: '2026.06.03',
+          dependencies: { react: '19.2.3' },
+        },
+        '7.0.1-rc'
+      )
     ).toThrow(/tailwind/i);
   });
 
-  it('throws when @typescript/native-preview is missing or malformed', () => {
+  it('throws when the typescript version is malformed', () => {
     expect(() =>
-      deriveBadgeValues({
-        version: '2026.06.03',
-        dependencies: { react: '19.2.3' },
-        devDependencies: { tailwindcss: '4.3.0' },
-      })
-    ).toThrow(/typescript|native-preview/i);
+      deriveBadgeValues(
+        {
+          version: '2026.06.03',
+          dependencies: { react: '19.2.3' },
+          devDependencies: { tailwindcss: '4.3.0' },
+        },
+        ''
+      )
+    ).toThrow(/typescript/i);
   });
 });
 

--- a/scripts/sync-readme-badges.ts
+++ b/scripts/sync-readme-badges.ts
@@ -21,28 +21,44 @@ interface PackageJson {
 
 const stripRange = (v: string): string => v.replace(/^[\^~]/, '');
 
-export function deriveBadgeValues(pkg: PackageJson): BadgeValues {
+/**
+ * The build compiler is pinned as `typescript-7: npm:typescript@rc`, so
+ * package.json only records the `rc` dist-tag — the concrete resolved version
+ * lives in bun.lock. Pull it from there so the badge tracks the real version.
+ */
+export function parseTypescriptVersion(lock: string): string {
+  const match = lock.match(/"typescript-7":\s*\[\s*"typescript@([^"]+)"/);
+  if (!match) {
+    throw new Error(
+      'Could not find resolved "typescript-7" version in bun.lock'
+    );
+  }
+  return match[1];
+}
+
+export function deriveBadgeValues(
+  pkg: PackageJson,
+  tsVersion: string
+): BadgeValues {
   const react = stripRange(pkg.dependencies?.react ?? '');
   const tailwind = stripRange(pkg.devDependencies?.tailwindcss ?? '');
-  const tsRaw = stripRange(
-    pkg.devDependencies?.['@typescript/native-preview'] ?? ''
-  );
-  // '7.0.0-dev.20260421.2' -> base '7.0.0' -> major.minor '7.0' -> '7.0_beta'
-  const tsBase = tsRaw.split('-')[0];
+  // '7.0.1-rc' -> base '7.0.1', prerelease 'rc' -> major.minor '7.0' -> '7.0_rc'
+  const [tsBase, tsPre = ''] = tsVersion.split('-');
   const [tsMajor, tsMinor] = tsBase.split('.');
+  const tsTag = tsPre.match(/^[a-z]+/i)?.[0];
   if (!react) throw new Error('Missing dependencies.react in package.json');
   if (!tailwind)
     throw new Error('Missing devDependencies.tailwindcss in package.json');
   if (!tsMajor || !tsMinor) {
-    throw new Error(
-      `Unexpected @typescript/native-preview version: "${tsRaw}"`
-    );
+    throw new Error(`Unexpected typescript version: "${tsVersion}"`);
   }
   return {
     version: pkg.version,
     react: react.split('.')[0],
     tailwind,
-    typescript: `${tsMajor}.${tsMinor}_beta`,
+    typescript: tsTag
+      ? `${tsMajor}.${tsMinor}_${tsTag}`
+      : `${tsMajor}.${tsMinor}`,
   };
 }
 
@@ -66,9 +82,12 @@ async function main(): Promise<void> {
   const pkg = JSON.parse(
     await readFile(join(root, 'package.json'), 'utf8')
   ) as PackageJson;
+  const tsVersion = parseTypescriptVersion(
+    await readFile(join(root, 'bun.lock'), 'utf8')
+  );
   const readmePath = join(root, 'README.md');
   const readme = await readFile(readmePath, 'utf8');
-  const updated = applyBadgeUpdates(readme, deriveBadgeValues(pkg));
+  const updated = applyBadgeUpdates(readme, deriveBadgeValues(pkg, tsVersion));
   if (updated !== readme) {
     await writeFile(readmePath, updated);
     console.log('README badges updated.');


### PR DESCRIPTION
## Summary

Two CI chores plus branch cleanup.

### Fix failing **Sync README Badges** action
It had been failing on every push to `main` since #133, which renamed the build compiler dep from `@typescript/native-preview` to `typescript-7: npm:typescript@rc`. The script still read the old key → empty string → `throw` (`Unexpected @typescript/native-preview version: ""`).

- The concrete version (`7.0.1-rc`) now lives only in `bun.lock`, so `parseTypescriptVersion(lock)` reads the resolved `typescript-7` alias from there.
- `deriveBadgeValues(pkg, tsVersion)` derives the prerelease tag generically (`rc` / `beta` / none) instead of hardcoding `_beta`.
- README TypeScript badge: `7.0_beta` → `7.0_rc`.
- Test suite updated — 10 tests passing under the root `vitest` in the CI gate.

### Scope the **Homepage Screenshot** trigger
`packages/ui/**` matched non-visual files (e.g. `packages/ui/package.json`), firing needless screenshot runs on dependency bumps. Narrowed to `packages/ui/src/**`, excluding `__tests__/**` and `*.test.*`.

## Test plan
- [x] `bunx vitest run scripts/__tests__/sync-readme-badges.test.ts` — 10/10 pass
- [x] `bun run scripts/sync-readme-badges.ts` produces the correct `7.0_rc` badge
- [x] Homepage-screenshot workflow YAML validated; negation paths parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)