### PR TITLE
fix(mobile): hoist More header buttons to module scope

### DIFF
--- a/apps/mobile/app/(tabs)/more/_layout.tsx
+++ b/apps/mobile/app/(tabs)/more/_layout.tsx
@@ -22,12 +22,34 @@ function HeaderBackButton() {
   );
 }
 
+// Text "Done" button for the Edit Tabs modal — a custom view gets the iOS 26
+// system glass as a pill, which reads correctly with a text label (vs an icon,
+// which wants a circle the custom-view path can't produce here).
+function DoneButton() {
+  return (
+    <Pressable
+      hitSlop={12}
+      onPress={() => router.back()}
+      accessibilityRole="button"
+      accessibilityLabel="Close"
+      // Breathing room so the system glass pill isn't tight on the text.
+      style={{ paddingHorizontal: 10 }}
+    >
+      <Text style={{ color: '#ffffff', fontSize: 17, fontWeight: '600' }}>
+        Done
+      </Text>
+    </Pressable>
+  );
+}
+
 export default function MoreLayout() {
   return (
     <Stack
+      // headerLeft callbacks reference module-scope components so they aren't
+      // redefined on every render (react/no-unstable-nested-components).
       screenOptions={{
         ...stackHeaderOptions,
-        headerLeft: () => <HeaderBackButton />,
+        headerLeft: HeaderBackButton,
       }}
     >
       <Stack.Screen name="index" options={{ headerShown: false }} />
@@ -41,25 +63,7 @@ export default function MoreLayout() {
           // require a scroll contentInset, which the drag overlay doesn't
           // account for (dragged rows snap under the header).
           headerLargeTitle: false,
-          // Text "Done" button — a custom view gets the iOS 26 system glass as a
-          // pill, which reads correctly with a text label (vs an icon, which
-          // wants a circle the custom-view path can't produce here).
-          headerLeft: () => (
-            <Pressable
-              hitSlop={12}
-              onPress={() => router.back()}
-              accessibilityRole="button"
-              accessibilityLabel="Close"
-              // Breathing room so the system glass pill isn't tight on the text.
-              style={{ paddingHorizontal: 10 }}
-            >
-              <Text
-                style={{ color: '#ffffff', fontSize: 17, fontWeight: '600' }}
-              >
-                Done
-              </Text>
-            </Pressable>
-          ),
+          headerLeft: DoneButton,
         }}
       />
     </Stack>


### PR DESCRIPTION
## Summary

Fixes the two `Do not define components during render` warnings surfaced by CI in `apps/mobile/app/(tabs)/more/_layout.tsx` (flagged by `react/no-unstable-nested-components`).

Both `headerLeft` callbacks were defined inline inside `MoreLayout`'s render:
- the detail-page back button (`() => <HeaderBackButton />`)
- the Edit Tabs modal's Done button (an inline `Pressable`)

Inline render callbacks recreate component identity on every render. Hoisted both to stable module-scope components (`HeaderBackButton` already existed; extracted `DoneButton`) and reference them directly from the header options. No behavioral change — same buttons, same handlers.

The remaining ~21 lint warnings are the intentional `jsx-a11y` `warn`-level rules documented in the root `CLAUDE.md`, left as-is.

## Test plan
- [x] `bun run lint` (apps/mobile) — clean, the two warnings gone
- [x] `bunx oxlint` — exit 0
- [x] `bun run typecheck` (apps/mobile) — passes

Stacked on #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)