### PR TITLE
fix(ui): apply high-contrast overrides to all remaining inline border-token backgrounds

### DIFF
--- a/apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
+++ b/apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
@@ -460,15 +460,7 @@ export default function DevelopmentRecipesPage() {
       {/* Max-width of 1920px accommodates wider displays while maintaining content readability */}
       <div className="mx-auto max-w-[1920px] space-y-3 py-3 px-4 pb-4 sm:px-6 lg:px-8">
         {error && (
-          <div
-            className="rounded-2xl px-4 py-3 text-sm"
-            style={{
-              borderWidth: 1,
-              borderColor: 'var(--color-border-secondary)',
-              backgroundColor: 'var(--color-border-muted)',
-              color: 'var(--color-text-primary)',
-            }}
-          >
+          <div className="rounded-2xl border border-secondary bg-border-muted px-4 py-3 text-sm text-primary">
             {error}
           </div>
         )}

--- a/apps/dorkroom/src/app/pages/films/films-page.tsx
+++ b/apps/dorkroom/src/app/pages/films/films-page.tsx
@@ -377,14 +377,7 @@ export default function FilmsPage() {
       />
 
       {error && (
-        <div
-          className="mb-6 rounded-2xl border px-4 py-3 text-sm"
-          style={{
-            borderColor: 'var(--color-border-secondary)',
-            backgroundColor: 'var(--color-border-muted)',
-            color: 'var(--color-text-primary)',
-          }}
-        >
+        <div className="mb-6 rounded-2xl border border-secondary bg-border-muted px-4 py-3 text-sm text-primary">
           {error}
         </div>
       )}

--- a/apps/dorkroom/src/styles/utilities.css
+++ b/apps/dorkroom/src/styles/utilities.css
@@ -279,6 +279,15 @@
       color: var(--color-text-primary) !important;
     }
 
+    .hoverable-icon-btn:hover {
+      background-color: var(--color-border-muted) !important;
+      color: var(--color-text-primary) !important;
+    }
+
+    .hoverable-link-tile:hover {
+      background-color: var(--color-border-primary) !important;
+    }
+
     .hoverable-delete-btn:hover {
       background-color: var(--del-bg-hover) !important;
       color: var(--del-color-hover) !important;

--- a/packages/ui/src/components/border-calculator/preview-and-controls-section.tsx
+++ b/packages/ui/src/components/border-calculator/preview-and-controls-section.tsx
@@ -101,15 +101,7 @@ export function PreviewAndControlsSection() {
         const shouldShow = !isPaperActuallyLandscape && !isSquareAspectRatio;
         return (
           shouldShow && (
-            <div
-              className="mt-2 rounded-xl px-3 py-2 text-center text-xs"
-              style={{
-                borderWidth: 1,
-                borderColor: 'var(--color-border-secondary)',
-                backgroundColor: 'var(--color-border-muted)',
-                color: 'var(--color-text-primary)',
-              }}
-            >
+            <div className="mt-2 rounded-xl border border-secondary bg-border-muted px-3 py-2 text-center text-xs text-primary">
               <strong className="font-semibold">Rotate your easel</strong>
               <br />
               Paper is in vertical orientation. Rotate your easel 90° to match
@@ -120,15 +112,7 @@ export function PreviewAndControlsSection() {
       })()}
 
       {calculation.isNonStandardPaperSize && (
-        <div
-          className="mt-2 rounded-xl px-3 py-2 text-center text-xs"
-          style={{
-            borderWidth: 1,
-            borderColor: 'var(--color-border-secondary)',
-            backgroundColor: 'var(--color-border-muted)',
-            color: 'var(--color-text-primary)',
-          }}
-        >
+        <div className="mt-2 rounded-xl border border-secondary bg-border-muted px-3 py-2 text-center text-xs text-primary">
           <strong className="font-semibold">Non-standard paper</strong>
           <br />
           Position paper in the {calculation.easelSizeLabel} slot all the way to

--- a/packages/ui/src/components/border-calculator/sections/presets-section.tsx
+++ b/packages/ui/src/components/border-calculator/sections/presets-section.tsx
@@ -67,19 +67,7 @@ export function PresetsSection({
         <button
           type="button"
           onClick={onClose}
-          className="rounded-lg border p-2 transition"
-          style={{
-            borderColor: 'var(--color-border-primary)',
-            backgroundColor: 'var(--color-border-muted)',
-            color: 'var(--color-text-primary)',
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor =
-              'var(--color-border-secondary)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.backgroundColor = 'var(--color-border-muted)';
-          }}
+          className="rounded-lg border border-primary bg-border-muted p-2 text-primary transition hoverable-action-btn"
         >
           <X className="size-5" />
         </button>
@@ -88,13 +76,7 @@ export function PresetsSection({
       <div className="space-y-4">
         {/* Create new preset */}
         {isCreating ? (
-          <div
-            className="rounded-lg border p-4 space-y-3"
-            style={{
-              borderColor: 'var(--color-border-primary)',
-              backgroundColor: 'var(--color-border-muted)',
-            }}
-          >
+          <div className="rounded-lg border border-primary bg-border-muted p-4 space-y-3">
             <TextInput
               value={newPresetName}
               onValueChange={setNewPresetName}
@@ -126,20 +108,7 @@ export function PresetsSection({
                   setIsCreating(false);
                   setNewPresetName('');
                 }}
-                className="rounded-lg border px-3 py-2 text-sm font-medium transition"
-                style={{
-                  borderColor: 'var(--color-border-primary)',
-                  backgroundColor: 'var(--color-border-muted)',
-                  color: 'var(--color-text-primary)',
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.backgroundColor =
-                    'var(--color-border-secondary)';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.backgroundColor =
-                    'var(--color-border-muted)';
-                }}
+                className="rounded-lg border border-primary bg-border-muted px-3 py-2 text-sm font-medium text-primary transition hoverable-action-btn"
               >
                 Cancel
               </button>
@@ -149,12 +118,7 @@ export function PresetsSection({
           <button
             type="button"
             onClick={() => setIsCreating(true)}
-            className="flex w-full items-center justify-center gap-2 rounded-lg border border-dashed px-4 py-3 text-sm font-medium transition"
-            style={{
-              borderColor: 'var(--color-border-primary)',
-              backgroundColor: 'var(--color-border-muted)',
-              color: 'var(--color-text-primary)',
-            }}
+            className="flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-primary bg-border-muted px-4 py-3 text-sm font-medium text-primary transition"
           >
             <Plus className="size-4" />
             Create New Preset

--- a/packages/ui/src/components/detail-panel/detail-panel.tsx
+++ b/packages/ui/src/components/detail-panel/detail-panel.tsx
@@ -1,7 +1,6 @@
 import { GripVertical, Maximize2, Minimize2, X } from 'lucide-react';
 import { type FC, type ReactNode, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { setStyles } from '../../lib/dom';
 
 /** Props for the reusable CloseButton component */
 interface CloseButtonProps {
@@ -17,25 +16,12 @@ export const DetailPanelCloseButton: FC<CloseButtonProps> = ({
   <button
     type="button"
     onClick={onClick}
-    className="rounded-full p-2 transition focus-visible:outline-none focus-visible:ring-2"
+    className="rounded-full p-2 text-muted transition focus-visible:outline-none focus-visible:ring-2 hoverable-icon-btn"
     style={
       {
-        color: 'var(--color-text-muted)',
         '--tw-ring-color': 'var(--color-border-primary)',
       } as React.CSSProperties
     }
-    onMouseEnter={(e) => {
-      setStyles(e.currentTarget, {
-        backgroundColor: 'var(--color-border-muted)',
-        color: 'var(--color-text-primary)',
-      });
-    }}
-    onMouseLeave={(e) => {
-      setStyles(e.currentTarget, {
-        backgroundColor: 'transparent',
-        color: 'var(--color-text-muted)',
-      });
-    }}
     aria-label={ariaLabel}
   >
     <X className="size-4" />
@@ -59,25 +45,12 @@ export const DetailPanelExpandButton: FC<ExpandButtonProps> = ({
   <button
     type="button"
     onClick={onClick}
-    className={`rounded-full p-2 transition focus-visible:outline-none focus-visible:ring-2 ${className}`}
+    className={`rounded-full p-2 text-muted transition focus-visible:outline-none focus-visible:ring-2 hoverable-icon-btn ${className}`}
     style={
       {
-        color: 'var(--color-text-muted)',
         '--tw-ring-color': 'var(--color-border-primary)',
       } as React.CSSProperties
     }
-    onMouseEnter={(e) => {
-      setStyles(e.currentTarget, {
-        backgroundColor: 'var(--color-border-muted)',
-        color: 'var(--color-text-primary)',
-      });
-    }}
-    onMouseLeave={(e) => {
-      setStyles(e.currentTarget, {
-        backgroundColor: 'transparent',
-        color: 'var(--color-text-muted)',
-      });
-    }}
     aria-label={isExpanded ? 'Collapse to panel' : 'Expand to full screen'}
   >
     {isExpanded ? (

--- a/packages/ui/src/components/development-recipes/filmdev-preview-modal.tsx
+++ b/packages/ui/src/components/development-recipes/filmdev-preview-modal.tsx
@@ -166,13 +166,7 @@ export function FilmdevPreviewModal({
       </div>
 
       {/* Recipe Preview */}
-      <div
-        className="rounded-lg border p-3"
-        style={{
-          borderColor: 'var(--color-border-secondary)',
-          backgroundColor: 'var(--color-border-muted)',
-        }}
-      >
+      <div className="rounded-lg border border-secondary bg-border-muted p-3">
         <div
           className="mb-2 text-sm font-semibold"
           style={{ color: 'var(--color-text-primary)' }}

--- a/packages/ui/src/components/development-recipes/recipe-detail-panel.tsx
+++ b/packages/ui/src/components/development-recipes/recipe-detail-panel.tsx
@@ -8,7 +8,6 @@ import { ExternalLink, Star } from 'lucide-react';
 import type { FC } from 'react';
 import { useState } from 'react';
 import { useTemperature } from '../../contexts/temperature-context';
-import { setStyles } from '../../lib/dom';
 import { formatTemperatureWithUnit } from '../../lib/temperature';
 import { DetailPanel } from '../detail-panel/detail-panel';
 import { PushPullAlert } from '../push-pull-alert';
@@ -216,23 +215,7 @@ const SidebarCustomRecipeButtons: FC<
       <button
         type="button"
         onClick={() => onEditCustomRecipe(view)}
-        className="flex-1 rounded-full px-4 py-2 text-sm font-medium transition"
-        style={{
-          backgroundColor: 'var(--color-border-muted)',
-          color: 'var(--color-text-secondary)',
-        }}
-        onMouseEnter={(e) => {
-          setStyles(e.currentTarget, {
-            backgroundColor: 'var(--color-border-secondary)',
-            color: 'var(--color-text-primary)',
-          });
-        }}
-        onMouseLeave={(e) => {
-          setStyles(e.currentTarget, {
-            backgroundColor: 'var(--color-border-muted)',
-            color: 'var(--color-text-secondary)',
-          });
-        }}
+        className="flex-1 rounded-full bg-border-muted px-4 py-2 text-sm font-medium text-secondary transition hoverable-action-btn"
       >
         Edit
       </button>
@@ -568,21 +551,7 @@ const ExpandedSideColumn: FC<PanelLayoutProps> = ({
           href={combination.infoSource}
           target="_blank"
           rel="noreferrer"
-          className="inline-flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2"
-          style={{
-            backgroundColor: 'var(--color-border-muted)',
-            color: 'var(--color-text-primary)',
-          }}
-          onMouseEnter={(e) => {
-            setStyles(e.currentTarget, {
-              backgroundColor: 'var(--color-border-primary)',
-            });
-          }}
-          onMouseLeave={(e) => {
-            setStyles(e.currentTarget, {
-              backgroundColor: 'var(--color-border-muted)',
-            });
-          }}
+          className="inline-flex items-center gap-2 rounded-lg bg-border-muted px-4 py-2.5 text-sm font-medium text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 hoverable-link-tile"
         >
           <ExternalLink className="size-4" />
           {isFilmDevOrgUrl(combination.infoSource)

--- a/packages/ui/src/components/development-recipes/results-cards-virtualized.tsx
+++ b/packages/ui/src/components/development-recipes/results-cards-virtualized.tsx
@@ -492,11 +492,7 @@ function RecipeCard({
                 type="button"
                 onClick={onEdit}
                 aria-label="Edit"
-                className="inline-flex items-center justify-center rounded-md p-1.5 text-xs transition focus-visible:outline-2 focus-visible:outline-offset-2 hoverable-action-btn"
-                style={{
-                  backgroundColor: 'var(--color-border-muted)',
-                  color: 'var(--color-text-secondary)',
-                }}
+                className="inline-flex items-center justify-center rounded-md p-1.5 text-xs text-secondary transition focus-visible:outline-2 focus-visible:outline-offset-2 hoverable-action-btn bg-border-muted"
                 title="Edit"
               >
                 <Edit2 className="size-3" />

--- a/packages/ui/src/components/development-recipes/shared-recipe-modal.tsx
+++ b/packages/ui/src/components/development-recipes/shared-recipe-modal.tsx
@@ -164,13 +164,7 @@ export function SharedRecipeModal({
         {description}
       </div>
 
-      <div
-        className="rounded-xl border p-4"
-        style={{
-          borderColor: 'var(--color-border-secondary)',
-          backgroundColor: 'var(--color-border-muted)',
-        }}
-      >
+      <div className="rounded-xl border border-secondary bg-border-muted p-4">
         <div
           className="mb-2 text-xs uppercase tracking-wide"
           style={{ color: 'var(--color-text-muted)' }}

--- a/packages/ui/src/components/films/film-detail-panel.tsx
+++ b/packages/ui/src/components/films/film-detail-panel.tsx
@@ -226,18 +226,7 @@ export const FilmDetailPanel: FC<FilmDetailPanelProps> = ({
         {/* Development recipes link */}
         <a
           href={developmentRecipesUrl}
-          className="inline-flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2"
-          style={{
-            backgroundColor: 'var(--color-border-muted)',
-            color: 'var(--color-text-primary)',
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.backgroundColor =
-              'var(--color-border-primary)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.backgroundColor = 'var(--color-border-muted)';
-          }}
+          className="inline-flex items-center gap-2 rounded-lg bg-border-muted px-4 py-2.5 text-sm font-medium text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 hoverable-link-tile"
         >
           <ExternalLink className="size-4" />
           View Development Recipes
@@ -415,17 +404,7 @@ const FilmDetailContent: FC<FilmDetailContentProps> = ({
       {/* Development recipes link */}
       <a
         href={developmentRecipesUrl}
-        className="inline-flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2"
-        style={{
-          backgroundColor: 'var(--color-border-muted)',
-          color: 'var(--color-text-primary)',
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--color-border-primary)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.backgroundColor = 'var(--color-border-muted)';
-        }}
+        className="inline-flex items-center gap-2 rounded-lg bg-border-muted px-4 py-2.5 text-sm font-medium text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 hoverable-link-tile"
       >
         <ExternalLink className="size-4" />
         View Development Recipes

--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -2,7 +2,6 @@ import { X } from 'lucide-react';
 import { createPortal } from 'react-dom';
 import { useBodyScrollLock } from '../hooks/use-body-scroll-lock';
 import { cn } from '../lib/cn';
-import { setStyles } from '../lib/dom';
 
 /**
  * Props for the Modal component.
@@ -99,26 +98,12 @@ export function Modal({
           <button
             type="button"
             onClick={onClose}
-            className="absolute right-4 top-4 rounded-full p-2 transition focus-visible:outline-none focus-visible:ring-2"
+            className="absolute right-4 top-4 rounded-full p-2 text-muted transition focus-visible:outline-none focus-visible:ring-2 hoverable-icon-btn"
             style={
               {
-                color: 'var(--color-text-muted)',
                 '--tw-ring-color': 'var(--color-border-primary)',
               } as React.CSSProperties
             }
-            onMouseEnter={(e) => {
-              setStyles(e.currentTarget, {
-                backgroundColor: 'var(--color-border-muted)',
-                color: 'var(--color-text-primary)',
-              });
-            }}
-            onMouseLeave={(e) => {
-              setStyles(e.currentTarget, {
-                backgroundColor:
-                  'var(--modal-close-bg-hover-leave, transparent)',
-                color: 'var(--color-text-muted)',
-              });
-            }}
             aria-label="Close"
           >
             <X className="size-4" />

--- a/packages/ui/src/components/ui/skeleton.tsx
+++ b/packages/ui/src/components/ui/skeleton.tsx
@@ -7,8 +7,7 @@ interface SkeletonProps {
 export function Skeleton({ className }: SkeletonProps) {
   return (
     <div
-      className={cn('animate-pulse rounded-md', className)}
-      style={{ backgroundColor: 'var(--color-border-muted)' }}
+      className={cn('animate-pulse rounded-md bg-border-muted', className)}
     />
   );
 }


### PR DESCRIPTION
## Summary

Finishes the High Contrast fix started in the recipe detail panel (`CollapsibleSection`): 21 remaining inline `backgroundColor: var(--color-border-*)` styles across 13 files are converted to theme-aware utility classes so the `[data-theme="high-contrast"]` white-card override can actually apply. Inline styles beat the stylesheet, so these cards, notices, buttons, and links rendered black-on-black in the theme built for low-vision users.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **Static cards/notices (6 sites)** → `border border-secondary bg-border-muted` (+ `text-primary` where applicable): shared-recipe-modal, filmdev-preview-modal, border-calculator notice tiles, create-preset panel, and the error notices on the development and films pages.
- **Static buttons/links (7 sites)** → same class conversion: recipe-detail-panel edit button and info-source link, results-cards icon button, film-detail-panel links, presets-section buttons.
- **JS hover handlers (6 sites)** → replaced `onMouseEnter`/`onMouseLeave` + `setStyles` pairs with two new CSS classes in the existing hover-capability block in `utilities.css` (`.hoverable-icon-btn`, `.hoverable-link-tile`); removed now-unused `setStyles` imports. The dead `--modal-close-bg-hover-leave` variable (defined nowhere) is gone.
- **Skeleton** → class-based; in High Contrast, loading skeletons change from solid black blocks to white boxes with a 2px black border, consistent with the card language.
- Deliberately untouched: the `mobile-sidebar` 1px divider (decorative hairline; black in HC is correct).

Net: −197/+28 lines.

## Testing

- [x] I have run `bun run test` and all checks pass (86 files, 1,724 tests)
- [x] `react-doctor --scope changed` reports zero new diagnostics
- [ ] Manual four-theme spot-check (no browser in the execution environment — reviewer should eyeball /development with a recipe open, /films with a film open, and the /border presets drawer in all four themes)

## Checklist

- [x] My code follows the project's code style
- [x] I have formatted my code with `bun run format`
- [x] My changes generate no new warnings
- [x] I have checked that there are no circular dependencies between packages

## Additional Notes

- Pre-existing (not introduced here, preserved verbatim): the darkroom theme sets `--color-border-primary` and `--color-text-primary` both to `#ff0000`, so hovered link-tiles are red-on-red. Fixing that is a darkroom token design decision — flagged for a separate change.
- After this lands, the invariant "no inline `backgroundColor` with a `--color-border-*` token" is grep-enforceable; `packages/ui/CLAUDE.md` could state it explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
