### PR TITLE
feat(mobile): serve Metro over Tailscale via `ios.sh server --tailscale`

### DIFF
--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -135,14 +135,16 @@ change**. Full commands and credential setup are in `apps/mobile/README.md`.
 `source`/`PATH`/`eas` incantation. Run from `apps/mobile`:
 
 ```bash
-./scripts/ios.sh server      # 1. Metro dev server (JS/TS-only changes; hot reload)
+./scripts/ios.sh server              # 1. Metro dev server (JS/TS-only changes; hot reload)
+./scripts/ios.sh server --tailscale  # 1b. same, but reachable over Tailscale (off-LAN device)
 ./scripts/ios.sh dev-build   # 2. local dev-client build → install + launch (native changes)
 ./scripts/ios.sh build       # 3. standalone preview build → install + launch (no Metro)
 ./scripts/ios.sh install     # (re)install the last built .ipa + launch
 ./scripts/ios.sh help        # usage
 ```
 
-Flags: `--clear` (server, stale bundler cache), `--no-launch`, `--no-install`
+Flags: `--clear` (server, stale bundler cache), `--tailscale` (server, serve
+over Tailscale — see below), `--port=N` (server), `--no-launch`, `--no-install`
 (build only). The script auto-detects the connected iPhone, sources the App
 Store Connect key env, and resolves `eas`/`fastlane`/`pod`/`bun` onto `PATH`
 itself. It handles the gotchas that bite the raw commands:
@@ -175,6 +177,17 @@ stale-module errors.
 ```bash
 bunx expo start --dev-client --host lan --clear
 ```
+
+**Over Tailscale (off-LAN device):** `./scripts/ios.sh server --tailscale`. Use
+when the phone isn't on the same Wi-Fi (other network, cellular). Plain-HTTP
+Metro can't work here — iOS ATS treats Tailscale's `100.64.0.0/10` CGNAT range
+as non-local (unlike your `192.168.x` LAN), and this dev build has no
+`NSAllowsArbitraryLoads`. The flag serves Metro over **trusted HTTPS** instead:
+it mints a Let's Encrypt cert for this Mac's MagicDNS name (`tailscale cert`;
+requires HTTPS enabled on the tailnet), binds Metro to loopback advertising that
+hostname, and fronts it with `tailscale serve`. It prints a `dorkroom://` deep
+link; the phone needs Tailscale connected with MagicDNS ("Use Tailscale DNS")
+on. Ctrl-C tears the proxy down. No native rebuild — it's still Fast Refresh.
 
 ### 2. New **development build** — for native changes (dev client over Metro)
 
@@ -236,6 +249,7 @@ eas build --local --profile preview --platform ios --non-interactive \
 | --- | --- |
 | "Tweak this screen / calculator / style / shared hook" | **1. Reload Metro** |
 | "I changed metro/babel/tailwind config" or cache is stale | **1. Reload with `--clear`** |
+| "Test on my phone off this Wi-Fi (other network / cellular)" | **1. `server --tailscale`** |
 | "Add a native module / change app.json plugins / permissions / icon / shortcuts" | **2. Dev build** + reinstall |
 | "Test on my phone without Metro / share a build / demo / check the release bundle" | **3. Preview build** |
 

--- a/apps/mobile/scripts/ios.sh
+++ b/apps/mobile/scripts/ios.sh
@@ -2,15 +2,27 @@
 #
 # ios.sh — one entry point for the three Dorkroom iOS workflows.
 #
-#   ./scripts/ios.sh server      # Metro dev server (JS/TS-only changes, hot reload)
+#   ./scripts/ios.sh server                # Metro dev server (JS/TS-only changes, hot reload)
+#   ./scripts/ios.sh server --tailscale    # ...same, but reachable over Tailscale (off-LAN)
 #   ./scripts/ios.sh dev-build   # local dev-client build -> install + launch (native changes)
 #   ./scripts/ios.sh build       # local standalone preview build -> install + launch (no Metro)
 #   ./scripts/ios.sh install     # (re)install the last built .ipa + launch
 #
 # Flags:
 #   --clear        (server)  start Metro with --clear (stale bundler cache)
