### PR TITLE
chore(home): rename Calculators section to Tools, drop Coming Soon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project uses [CalVer](https://calver.org/) date-based versioning: `YYYY.MM.
 
 ### Changed
 
+- Renamed the home page's "Calculators" section heading to "Tools", and removed the "Coming soon" strip (Docs / Infobase) that sat below the tool grid. The now-unused `data-coming-soon` darkroom-theme CSS guards were dropped as well.
+- Reworded the non-standard temperature warning in the development recipes / recipe detail view to read "Raise/Lower your chemistry (developer, stop, and fixer) **temperature** to … before starting development" for clarity.
 - Faster initial render (First Contentful Paint): the app now paints a lightweight inline shell (a centered spinner) straight from `index.html`, so first paint is no longer gated on downloading and executing the full JavaScript entry bundle — React swaps the shell out on mount. In addition, `@dorkroom/ui` and `@dorkroom/logic` are now marked side-effect-free (`"sideEffects": false`) so the bundler can tree-shake the shared barrel; form, table, and virtualization code no longer lands in the initial critical-path chunk on routes that don't use it. Together these cut the eager critical-path JS by roughly 30% and decouple first paint from bundle execution, without any layout shift (CLS stays 0).
 
 ## [2026.07.03]

--- a/apps/dorkroom/package.json
+++ b/apps/dorkroom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dorkroom/dorkroom",
-  "version": "2026.07.03",
+  "version": "2026.07.04",
   "private": true,
   "license": "AGPL-3.0-only",
   "scripts": {

--- a/apps/dorkroom/src/app/pages/__tests__/home-page.integration.test.tsx
+++ b/apps/dorkroom/src/app/pages/__tests__/home-page.integration.test.tsx
@@ -123,9 +123,9 @@ describe('HomePage', () => {
       // The page should still render with main content visible
       expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
 
-      // Calculators section should still be visible (static content, not API-dependent)
+      // Tools section should still be visible (static content, not API-dependent)
       expect(
-        screen.getByRole('heading', { name: /calculators/i, level: 2 })
+        screen.getByRole('heading', { name: /tools/i, level: 2 })
       ).toBeInTheDocument();
     });
 

--- a/apps/dorkroom/src/app/pages/home-page.tsx
+++ b/apps/dorkroom/src/app/pages/home-page.tsx
@@ -2,10 +2,8 @@ import { useStats } from '@dorkroom/logic';
 import { CATEGORY_LABELS, Greeting, ToolCard } from '@dorkroom/ui';
 import { Link } from '@tanstack/react-router';
 import {
-  BookOpen,
   CalculatorIcon,
   Camera,
-  Construction,
   Crop,
   Film,
   FlaskConical,
@@ -13,7 +11,6 @@ import {
   Frame,
   Gauge,
   GitBranch,
-  GraduationCap,
   HandCoins,
   Ruler,
   Timer,
@@ -98,19 +95,6 @@ const CALCULATORS = [
   },
 ] as const;
 
-const COMING_SOON = [
-  {
-    title: 'Docs',
-    description: 'Documentation for Dorkroom',
-    icon: BookOpen,
-  },
-  {
-    title: 'Infobase',
-    description: 'Photography & darkroom guides',
-    icon: GraduationCap,
-  },
-];
-
 export function HomePage() {
   const { data: stats, isPending: isStatsLoading } = useStats();
   // Compute the year client-only to avoid a render-time new Date() value.
@@ -191,7 +175,7 @@ export function HomePage() {
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-xl font-semibold text-[color:var(--color-text-primary)] flex items-center gap-2">
             <CalculatorIcon className="size-5 text-[color:var(--color-text-tertiary)]" />
-            Calculators
+            Tools
           </h2>
           <div
             className="h-px flex-1 ml-4"
@@ -214,35 +198,6 @@ export function HomePage() {
             />
           ))}
         </div>
-      </div>
-
-      {/* Coming Soon - quiet strip below the grid */}
-      <div
-        className="rounded-2xl border border-dashed px-4 py-3 flex flex-col sm:flex-row sm:items-center gap-x-8 gap-y-2"
-        style={{
-          borderColor: 'var(--color-border-secondary)',
-          backgroundColor: 'var(--color-surface-muted)',
-        }}
-        data-coming-soon-section
-      >
-        <span className="flex shrink-0 items-center gap-2 text-xs font-bold uppercase tracking-wider text-[color:var(--color-text-tertiary)]">
-          <Construction className="size-4" data-coming-soon />
-          Coming soon
-        </span>
-        {COMING_SOON.map((item) => (
-          <div key={item.title} className="flex items-center gap-2 min-w-0">
-            <item.icon
-              className="size-4 shrink-0 text-[color:var(--color-text-tertiary)]"
-              data-coming-soon
-            />
-            <span className="font-medium text-[color:var(--color-text-secondary)]">
-              {item.title}
-            </span>
-            <span className="text-sm text-[color:var(--color-text-tertiary)] truncate">
-              {item.description}
-            </span>
-          </div>
-        ))}
       </div>
 
       {/* Footer Links - Minimal */}

--- a/apps/dorkroom/src/styles/theme.css
+++ b/apps/dorkroom/src/styles/theme.css
@@ -970,8 +970,8 @@
   color: var(--color-official-badge-icon) !important;
 }
 
-/* Ensure all icons use only black/red in darkroom theme (except coming soon section) */
-[data-theme="darkroom"] svg:not([data-coming-soon]) {
+/* Ensure all icons use only black/red in darkroom theme */
+[data-theme="darkroom"] svg {
   color: var(--color-text-primary);
   stroke: var(--color-text-primary);
 }
@@ -999,9 +999,7 @@
 
 /* Make tool card icons black on hover in darkroom mode (so they're visible against red bg) */
 /* Only target anchor tags (tool cards), not button elements (dropdown items), but exclude statcards */
-[data-theme="darkroom"]
-  a.group:hover
-  svg:not([data-coming-soon]):not([data-statcard-icon]) {
+[data-theme="darkroom"] a.group:hover svg:not([data-statcard-icon]) {
   color: #000000;
   stroke: #000000;
 }
@@ -1014,16 +1012,14 @@
 }
 
 /* Make navigation icons black when nav item is active in darkroom mode (red bg needs black icons) */
-[data-theme="darkroom"] nav .shadow-subtle svg:not([data-coming-soon]) {
+[data-theme="darkroom"] nav .shadow-subtle svg {
   color: #000000;
   stroke: #000000;
 }
 
 /* Keep dropdown menu icons red on hover in darkroom mode (visible against black hover bg) */
-[data-theme="darkroom"]
-  button[role="menuitem"]:hover
-  svg:not([data-coming-soon]),
-[data-theme="darkroom"] a[role="menuitem"]:hover svg:not([data-coming-soon]) {
+[data-theme="darkroom"] button[role="menuitem"]:hover svg,
+[data-theme="darkroom"] a[role="menuitem"]:hover svg {
   color: #ff0000;
   stroke: #ff0000;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dorkroom/source",
-  "version": "2026.07.03",
+  "version": "2026.07.04",
   "license": "AGPL-3.0-only",
   "scripts": {
     "supabase:login": "bunx supabase login",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dorkroom/api",
-  "version": "2026.07.03",
+  "version": "2026.07.04",
   "license": "AGPL-3.0-only",
   "description": "API client and type definitions for the Dorkroom analog photography calculator",
   "keywords": [

--- a/packages/logic/package.json
+++ b/packages/logic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dorkroom/logic",
-  "version": "2026.07.03",
+  "version": "2026.07.04",
   "license": "AGPL-3.0-only",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dorkroom/ui",
-  "version": "2026.07.03",
+  "version": "2026.07.04",
   "license": "AGPL-3.0-only",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/ui/src/components/temperature-alert.tsx
+++ b/packages/ui/src/components/temperature-alert.tsx
@@ -94,7 +94,8 @@ export function TemperatureAlert({
         </div>
         <div>
           {warning.isHigher ? 'Raise' : 'Lower'} your chemistry (developer,
-          stop, and fixer) to {recipeTemp.text} before starting development.
+          stop, and fixer) temperature to {recipeTemp.text} before starting
+          development.
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Small home-page copy/cleanup pass plus a recipes wording fix.

- **Home page:** renamed the **"Calculators"** section heading to **"Tools"**.
- **Home page:** removed the **"Coming soon"** strip (Docs / Infobase) that sat below the tool grid, along with its now-unused `COMING_SOON` const and `BookOpen` / `Construction` / `GraduationCap` icon imports.
- **Darkroom theme CSS:** dropped the now-dead `:not([data-coming-soon])` guards in `theme.css` (no element carries that attribute anymore).
- **Development recipes:** reworded the non-standard temperature warning to read "Raise/Lower your chemistry (developer, stop, and fixer) **temperature** to … before starting development" for clarity.
- Bumped the web-app CalVer versions to `2026.07.04` and added `CHANGELOG.md` entries under the existing `[2026.07.04]` section. (`apps/mobile` and `api/` version independently and were left untouched.)

## Testing

- `bun run test` (lint / test / build / typecheck) — 20/20 tasks pass, 80 test files, 1631 tests green. Updated the home-page integration test that asserted on the old "Calculators" heading.
- `npx react-doctor@latest` — 100/100 on all four projects (`@dorkroom/source`, `@dorkroom/mobile`, `@dorkroom/logic`, `@dorkroom/ui`).
- `bun run format` — no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)