### PR TITLE
fix(security): resolve CodeQL code-scanning alerts

### DIFF
--- a/packages/logic/src/hooks/use-reciprocity-calculator.ts
+++ b/packages/logic/src/hooks/use-reciprocity-calculator.ts
@@ -73,19 +73,22 @@ export const parseReciprocityTime = (input: string): number | null => {
   let seconds = 0;
   let valid = false;
 
-  const hourMatch = cleaned.match(/(\d+(\.\d+)?)\s*h/);
+  // Digit runs are bounded (`\d{1,9}`) rather than `\d+`: exposure times never
+  // need nine digits, and the bound keeps these unanchored matches linear
+  // (unbounded `\d+` next to `\s*` is a polynomial-ReDoS pattern).
+  const hourMatch = cleaned.match(/(\d{1,9}(\.\d{1,9})?)\s*h/);
   if (hourMatch) {
     seconds += parseFloat(hourMatch[1]) * 3600;
     valid = true;
   }
 
-  const minuteMatch = cleaned.match(/(\d+(\.\d+)?)\s*m(?!s)/);
+  const minuteMatch = cleaned.match(/(\d{1,9}(\.\d{1,9})?)\s*m(?!s)/);
   if (minuteMatch) {
     seconds += parseFloat(minuteMatch[1]) * 60;
     valid = true;
   }
 
-  const secondMatch = cleaned.match(/(\d+(\.\d+)?)\s*s/);
+  const secondMatch = cleaned.match(/(\d{1,9}(\.\d{1,9})?)\s*s/);
   if (secondMatch) {
     seconds += parseFloat(secondMatch[1]);
     valid = true;

--- a/packages/logic/src/utils/base64.ts
+++ b/packages/logic/src/utils/base64.ts
@@ -35,7 +35,12 @@ export function decodeBase64(input: string): string {
  * Replaces `+` with `-`, `/` with `_`, and strips trailing `=` padding.
  */
 export function toUrlSafe(base64: string): string {
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  // `={1,2}$` (bounded) rather than `=+$`: valid base64 has at most two
+  // padding chars, and the bound keeps the match linear (no ReDoS backtracking).
+  return base64
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/={1,2}$/, '');
 }
 
 /**

--- a/packages/logic/src/utils/text-sanitization.ts
+++ b/packages/logic/src/utils/text-sanitization.ts
@@ -26,26 +26,34 @@ export function sanitizeText(
 
   let sanitized = text;
 
-  // Remove all HTML tags (including self-closing and malformed tags)
-  // This regex handles: <tag>, </tag>, <tag/>, <tag attr="value">
-  sanitized = sanitized.replace(/<[^>]*>/g, '');
-
-  // Remove dangerous protocol handlers and event attributes
-  // Handle variations: javascript:, JAVASCRIPT:, java\x00script:, etc.
-  sanitized = sanitized
-    .replace(/javascript\s*:/gi, '')
-    .replace(/vbscript\s*:/gi, '')
-    .replace(/on\w+\s*=/gi, '') // onclick=, onerror=, etc.
-    .replace(/data\s*:\s*text\/html/gi, '')
-    .replace(/data\s*:\s*application/gi, '');
-
-  // Remove any remaining script-related content
-  // This catches cases where tags were URL-encoded or obfuscated
-  sanitized = sanitized
-    .replace(/script/gi, '')
-    .replace(/iframe/gi, '')
-    .replace(/object/gi, '')
-    .replace(/embed/gi, '');
+  // Apply the tag/pattern removals repeatedly until the string stops changing.
+  // A single pass is bypassable because one removal can splice two fragments
+  // into a fresh dangerous token (e.g. `<scr<script>ipt>` -> `<script>`), so we
+  // loop to a fixpoint rather than replacing once.
+  let previous: string;
+  do {
+    previous = sanitized;
+    sanitized = sanitized
+      // Remove all HTML tags (including self-closing and malformed tags).
+      // Handles: <tag>, </tag>, <tag/>, <tag attr="value">
+      // The `{0,2000}` bound (rather than `*`) keeps this linear — an unbounded
+      // `[^>]*` next to a required `>` backtracks quadratically on input like
+      // `<<<<…` (polynomial ReDoS); no real tag approaches 2000 chars.
+      .replace(/<[^>]{0,2000}>/g, '')
+      // Remove dangerous protocol handlers and event attributes.
+      // Handle variations: javascript:, JAVASCRIPT:, java\x00script:, etc.
+      .replace(/javascript\s*:/gi, '')
+      .replace(/vbscript\s*:/gi, '')
+      .replace(/on\w+\s*=/gi, '') // onclick=, onerror=, etc.
+      .replace(/data\s*:\s*text\/html/gi, '')
+      .replace(/data\s*:\s*application/gi, '')
+      // Remove any remaining script-related content. This catches cases where
+      // tags were URL-encoded or obfuscated.
+      .replace(/script/gi, '')
+      .replace(/iframe/gi, '')
+      .replace(/object/gi, '')
+      .replace(/embed/gi, '');
+  } while (sanitized !== previous);
 
   // Remove null bytes and other control characters (except \n, \r, \t)
   // Using RegExp constructor to avoid biome lint warning about control characters

--- a/packages/logic/src/utils/url-helpers.ts
+++ b/packages/logic/src/utils/url-helpers.ts
@@ -217,6 +217,37 @@ export function isClipboardSupported(): boolean {
 }
 
 /**
+ * Checks whether a value points at filmdev.org (or a subdomain of it).
+ *
+ * Parses the value as a URL and compares the host, rather than using a
+ * substring match like `value.includes('filmdev.org')` — a substring check
+ * would wrongly accept `evil.com/filmdev.org` or `filmdev.org.attacker.com`.
+ * Accepts protocol-less input (e.g. `filmdev.org/12345`) by assuming https.
+ *
+ * @public
+ * @param value - URL or host-like string to test
+ * @returns True if the host is `filmdev.org` or `*.filmdev.org`
+ * @example
+ * ```typescript
+ * isFilmDevOrgUrl('https://www.filmdev.org/recipe/123'); // true
+ * isFilmDevOrgUrl('filmdev.org/12345');                  // true
+ * isFilmDevOrgUrl('https://evil.com/filmdev.org');       // false
+ * ```
+ */
+export function isFilmDevOrgUrl(value: string | null | undefined): boolean {
+  if (!value) return false;
+  const trimmed = value.trim();
+  try {
+    const { hostname } = new URL(
+      trimmed.includes('://') ? trimmed : `https://${trimmed}`
+    );
+    return hostname === 'filmdev.org' || hostname.endsWith('.filmdev.org');
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Gets a user-friendly URL for display purposes by removing the protocol.
  * Creates cleaner URLs for UI display while preserving path and hash.
  *

--- a/packages/ui/src/components/development-recipes/recipe-detail-panel.tsx
+++ b/packages/ui/src/components/development-recipes/recipe-detail-panel.tsx
@@ -2,6 +2,7 @@ import type { Dilution } from '@dorkroom/api';
 import {
   calculatePushPull,
   type DevelopmentCombinationView,
+  isFilmDevOrgUrl,
 } from '@dorkroom/logic';
 import { ExternalLink, Star } from 'lucide-react';
 import type { FC } from 'react';
@@ -354,7 +355,7 @@ const SidebarPanelContent: FC<PanelLayoutProps> = ({
           className="inline-flex items-center gap-2 text-xs text-tertiary underline-offset-4 hover:text-primary hover:underline"
         >
           <ExternalLink className="size-3" />{' '}
-          {combination.infoSource.includes('filmdev.org')
+          {isFilmDevOrgUrl(combination.infoSource)
             ? 'View on FilmDev.org'
             : 'View source'}
         </a>
@@ -584,7 +585,7 @@ const ExpandedSideColumn: FC<PanelLayoutProps> = ({
           }}
         >
           <ExternalLink className="size-4" />
-          {combination.infoSource.includes('filmdev.org')
+          {isFilmDevOrgUrl(combination.infoSource)
             ? 'View on FilmDev.org'
             : 'View Source'}
         </a>

--- a/packages/ui/src/components/development-recipes/recipe-detail.tsx
+++ b/packages/ui/src/components/development-recipes/recipe-detail.tsx
@@ -2,6 +2,7 @@ import type { Dilution } from '@dorkroom/api';
 import {
   calculatePushPull,
   type DevelopmentCombinationView,
+  isFilmDevOrgUrl,
 } from '@dorkroom/logic';
 import { Edit2, ExternalLink, Share2, Star, Trash2 } from 'lucide-react';
 import { useState } from 'react';
@@ -155,7 +156,7 @@ export function DevelopmentRecipeDetail({
           className="inline-flex items-center gap-2 text-xs text-tertiary underline-offset-4 hover:text-primary hover:underline"
         >
           <ExternalLink className="size-3" />{' '}
-          {combination.infoSource.includes('filmdev.org')
+          {isFilmDevOrgUrl(combination.infoSource)
             ? 'View on FilmDev.org'
             : 'View source'}
         </a>

--- a/packages/ui/src/components/development-recipes/table-columns.tsx
+++ b/packages/ui/src/components/development-recipes/table-columns.tsx
@@ -1,6 +1,7 @@
 import {
   calculatePushPull,
   type DevelopmentCombinationView,
+  isFilmDevOrgUrl,
 } from '@dorkroom/logic';
 import type { CellContext, ColumnDef } from '@tanstack/react-table';
 import type { LucideIcon } from 'lucide-react';
@@ -545,7 +546,7 @@ export const createTableColumns = (
               target="_blank"
               rel="noreferrer"
               title={
-                combination.infoSource.includes('filmdev.org')
+                isFilmDevOrgUrl(combination.infoSource)
                   ? 'View on FilmDev.org'
                   : 'View source'
               }

--- a/packages/ui/src/forms/schemas/import-recipe.schema.ts
+++ b/packages/ui/src/forms/schemas/import-recipe.schema.ts
@@ -1,3 +1,4 @@
+import { isFilmDevOrgUrl } from '@dorkroom/logic';
 import { z } from 'zod';
 
 /**
@@ -10,8 +11,8 @@ export const importRecipeSchema = z.object({
     .min(1, 'Please enter a recipe URL, ID, or code')
     .refine((value) => {
       const trimmed = value.trim();
-      // Match filmdev.org URL
-      if (trimmed.includes('filmdev.org')) return true;
+      // Match filmdev.org URL (host-checked, not a loose substring match)
+      if (isFilmDevOrgUrl(trimmed)) return true;
       // Match filmdev recipe ID (typically numeric)
       if (/^\d+$/.test(trimmed)) return true;
       // Match shared recipe code (alphanumeric)

--- a/scripts/verify-legacy-build.ts
+++ b/scripts/verify-legacy-build.ts
@@ -88,8 +88,11 @@ function startStaticServer(transformHtml?: (html: string) => string): Promise<{
       });
       res.end(body);
     } catch (err) {
-      res.writeHead(500);
-      res.end(String(err));
+      // Log the detail server-side; don't reflect the error (which may carry a
+      // stack trace or attacker-controlled path) back in the response body.
+      console.error('  [500]', err);
+      res.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end('Internal server error');
     }
   });
   return new Promise((resolve) => {


### PR DESCRIPTION
Resolves all 16 open CodeQL code-scanning alerts: **14 fixed in code**, **2 dismissed** on GitHub as non-issues.

## Fixed in code (14 alerts)

**URL substring sanitization (5 alerts)** — `.includes('filmdev.org')` would wrongly accept hosts like `evil.com/filmdev.org`. Replaced with a new host-parsing helper `isFilmDevOrgUrl()` in `@dorkroom/logic`, used by the import-recipe schema and the three recipe components. These call sites only pick a link label, so behavior is unchanged for real filmdev URLs — the check is just correct now.

**Polynomial ReDoS (5 alerts)** — bounded previously unbounded quantifiers:
- `base64.ts`: `=+$` → `={1,2}$` (valid base64 padding is at most 2 chars)
- `use-reciprocity-calculator.ts`: `\d+` → `\d{1,9}` in the three time-parse regexes
- `text-sanitization.ts`: `<[^>]*>` → `<[^>]{0,2000}>`

**Incomplete multi-character sanitization (2 alerts)** — `sanitizeText` now loops its tag/protocol removals to a fixpoint, so one removal can't splice two fragments into a fresh dangerous token (e.g. `<scr<script>ipt>` → `<script>`).

**Stack-trace exposure + XSS-through-exception (2 alerts)** — the `verify-legacy-build.ts` static server no longer reflects `String(err)` in the response body; it logs the detail server-side and returns a generic 500.

## Dismissed (2 alerts)
- `og.test.ts:224` (`incomplete-url-substring-sanitization`) → **used in tests**: a vitest `fetch` mock, not runtime handling.
- `verify-legacy-build.ts:110` (`incomplete-multi-character-sanitization`) → **false positive**: `forceLegacyHtml()` rewrites our own trusted Vite build output, not untrusted input.

## Verification
- `bun run test` (lint + test + build + typecheck): passes, 1631 tests green.
- React Doctor: 0 issues across all four projects — no regression.

The 14 code-fixed alerts remain "open" on GitHub until CodeQL re-scans this branch; they'll auto-close once scanned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)