+#   --tailscale    (server)  serve Metro over HTTPS via Tailscale (see "Tailscale" below)
+#   --port=N       (server)  dev server port (default 8081)
 #   --no-launch    (dev-build/build/install)  install but don't launch
 #   --no-install   (dev-build/build)  build only, skip install/launch
+#
+# Tailscale (server --tailscale): loads the dev client from anywhere on your
+# tailnet (other Wi-Fi, cellular), not just the LAN. iOS ATS blocks plain-HTTP
+# Metro over Tailscale's 100.64.0.0/10 CGNAT range (it isn't "local" like your
+# 192.168.x LAN), so this serves Metro over trusted HTTPS instead: mint a real
+# TLS cert for this node's MagicDNS name (`tailscale cert`; needs HTTPS enabled
+# on the tailnet), bind Metro to loopback advertising that hostname, and front
+# it with `tailscale serve`. Ctrl-C tears the proxy down. The phone needs
+# Tailscale connected with MagicDNS ("Use Tailscale DNS") on.
 #
 # Why this script exists (gotchas it handles for you):
 #   * `eas` isn't on PATH in a fresh shell — node/npm are nvm lazy-load shims but
@@ -29,6 +41,9 @@ BUILD_LOG="/tmp/dorkroom-build.log"
 DEV_IPA="/tmp/dorkroom-dev.ipa"
 PREVIEW_IPA="/tmp/dorkroom-preview.ipa"
 BUNDLE_ID="art.dorkroom.mobile"
+SCHEME="dorkroom"   # app.json expo.scheme — for the dev-client deep link
+PORT="${PORT:-8081}"
+CERT_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/dorkroom-tailscale"
 
 # --- PATH: make eas / fastlane / pod / bun resolvable ------------------------
 export PATH="/opt/homebrew/bin:$HOME/.bun/bin:$PATH"
@@ -37,8 +52,12 @@ if ! command -v eas >/dev/null 2>&1; then
     [ -x "$d/eas" ] && { export PATH="$d:$PATH"; break; }
   done
 fi
+TS="$(command -v tailscale || true)"
+[ -z "$TS" ] && [ -x "/Applications/Tailscale.app/Contents/MacOS/Tailscale" ] \
+  && TS="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
 
 log()  { printf '\033[1;36m▸ %s\033[0m\n' "$*"; }
