### PR TITLE
Route /keystatic to dorkroom-docs microfrontend

### DIFF
--- a/apps/dorkroom/microfrontends.json
+++ b/apps/dorkroom/microfrontends.json
@@ -13,6 +13,9 @@
         {
           "paths": [
             "/docs/:path*",
+            "/keystatic",
+            "/keystatic/:path*",
+            "/api/keystatic/:path*",
             "/api/search",
             "/og/docs/:path*",
             "/llms-full.txt"


### PR DESCRIPTION
## Why

`dorkroom.art/keystatic` (the docs project's Keystatic CMS admin) currently 404s with the main app's not-found page. The microfrontends routing table only sends `/docs/*`, `/api/search`, `/og/docs/*`, and `/llms-full.txt` to `dorkroom-docs`; every other path (including `/keystatic` and `/api/keystatic/*`) falls through to this default app, which has no such route.

## Change

Adds `/keystatic`, `/keystatic/:path*`, and `/api/keystatic/:path*` to the `dorkroom-docs` routing in `apps/dorkroom/microfrontends.json`.

After this deploys (default app redeploy), the CMS admin is reachable at `https://dorkroom.art/keystatic` and its API calls resolve to the docs app.

## Note

Pairs with a docs-repo change setting the Keystatic Cloud project slug and documenting this routing (narrowstacks/dorkroom-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)