### PR TITLE
fix: restore React Doctor 100/100 across all four projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,6 @@ permissions:
   actions: read
   contents: read
 
-# Environment variables for Turbo Remote Caching
-# Set TURBO_TOKEN as a repository secret and TURBO_TEAM as a repository variable
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -69,4 +63,11 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run quality checks (lint, test, build, typecheck)
+        # Turbo Remote Caching secrets are scoped to this step only, so they
+        # are never present in the environment during `bun install` (which
+        # executes package lifecycle scripts). Set TURBO_TOKEN as a repository
+        # secret and TURBO_TEAM as a repository variable.
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
         run: bun run test

--- a/apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
+++ b/apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
@@ -372,14 +372,19 @@ export default function DevelopmentRecipesPage() {
     onShareCombination: handleShareCombination,
   });
 
-  // Update ref on each render to keep handlers current
-  columnHandlersRef.current = {
-    isFavorite: handleCheckFavorite,
-    onToggleFavorite: handleToggleFavorite,
-    onEditCustomRecipe: handleEditCustomRecipe,
-    onDeleteCustomRecipe: handleDeleteCustomRecipe,
-    onShareCombination: handleShareCombination,
-  };
+  // Update ref after each commit to keep handlers current. This runs in an
+  // effect rather than during render because render must stay pure — the
+  // column wrappers below only read columnHandlersRef.current from event
+  // handlers (post-render), so a same-tick effect assignment is equivalent.
+  useEffect(() => {
+    columnHandlersRef.current = {
+      isFavorite: handleCheckFavorite,
+      onToggleFavorite: handleToggleFavorite,
+      onEditCustomRecipe: handleEditCustomRecipe,
+      onDeleteCustomRecipe: handleDeleteCustomRecipe,
+      onShareCombination: handleShareCombination,
+    };
+  });
 
   // Create stable columns - wrapper functions read from ref at call time
   const columns = useMemo(

--- a/apps/dorkroom/src/app/pages/films/films-page.tsx
+++ b/apps/dorkroom/src/app/pages/films/films-page.tsx
@@ -193,6 +193,7 @@ export default function FilmsPage() {
   const urlFilm = useMemo(() => {
     if (!urlFilmSlug) return null;
     return films.find((f) => f.slug === urlFilmSlug) ?? null;
+    // eslint-disable-next-line react-doctor/exhaustive-deps -- react-doctor reports "stale searchParams.film" via alias tracing through urlFilmSlug, but urlFilmSlug IS searchParams.film re-derived every render (line 189, not memoized); adding searchParams.film directly is flagged as a redundant dep by react-hooks/exhaustive-deps
   }, [films, urlFilmSlug]);
 
   // Sync URL params to filter state when URL changes (back/forward navigation, bookmarks).
@@ -282,6 +283,7 @@ export default function FilmsPage() {
     if (urlFilm) {
       setSelectedFilm(urlFilm);
     }
+    // eslint-disable-next-line react-doctor/exhaustive-deps -- same alias-tracing false positive as the urlFilm useMemo above: urlFilmSlug already IS searchParams.film re-derived every render, so it's already covered
   }, [urlFilm, urlFilmSlug, isLoading]);
 
   // Debounced URL sync (500ms)

--- a/apps/dorkroom/src/app/pages/home-page.tsx
+++ b/apps/dorkroom/src/app/pages/home-page.tsx
@@ -186,8 +186,8 @@ export function HomePage() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 auto-rows-fr">
           {CALCULATORS.map((tool, index) => (
             <ToolCard
-              {...tool}
               key={tool.title}
+              {...tool}
               as={Link}
               href={tool.href}
               className={

--- a/apps/dorkroom/src/app/pages/mat-calculator/mat-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/mat-calculator/mat-calculator-page.tsx
@@ -285,7 +285,7 @@ function MatSidebar({
       >
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           {guideBarCuts.map((c) => (
-            <GuideBarCard {...c} key={c.title} />
+            <GuideBarCard key={c.title} {...c} />
           ))}
         </div>
       </CalculatorCard>

--- a/apps/mobile/src/components/meter/meter-readout.tsx
+++ b/apps/mobile/src/components/meter/meter-readout.tsx
@@ -1,6 +1,6 @@
 import * as Haptics from 'expo-haptics';
 import { SymbolView } from 'expo-symbols';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 // PanResponder is intentional here: the scrubber deliberately avoids a react-native-gesture-handler dependency, commits the value live on each stop crossing (one re-render per stop, gated by the haptic tick — the smooth glide rides an Animated.Value the overlay wheel binds to, not React state). Migrating to Gesture.Pan() would be an invasive, behavior-changing rewrite of the gesture/animation pipeline for no functional gain. The type-only Animated import is erased at runtime, so there's no UI-thread animation that reanimated would improve.
 /* eslint-disable react-doctor/rn-prefer-reanimated, react-doctor/rn-no-panresponder -- intentional PanResponder + JS Animated pipeline; see note above */
 import {
@@ -297,56 +297,65 @@ function ValueScrubber({
   // A disabled setting (e.g. ISO while locked to the roll's EI) swallows the
   // gesture and prompts instead of scrubbing. Kept in refs the once-created
   // PanResponder reads, so the check happens in the gesture handler itself.
+  // Refreshed in an effect (not during render) for the same reason as
+  // `controller` above: render must stay pure, and these are only ever read
+  // later, from the gesture handlers.
   const disabledRef = useRef(field.disabled);
-  disabledRef.current = field.disabled;
   const onBlockedRef = useRef(field.onBlocked);
-  onBlockedRef.current = field.onBlocked;
   const onTapHintRef = useRef(onTapHint);
-  onTapHintRef.current = onTapHint;
-
-  const panRef = useRef<ReturnType<typeof PanResponder.create>>(null);
-  panRef.current ??= PanResponder.create({
-    onStartShouldSetPanResponder: () => true,
-    onMoveShouldSetPanResponder: () => true,
-    onPanResponderTerminationRequest: () => false,
-    onPanResponderGrant: () => {
-      if (disabledRef.current) {
-        onBlockedRef.current?.();
-        return;
-      }
-      controller.current.prepare();
-      clearHoldTimer();
-      holdTimer.current = setTimeout(() => {
-        holdTimer.current = null;
-        controller.current.begin();
-      }, HOLD_TO_SCRUB_MS);
-    },
-    onPanResponderMove: (_e, g) => {
-      if (disabledRef.current) return;
-      const moved = Math.hypot(g.dx, g.dy);
-      if (!scrubbing.current && moved >= DRAG_TO_SCRUB_PX) {
-        clearHoldTimer();
-        controller.current.begin();
-      }
-      controller.current.move(g);
-    },
-    onPanResponderRelease: () => {
-      if (disabledRef.current) return;
-      clearHoldTimer();
-      if (scrubbing.current) {
-        controller.current.end();
-      } else {
-        dragY.setValue(0);
-        onTapHintRef.current();
-      }
-    },
-    onPanResponderTerminate: () => {
-      if (disabledRef.current) return;
-      clearHoldTimer();
-      controller.current.cancel();
-    },
+  useEffect(() => {
+    disabledRef.current = field.disabled;
+    onBlockedRef.current = field.onBlocked;
+    onTapHintRef.current = onTapHint;
   });
-  const pan = panRef.current;
+
+  // Created once and reused for the component's lifetime (a lazy useState
+  // initializer, not a ref write in render, so it stays pure) — Fast Refresh
+  // survives because the handlers below close over the refs above, not over
+  // `field` directly.
+  const [pan] = useState(() =>
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      onPanResponderTerminationRequest: () => false,
+      onPanResponderGrant: () => {
+        if (disabledRef.current) {
+          onBlockedRef.current?.();
+          return;
+        }
+        controller.current.prepare();
+        clearHoldTimer();
+        holdTimer.current = setTimeout(() => {
+          holdTimer.current = null;
+          controller.current.begin();
+        }, HOLD_TO_SCRUB_MS);
+      },
+      onPanResponderMove: (_e, g) => {
+        if (disabledRef.current) return;
+        const moved = Math.hypot(g.dx, g.dy);
+        if (!scrubbing.current && moved >= DRAG_TO_SCRUB_PX) {
+          clearHoldTimer();
+          controller.current.begin();
+        }
+        controller.current.move(g);
+      },
+      onPanResponderRelease: () => {
+        if (disabledRef.current) return;
+        clearHoldTimer();
+        if (scrubbing.current) {
+          controller.current.end();
+        } else {
+          dragY.setValue(0);
+          onTapHintRef.current();
+        }
+      },
+      onPanResponderTerminate: () => {
+        if (disabledRef.current) return;
+        clearHoldTimer();
+        controller.current.cancel();
+      },
+    })
+  );
 
   return (
     <View

--- a/apps/mobile/src/components/meter/scrub-overlay.tsx
+++ b/apps/mobile/src/components/meter/scrub-overlay.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useState } from 'react';
 // eslint-disable-next-line react-doctor/rn-prefer-reanimated -- JS-thread Animated is intentional: the drag is a JS-thread PanResponder (no gesture-handler) and reanimated's worklet babel plugin isn't wired up; the ruler commits on release so there are no React re-renders during the drag, keeping the glide smooth.
 import { Animated, Text, View } from 'react-native';
 import { readoutText as MONO } from '@/theme/tokens';
@@ -10,9 +10,8 @@ import { SCRUB_COL_WIDTH, SCRUB_GAP } from './scrub-math';
  * (writer) and the ruler (reader). Lives here so the screen needn't import
  * Animated directly. Carries the live combined drag offset in px (right/up +). */
 export function useDragOffset() {
-  const ref = useRef<Animated.Value>(null);
-  ref.current ??= new Animated.Value(0);
-  return ref.current;
+  const [value] = useState(() => new Animated.Value(0));
+  return value;
 }
 
 const SHADOW = {

--- a/apps/mobile/src/screens/meter-screen.tsx
+++ b/apps/mobile/src/screens/meter-screen.tsx
@@ -215,10 +215,14 @@ export function MeterScreen() {
   const { hasPermission, requestPermission } = meter;
   // Still-photo output for the shutter; kept in a ref so the capture hook reads
   // the latest instance without re-subscribing each render. Force JPEG (the iOS
-  // default is HEIC, which Skia's grayscale pass can't decode).
+  // default is HEIC, which Skia's grayscale pass can't decode). Refreshed in an
+  // effect rather than during render, since render must stay pure — the ref is
+  // only read later, from the capture hook's own handler.
   const photoOutput = usePhotoOutput({ containerFormat: 'jpeg' });
   const photoOutputRef = useRef<CameraPhotoOutput | null>(photoOutput);
-  photoOutputRef.current = photoOutput;
+  useEffect(() => {
+    photoOutputRef.current = photoOutput;
+  });
   const capture = useMeterCapture(photoOutputRef);
   const { flashStyle, triggerFlash } = useShutterFlash();
   // Seed the solver from the last persisted locked setting + ISO (read once).

--- a/packages/ui/src/components/border-calculator/mobile-border-calculator.tsx
+++ b/packages/ui/src/components/border-calculator/mobile-border-calculator.tsx
@@ -703,6 +703,7 @@ export function MobileBorderCalculator({
       formatDimensions,
       currentSettings,
     }),
+    // eslint-disable-next-line react-doctor/exhaustive-deps -- react-doctor reports "stale dimensionData.paperSizeWarning" via alias tracing through paperSizeWarning, but paperSizeWarning (line 333) IS `calculation?.paperSizeWarning ?? dimensionData.paperSizeWarning` re-derived every render; adding dimensionData.paperSizeWarning directly is flagged as a redundant dep by react-hooks/exhaustive-deps
     [
       form,
       formValues,

--- a/packages/ui/src/components/border-calculator/mobile-border-calculator.tsx
+++ b/packages/ui/src/components/border-calculator/mobile-border-calculator.tsx
@@ -898,6 +898,7 @@ export function MobileBorderCalculator({
                 } as React.CSSProperties
               }
               title="Share preset"
+              aria-label="Share preset"
             >
               <Share className="size-5" />
             </button>

--- a/packages/ui/src/components/border-calculator/presets-section.tsx
+++ b/packages/ui/src/components/border-calculator/presets-section.tsx
@@ -45,6 +45,7 @@ export function PresetsSection() {
             disabled={isSharing || isGeneratingShareUrl}
             className="rounded-full border p-2 transition focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50 disabled:cursor-not-allowed text-[color:var(--color-text-primary)] border-[color:var(--color-border-secondary)] bg-[rgba(var(--color-background-rgb),0.08)] hover:bg-[rgba(var(--color-background-rgb),0.14)] focus-visible:ring-[color:var(--color-focus-ring)]"
             title="Share preset"
+            aria-label="Share preset"
           >
             {isGeneratingShareUrl ? (
               <svg
@@ -76,6 +77,7 @@ export function PresetsSection() {
             onClick={() => setIsEditingPreset(true)}
             className="rounded-full border p-2 transition focus-visible:outline-none focus-visible:ring-2 text-[color:var(--color-text-primary)] border-[color:var(--color-border-secondary)] bg-[rgba(var(--color-background-rgb),0.08)] hover:bg-[rgba(var(--color-background-rgb),0.14)] focus-visible:ring-[color:var(--color-focus-ring)]"
             title="Edit preset"
+            aria-label="Edit preset"
           >
             <Save className="size-4" />
           </button>

--- a/packages/ui/src/components/border-calculator/sections/border-size-section.tsx
+++ b/packages/ui/src/components/border-calculator/sections/border-size-section.tsx
@@ -38,6 +38,7 @@ export function BorderSizeSection({ onClose }: BorderSizeSectionProps) {
           type="button"
           onClick={onClose}
           className="rounded-lg border border-white/20 bg-white/5 p-2 text-white transition hover:bg-white/10"
+          aria-label="Close border size"
         >
           <X className="size-5" />
         </button>

--- a/packages/ui/src/components/border-calculator/sections/paper-size-section.tsx
+++ b/packages/ui/src/components/border-calculator/sections/paper-size-section.tsx
@@ -165,6 +165,7 @@ export function PaperSizeSection({ onClose }: PaperSizeSectionProps) {
           type="button"
           onClick={onClose}
           className="rounded-lg border border-white/20 bg-white/5 p-2 text-white transition hover:bg-white/10"
+          aria-label="Close paper & image size"
         >
           <X className="size-5" />
         </button>

--- a/packages/ui/src/components/border-calculator/sections/position-offsets-section.tsx
+++ b/packages/ui/src/components/border-calculator/sections/position-offsets-section.tsx
@@ -30,6 +30,7 @@ export function PositionOffsetsSection({
           type="button"
           onClick={onClose}
           className="rounded-lg border border-white/20 bg-white/5 p-2 text-white transition hover:bg-white/10"
+          aria-label="Close position & offsets"
         >
           <X className="size-5" />
         </button>

--- a/packages/ui/src/components/border-calculator/sections/presets-section.tsx
+++ b/packages/ui/src/components/border-calculator/sections/presets-section.tsx
@@ -68,6 +68,7 @@ export function PresetsSection({
           type="button"
           onClick={onClose}
           className="rounded-lg border border-primary bg-border-muted p-2 text-primary transition hoverable-action-btn"
+          aria-label="Close presets"
         >
           <X className="size-5" />
         </button>
@@ -186,6 +187,7 @@ export function PresetsSection({
                           type="button"
                           onClick={() => startEdit(preset)}
                           className="rounded p-1 text-white/70 transition hover:bg-white/10 hover:text-white"
+                          aria-label={`Edit ${preset.name}`}
                         >
                           <Save className="size-4" />
                         </button>
@@ -193,6 +195,7 @@ export function PresetsSection({
                           type="button"
                           onClick={() => onDeletePreset(preset.id)}
                           className="rounded p-1 text-red-400 transition hover:bg-red-500/10 hover:text-red-300"
+                          aria-label={`Delete ${preset.name}`}
                         >
                           <Trash2 className="size-4" />
                         </button>

--- a/packages/ui/src/components/development-recipes/table-columns.tsx
+++ b/packages/ui/src/components/development-recipes/table-columns.tsx
@@ -545,6 +545,11 @@ export const createTableColumns = (
                   ? 'View on FilmDev.org'
                   : 'View source'
               }
+              aria-label={
+                isFilmDevOrgUrl(combination.infoSource)
+                  ? 'View on FilmDev.org'
+                  : 'View source'
+              }
               className="inline-flex items-center"
               style={{ color: 'var(--color-text-tertiary)' }}
               onClick={(e) => {

--- a/packages/ui/src/components/films/film-image.tsx
+++ b/packages/ui/src/components/films/film-image.tsx
@@ -1,5 +1,5 @@
 import { Film } from 'lucide-react';
-import { type FC, useEffect, useRef, useState } from 'react';
+import { type FC, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { cn } from '../../lib/cn';
 
 interface FilmImageProps {
@@ -60,14 +60,20 @@ export const FilmImage: FC<FilmImageProps> = ({
 }) => {
   // Single consolidated state so the per-src reset is one update.
   const [state, setState] = useState<ImageState>(() => getInitialState(src));
-  // Track the previous src in a ref and reset state during render when it
-  // changes, instead of in an effect. See
-  // https://react.dev/learn/you-might-not-need-an-effect
-  const prevSrcRef = useRef(src);
-  if (src !== prevSrcRef.current) {
-    prevSrcRef.current = src;
+  // Reset state when src changes (skipping the initial mount, since useState
+  // above already initializes correctly for it). A layout effect — not a
+  // render-time ref write, which react-doctor's no-ref-current-in-render rule
+  // flags, since render must stay pure — runs synchronously after the DOM
+  // update but before the browser paints, so there's no visible flash of the
+  // previous src's state.
+  const isFirstRender = useRef(true);
+  useLayoutEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
     setState(getInitialState(src));
-  }
+  }, [src]);
 
   const { hasError, isLoading, hasTimedOut } = state;
   const dimension = sizeMap[size];

--- a/packages/ui/src/components/share-modal.tsx
+++ b/packages/ui/src/components/share-modal.tsx
@@ -243,6 +243,7 @@ function WebLinkSection({
           <button
             type="button"
             onClick={onCopy}
+            aria-label={copySuccess ? 'Copied web link' : 'Copy web link'}
             className={cn(
               'px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2'
             )}

--- a/packages/ui/src/components/theme-toggle.tsx
+++ b/packages/ui/src/components/theme-toggle.tsx
@@ -181,14 +181,14 @@ export function ThemeToggle({
   }, [isOpen]);
 
   // Toggle the dropdown via pointer. Reset focus tracking when opening to
-  // match the previous reset-on-open behavior.
+  // match the previous reset-on-open behavior. The ref write happens here,
+  // in the event handler, rather than inside the state updater — updaters
+  // must stay pure since React may invoke them more than once.
   const toggleOpen = () => {
-    setIsOpen((prev) => {
-      if (!prev) {
-        focusedIndexRef.current = -1;
-      }
-      return !prev;
-    });
+    if (!isOpen) {
+      focusedIndexRef.current = -1;
+    }
+    setIsOpen((prev) => !prev);
   };
 
   const handleThemeChange = (newTheme: Theme) => {


### PR DESCRIPTION
## Summary

Restores React Doctor to **100/100 with zero diagnostics on all four projects** (`@dorkroom/source`, `@dorkroom/mobile`, `@dorkroom/logic`, `@dorkroom/ui`). The unpinned `react-doctor@latest` ruleset had drifted since the last restoration (`0655d22`), leaving baseline main at 67/74/100/76 (~22 unique findings) and making the CLAUDE.md "100×4" gate unmeetable. Stacked on #146 (both touch the presets-section files).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional changes) — render-purity fixes preserve behavior

## Changes Made

- **`control-has-associated-label` (11)** — truthful `aria-label`s on icon-only controls across the border-calculator sections, share modal, and recipe table link.
- **`no-ref-current-in-render` (8)** — render-purity fixes with behavior preserved: `columnHandlersRef` assignment moved to an effect; `film-image` reset moved to `useLayoutEffect`; the mobile light-meter's PanResponder converted to a `useState` lazy initializer with latest-value refs refreshed in an effect (handler bodies unchanged; no gesture/animation pipeline changes).
- **`no-impure-state-updater` (1)** — theme-toggle's `focusedIndexRef` write moved out of the `setIsOpen` updater into the event handler.
- **`jsx-key` (2)** — missing/mis-placed `key` props on home and mat-calculator pages.
- **`exhaustive-deps` (3)** — verified as alias-tracing false positives (the "missing" dep is already covered by an unmemoized derived local that's in the deps array; adding it directly is flagged as redundant by `react-hooks/exhaustive-deps`). Suppressed with justifying comments per the repo's suppression policy.
- **`build-pipeline-secret-boundary` (1)** — a real finding, fixed for real: `TURBO_TOKEN`/`TURBO_TEAM` were job-level env vars in `ci.yml`, present during `bun install --frozen-lockfile` (which executes package lifecycle scripts). Now scoped to only the `bun run test` step.

## Testing

- [x] I have run `bun run test` and all checks pass (1,724 tests)
- [x] `cd apps/mobile && bun run test` — 251/251 pass; mobile typecheck and lint exit 0
- [x] Final `npx react-doctor@latest --json -y`: score 100, 0 diagnostics, all four projects (verified twice, plus independently by the reviewer)

## Checklist

- [x] My code follows the project's code style
- [x] I have formatted my code with `bun run format`
- [x] My changes generate no new warnings
- [x] I have checked that there are no circular dependencies between packages

## Additional Notes

- **Reviewer focus**: theme-toggle focus behavior (41/41 existing tests pass), mobile meter scrub responsiveness (structural conversion only — handler bodies byte-identical), and the three suppression justifications.
- The `--explain` CLI flag was removed from react-doctor; its replacement is `why <file:line>`.
- Follow-up for whoever merges: update the restoration-commit reference in `CLAUDE.md`'s React Doctor section (currently cites `0655d22`), and consider an informational CI run of the scan so the next ruleset drift is visible immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