+warn() { printf '\033[1;33m! %s\033[0m\n' "$*" >&2; }
 die()  { printf '\033[1;31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
 
 # --- helpers -----------------------------------------------------------------
@@ -71,6 +90,93 @@ install_and_launch() {
   fi
 }
 
+# --- Tailscale serving (server --tailscale) ----------------------------------
+# This node's MagicDNS name, no trailing dot (e.g. io.fawn-snares.ts.net).
+ts_dnsname() {
+  "$TS" status --json 2>/dev/null \
+    | python3 -c "import sys,json;print(json.load(sys.stdin)['Self']['DNSName'].rstrip('.'))"
+}
+
+# Ensure a currently-valid cert for $1 exists in $CERT_DIR; mint if missing or
+# expiring within a day. Let's Encrypt rate-limits issuance, so we reuse.
+ts_ensure_cert() {
+  local name="$1"
+  CRT="$CERT_DIR/$name.crt"; KEY="$CERT_DIR/$name.key"
+  mkdir -p "$CERT_DIR"
+  if [ -f "$CRT" ] && [ -f "$KEY" ] && openssl x509 -checkend 86400 -noout -in "$CRT" >/dev/null 2>&1; then
+    log "Reusing TLS cert: $CRT"
+  else
+    log "Minting TLS cert for $name (tailscale cert)…"
+    "$TS" cert --cert-file "$CRT" --key-file "$KEY" "$name" \
+      || die "tailscale cert failed. Enable HTTPS for the tailnet (admin console → DNS → Enable HTTPS)."
+  fi
+}
+
+# Start Metro on loopback fronted by `tailscale serve` for TLS. Runs in the
+# foreground; the trap tears the proxy + Metro down on exit.
+serve_over_tailscale() {
+  [ -n "$TS" ] || die "tailscale CLI not found (install the Tailscale app or 'brew install tailscale')."
+  "$TS" status >/dev/null 2>&1 || die "Tailscale is not running / not logged in. Start it and retry."
+  local name ip4; name="$(ts_dnsname)"; ip4="$("$TS" ip -4 2>/dev/null | head -1)"
+  [ -n "$name" ] || die "Could not determine this node's MagicDNS name."
+  ts_ensure_cert "$name"
+
+  local plog metro_pid=""; plog="$(mktemp -t dorkroom-metro.XXXXXX.log)"
+  # shellcheck disable=SC2329  # invoked indirectly via `trap` below
+  cleanup_ts() {
+    log "Shutting down…"
+    "$TS" serve --https="$PORT" off >/dev/null 2>&1 || true
+    [ -n "$metro_pid" ] && kill "$metro_pid" 2>/dev/null || true
+    rm -f "$plog"
+  }
+  trap cleanup_ts EXIT INT TERM
+
+  # 1. Metro on loopback ONLY, advertising the MagicDNS hostname. Must bind the
+  #    port before `tailscale serve` claims it, or Expo's probe skips the server.
+  log "Starting Metro on loopback :$PORT (advertising https://$name:$PORT)…"
+  local metro_args=(expo start --dev-client --host localhost --port "$PORT")
+  [ "$CLEAR" = "1" ] && metro_args+=(--clear)
+  ( cd "$APP_DIR" && REACT_NATIVE_PACKAGER_HOSTNAME="$name" exec bunx "${metro_args[@]}" ) \
+    >"$plog" 2>&1 &
+  metro_pid=$!
+
+  # 2. Wait for Metro to answer on loopback (or bail if it died).
+  for _ in $(seq 1 60); do
+    kill -0 "$metro_pid" 2>/dev/null || { cat "$plog"; die "Metro exited during startup."; }
+    curl -fsS -o /dev/null "http://localhost:$PORT/status" 2>/dev/null && break
+    sleep 1
+  done
+  curl -fsS -o /dev/null "http://localhost:$PORT/status" 2>/dev/null \
+    || { cat "$plog"; die "Metro did not become ready on :$PORT."; }
+
+  # 3. Front it with a TLS terminator on the tailnet interface.
+  log "Enabling tailscale serve: https://$name:$PORT → localhost:$PORT"
+  "$TS" serve --https="$PORT" off >/dev/null 2>&1 || true
+  "$TS" serve --bg --https="$PORT" "http://localhost:$PORT" >/dev/null \
+    || die "tailscale serve failed."
+
+  # 4. Verify the phone-facing chain (manifest over TLS with our cert as CA).
+  if [ -n "$ip4" ]; then
+    local bu
+    bu="$(curl -fsS --cacert "$CRT" --resolve "$name:$PORT:$ip4" \
+           "https://$name:$PORT/" -H 'Expo-Platform: ios' 2>/dev/null \
+           | python3 -c "import sys,json;print(json.load(sys.stdin)['launchAsset']['url'])" 2>/dev/null || true)"
+    case "$bu" in
+      https://$name:$PORT/*) log "Verified: manifest serves https bundle URL over Tailscale ✓" ;;
+      "") warn "Could not verify the manifest over TLS (still starting?). Try loading it on the phone." ;;
+      *)  warn "Manifest bundle URL is unexpected: $bu" ;;
+    esac
+  fi
+
+  printf '\n\033[1;32m  Dev client URL:\033[0m  https://%s:%s\n' "$name" "$PORT"
+  printf '\033[1;32m  Deep link:     \033[0m  %s://expo-development-client/?url=https://%s:%s\n\n' "$SCHEME" "$name" "$PORT"
+  log "Phone needs Tailscale connected with MagicDNS on. Ctrl-C here to stop."
+
+  # 5. Foreground: stream Metro logs; cleanup runs on exit.
+  tail -n +1 -f "$plog" &
+  wait "$metro_pid"
+}
+
 # Run a local EAS build, streaming the full log to $BUILD_LOG. pipefail + tee
 # means the exit status reflects eas, and the whole log is saved (not truncated).
 run_build() {
@@ -87,10 +193,12 @@ run_build() {
 cmd="${1:-help}"; shift || true
 
 # parse trailing flags
-CLEAR=0; LAUNCH=1; INSTALL=1
+CLEAR=0; LAUNCH=1; INSTALL=1; TAILSCALE=0
 for arg in "$@"; do
   case "$arg" in
     --clear)      CLEAR=1 ;;
+    --tailscale)  TAILSCALE=1 ;;
+    --port=*)     PORT="${arg#--port=}" ;;
     --no-launch)  LAUNCH=0 ;;
     --no-install) INSTALL=0 ;;
     *) die "Unknown flag: $arg" ;;
@@ -100,6 +208,10 @@ done
 case "$cmd" in
   server|dev|start)
     command -v bunx >/dev/null 2>&1 || die "bun not found on PATH."
+    if [ "$TAILSCALE" = "1" ]; then
+      serve_over_tailscale
+      exit 0
+    fi
     args=(expo start --dev-client --host lan)
     [ "$CLEAR" = "1" ] && args+=(--clear)
     log "Metro dev server (open the installed dev client on the phone; same Wi-Fi)"
@@ -125,6 +237,6 @@ case "$cmd" in
     ;;
 
   help|-h|--help|*)
-    sed -n '3,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    sed -n '3,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
     ;;
 esac


### PR DESCRIPTION
## What

Adds `./scripts/ios.sh server --tailscale` — an off-LAN dev-server path so the iOS dev client can load Metro over Tailscale (other Wi-Fi, cellular), not just the same LAN. Plus `--port=N`.

## Why plain HTTP doesn't work over Tailscale

iOS App Transport Security treats Tailscale's `100.64.0.0/10` CGNAT range as **non-local** — unlike the `192.168.x` LAN, which works via `NSAllowsLocalNetworking`. This dev build has no `NSAllowsArbitraryLoads`, so the dev client rejects a plain-`http://100.x` bundle URL with:

> The resource could not be loaded because the App Transport Security policy requires the use of a secure connection.

## How the flag fixes it (no native rebuild)

- Mints a real Let's Encrypt TLS cert for this Mac's MagicDNS name via `tailscale cert` (cached + reused until expiry; requires HTTPS enabled on the tailnet)
- Binds Metro to **loopback only**, advertising the MagicDNS hostname via `REACT_NATIVE_PACKAGER_HOSTNAME` (Expo honors `X-Forwarded-Proto`, so the manifest hands the phone an `https://…` bundle URL)
- Fronts it with `tailscale serve` (TLS terminator on the tailnet interface) — Metro-first ordering so Expo's port probe doesn't skip the server
- Self-verifies the phone-facing chain, prints a `dorkroom://` deep link, and tears the proxy down on Ctrl-C

Folded into `ios.sh` (single entry point) rather than a separate script. Documented in `apps/mobile/CLAUDE.md` (quick-path list, reload-Metro section, decision table).

## Verification

- `shellcheck` + `bash -n` clean
- Ran `ios.sh server --tailscale` end-to-end: manifest `200` over Tailscale HTTPS, bundle fetched over TLS (`200`, 16.8 MB), cert reuse confirmed
- Ctrl-C teardown leaves proxy off / port free / no stray processes

## Not included

No CalVer bump / CHANGELOG entry — dev-only tooling + agent docs, no impact on the shipped iOS app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)