### PR TITLE
feat(dx): screenshot visual changes on every PR

### DIFF
--- a/.claude/skills/pr-screenshots/SKILL.md
+++ b/.claude/skills/pr-screenshots/SKILL.md
@@ -103,12 +103,17 @@ doesn't exist. Fix it; don't ship a PR with a missing screenshot.
 
 The "before" state is the merge-base, not your working tree. Get it from a
 worktree, which never touches your working tree — no stashing, nothing to lose.
-Leave the "after" server running: the second one auto-picks the next free port,
-which you read back the same way.
+
+**Stop the "after" server first.** The two dev servers cannot run side by side:
+the microfrontends proxy claims a fixed port and dies with `Microfrontends proxy
+error: Port is not available` rather than picking another one. (Bare `vite` does
+increment — `bun run dev` doesn't, because the proxy is in front of it.)
 
 ```bash
+pkill -f 'turbo run dev'          # free the port before starting the second server
+
 BASE=$(git merge-base HEAD origin/main)
-git worktree add /tmp/dr-before "$BASE"
+git worktree add --detach /tmp/dr-before "$BASE"
 (cd /tmp/dr-before && bun install && bun run dev > /tmp/dr-before.log 2>&1 &)
 until grep -q 'Local:' /tmp/dr-before.log; do sleep 1; done
 BEFORE=$(grep -o 'http://localhost:[0-9]*' /tmp/dr-before.log | head -1)
@@ -116,6 +121,7 @@ BEFORE=$(grep -o 'http://localhost:[0-9]*' /tmp/dr-before.log | head -1)
 bun run scripts/pr-screenshots.ts .pr-screenshots/shots.json \
   --base-url "$BEFORE" --out-dir .pr-screenshots/before
 
+pkill -f 'turbo run dev'
 git worktree remove --force /tmp/dr-before
 ```
 

--- a/.claude/skills/pr-screenshots/SKILL.md
+++ b/.claude/skills/pr-screenshots/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: pr-screenshots
+description: Capture before/after screenshots of visual changes and attach them to a PR. Use when opening a PR, or when asked to "add screenshots to the PR", "show what this looks like", "prove the UI change works", or "document this visually". Any PR that changes rendered output — a route, a shared component, a theme token, or a calculator's displayed result — needs these. Screenshots are uploaded to GitHub's CDN, never committed to the repo.
+user_invocable: true
+---
+
+# PR Screenshots
+
+A reviewer reading a diff has to imagine the result. Screenshots mean they don't
+have to — and they catch the regressions a diff hides: a value that now renders
+`NaN`, a card that lost its padding, a theme where the text went invisible.
+
+Two scripts do the work:
+
+- `scripts/pr-screenshots.ts` — captures a **shot list** against a running dev
+  server, writes WebP files.
+- `scripts/github-upload-attachment.ts` — uploads those files to GitHub and
+  returns permanent `user-attachments/assets/…` URLs. Nothing lands in the repo.
+
+## Step 1 — Decide whether the change is visual
+
+**Visual** if the diff touches any of:
+
+- `apps/dorkroom/src/**` — routes, components, styles
+- `packages/ui/**` — shared components, theme tokens
+- a calculator in `packages/logic/**` whose result is *displayed*:
+  `use-*-calculator.ts`, `use-light-meter-solver.ts`, `border-calculator/`
+
+**Not visual** if the diff only touches `api/`, `packages/api/**`, tests,
+configs, docs, or CI.
+
+If it isn't visual, say so in the PR description — one line, e.g. *"No rendered
+output changes; no screenshots."* Don't just omit the section, or a reviewer
+can't tell whether it was considered or forgotten.
+
+## Step 2 — Map the diff to routes, write the shot list
+
+Routes live in `apps/dorkroom/src/routes/` and map 1:1 to paths
+(`reciprocity.tsx` → `/reciprocity`). For a changed shared component or logic
+hook, grep for its consumers — every route that renders it is affected.
+
+**Default matrix: desktop × dark, one shot per affected route.** Widen only for
+cause:
+
+| Diff touches | Add |
+|---|---|
+| layout / responsive classes | a `mobile` shot |
+| theme tokens, colors, a theme's stylesheet | a shot in *that* theme (not all four) |
+| an error path, or output that needs specific inputs | an `actions` block |
+
+Themes are `light`, `dark`, `darkroom`, `high-contrast`. There is no `system` —
+a screenshot must be deterministic.
+
+Write the list to `.pr-screenshots/shots.json`:
+
+```jsonc
+{
+  "shots": [
+    // Bare route. Calculators have sensible defaults, so this already renders
+    // a real calculation — no actions needed.
+    { "id": "reciprocity", "route": "/reciprocity" },
+
+    // A driven state, for an error path or specific inputs.
+    {
+      "id": "reciprocity-negative",
+      "route": "/reciprocity",
+      "actions": [
+        { "fill": "#duration", "value": "-5" },
+        { "waitFor": "[role=alert]" }
+      ]
+    }
+  ]
+}
+```
+
+Fields: `id` (required — becomes the filename and the image's alt text), `route`
+(required), `viewport` (`desktop` | `mobile`, default `desktop`), `theme`
+(default `dark`), `actions` (optional: `fill`, `click`, `select`, `waitFor`).
+
+Keep it tight. Three or four shots that show the change beat twelve that bury
+it.
+
+## Step 3 — Capture "after"
+
+**Never hardcode the dev server's port.** `@vercel/microfrontends` assigns it
+(4503 at time of writing, not the 4200 in `vite.config.ts`) and increments when
+that port is taken, so `PORT=…` does *not* override it. Always read the port
+back from the server's own output:
+
+```bash
+bun run dev > /tmp/dr-after.log 2>&1 &
+until grep -q 'Local:' /tmp/dr-after.log; do sleep 1; done
+AFTER=$(grep -o 'http://localhost:[0-9]*' /tmp/dr-after.log | head -1)
+
+bun run scripts/pr-screenshots.ts .pr-screenshots/shots.json \
+  --base-url "$AFTER" --out-dir .pr-screenshots/after
+```
+
+If a shot fails here, the shot list is wrong — a bad selector, a route that
+doesn't exist. Fix it; don't ship a PR with a missing screenshot.
+
+## Step 4 — Capture "before"
+
+The "before" state is the merge-base, not your working tree. Get it from a
+worktree, which never touches your working tree — no stashing, nothing to lose.
+Leave the "after" server running: the second one auto-picks the next free port,
+which you read back the same way.
+
+```bash
+BASE=$(git merge-base HEAD origin/main)
+git worktree add /tmp/dr-before "$BASE"
+(cd /tmp/dr-before && bun install && bun run dev > /tmp/dr-before.log 2>&1 &)
+until grep -q 'Local:' /tmp/dr-before.log; do sleep 1; done
+BEFORE=$(grep -o 'http://localhost:[0-9]*' /tmp/dr-before.log | head -1)
+
+bun run scripts/pr-screenshots.ts .pr-screenshots/shots.json \
+  --base-url "$BEFORE" --out-dir .pr-screenshots/before
+
+git worktree remove --force /tmp/dr-before
+```
+
+**Always remove the worktree**, including when capture fails.
+
+Two things to know:
+
+- **A failed "before" shot is often correct.** A route or selector that doesn't
+  exist at the merge-base means the UI is *new*. Read
+  `.pr-screenshots/before/manifest.json`, confirm the failure is "this didn't
+  exist yet", and give that shot an after-only entry in the table.
+- **Shortcut:** if the PR's base is `main`, `--base-url https://dorkroom.art`
+  captures "before" from production and skips the worktree install entirely —
+  by far the slowest step. Only valid when `main` is deployed and current.
+
+## Step 5 — Upload
+
+First run only, to save a GitHub session into a persistent browser profile:
+
+```bash
+bun run scripts/github-upload-attachment.ts --login
+```
+
+That opens a headed browser; log in once. The profile lives at
+`~/.dorkroom/gh-upload-profile`, outside the repo — it holds a real session, so
+treat it as a credential. Every run after that is headless:
+
+```bash
+bun run scripts/github-upload-attachment.ts --pr <number> \
+  .pr-screenshots/before/*.webp .pr-screenshots/after/*.webp
+```
+
+It prints `{"<path>": "<url>"}`. If it reports you're not logged in, the session
+expired — re-run `--login`.
+
+<details>
+<summary>Why a browser at all?</summary>
+
+GitHub has no upload API. But dropping a file on a comment box uploads it
+immediately and returns a permanent `user-attachments/assets/…` URL — and that
+URL survives even if the comment is never submitted. So the script uploads,
+harvests the URLs, and clears the box without posting anything. This is exactly
+what happens when a human drags an image into a PR.
+</details>
+
+## Step 6 — Embed in the PR
+
+Append a `## Screenshots` section with `gh pr edit`, pairing before and after by
+shot id:
+
+```markdown
+## Screenshots
+
+### `/reciprocity` — desktop, dark
+
+| Before | After |
+|---|---|
+| <img width="500" alt="reciprocity before" src="https://github.com/user-attachments/assets/…" /> | <img width="500" alt="reciprocity after" src="https://github.com/user-attachments/assets/…" /> |
+```
+
+New UI has no before — use a single **After** column and say the route is new.
+Group by route, and put the shot that best shows the change first.
+
+## Step 7 — Clean up
+
+`.pr-screenshots/` is gitignored, but confirm `git status` is clean before
+committing. Nothing from this flow belongs in a commit.

--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,15 @@ Thumbs.db
 .nx
 
 # AI
+# Shared config (skills, agents, hooks) is committed; only local state is not.
+# Without these negations, `.claude/*` silently swallows every new skill.
 .claude/*
+!.claude/agents/
+!.claude/hooks/
+!.claude/skills/
+!.claude/settings.json
+.claude/settings.local.json
+.claude/worktrees/
 .agents/*
 .codex/*
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -3,6 +3,7 @@
   "ignorePatterns": [
     "**/dist",
     "**/coverage",
+    "**/.claude",
     "**/node_modules",
     "**/routeTree.gen.ts",
     "**/*.tsbuildinfo",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,19 @@ When adding new routes/pages, modifying existing routes, or changing API endpoin
 - **`@typescript/native-preview` is an exact dev snapshot that never auto-updates.** Re-evaluate it periodically (e.g. monthly) against newer snapshots for interim fixes — the feed is the `@beta`/`@latest` tags at <https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions> (`bun pm view @typescript/native-preview`).
 - **Dependency pinning is two-tier:** toolchain that shapes the production bundle (vite, vitest, tailwindcss, jsdom, etc.) is pinned exact; everything else uses `^` ranges. Babel (`@babel/*`) stays on ranges — Vite 8/Oxc does the actual transforms, so Babel is dev-only tooling here. The `bunfig.toml` `minimumReleaseAge` gate (7 days) backstops the ranges. To install something published in the last week (e.g. an urgent CVE patch), run `bun install --minimum-release-age 0` or add the package to `minimumReleaseAgeExcludes`.
 
+## Pull Requests
+
+**Every PR that changes rendered output must include before/after screenshots.**
+That means a route, a shared component, a theme token, or a calculator's
+displayed result — anything a user would see. Use the **`pr-screenshots`** skill:
+it maps the diff to the affected routes, captures each one before (from the
+merge-base) and after, and uploads the images to GitHub's CDN. Nothing is
+committed to the repo.
+
+If a PR has no rendered output — an `api/` change, a config bump, tests — say so
+in the description in one line. Silence is ambiguous: a reviewer can't tell
+whether screenshots were considered or forgotten.
+
 ## Git
 
 - Conventional commits, short messages

--- a/biome.json
+++ b/biome.json
@@ -9,6 +9,7 @@
       "!**/coverage",
       "!**/.nx",
       "!**/.impeccable",
+      "!**/.claude",
       "!**/node_modules",
       "!**/routeTree.gen.ts",
       "!api/openapi-spec.json",

--- a/docs/superpowers/specs/2026-07-13-pr-screenshots-design.md
+++ b/docs/superpowers/specs/2026-07-13-pr-screenshots-design.md
@@ -1,0 +1,280 @@
+# PR Screenshots — Design
+
+**Date:** 2026-07-13
+**Status:** Approved, pending implementation
+
+## Problem
+
+PRs that change what the app renders — a calculator's visible output, a
+component's layout, a theme token — ship without visual evidence. A reviewer
+reading the diff has to imagine the result, and regressions in spacing, theme
+contrast, or a calculator's displayed value pass unnoticed.
+
+We want every PR that changes rendered output to carry before/after screenshots
+of the affected routes, produced automatically, without committing binaries to
+the repo.
+
+## Goals
+
+- A PR touching rendered UI or a calculator's visible output gets before/after
+  screenshots in its description, without the author doing anything manual.
+- Screenshots are hosted by GitHub, not committed to the repo.
+- Non-visual PRs say so explicitly rather than silently omitting screenshots.
+
+## Non-goals
+
+- Pixel-diffing or automated visual regression assertions. This is evidence for
+  a human reviewer, not a gate.
+- Screenshotting the iOS app (`apps/mobile`). Web only.
+- Running in CI. This runs locally, as part of opening the PR.
+
+## Architecture
+
+Three pieces, each independently useful:
+
+1. `scripts/pr-screenshots.ts` — a Playwright capture driver. Pure mechanism:
+   given a shot list and a base URL, it produces WebP files. Knows nothing
+   about git, PRs, or diffs.
+2. `.claude/skills/pr-screenshots/SKILL.md` — the workflow. Decides whether a
+   change is visual, maps the diff to routes, authors the shot list, drives the
+   two captures, delegates upload, and writes the PR body.
+3. A **Pull Requests** section in `CLAUDE.md` making the screenshot step a
+   standing rule for future PRs.
+
+Hosting is solved by a trick borrowed from the installed
+`github-upload-image-to-pr` skill: uploading an image to a PR's comment textarea
+mints a persistent `https://github.com/user-attachments/assets/…` URL, and that
+URL survives even if the comment is never submitted. So we upload, harvest the
+URL, and clear the textarea without posting anything.
+
+We *reimplement* that as `scripts/github-upload-attachment.ts` rather than
+calling the skill, for two reasons. First, that skill lives in `.agents/skills/`
+— an installer-managed tree governed by `skills-lock.json` — so it is not
+repo-authored, can't be committed, and any local edit to it is clobbered on
+reinstall. Second, it drives whatever browser the user happens to have open via
+MCP, which is exactly the dependency that makes it unreliable. A script that
+launches its own Playwright browser has neither problem.
+
+### Component 1: `scripts/pr-screenshots.ts`
+
+Follows the conventions already established by `scripts/screenshot-homepage.ts`:
+Playwright `chromium`, viewport-only (not full-page) PNG buffer, `sharp` →
+WebP at quality 90, `await page.evaluate(() => document.fonts.ready)` before
+capture, theme forced via an init script that seeds
+`localStorage['dorkroom-theme']` (the key read by
+`packages/ui/src/contexts/theme-context.tsx`).
+
+**Input** — a shot list JSON, passed by path:
+
+```jsonc
+{
+  "baseUrl": "http://localhost:4200",
+  "outDir": ".pr-screenshots/after",
+  "shots": [
+    // A bare route. Calculators have sensible defaults, so this already
+    // renders a real calculation.
+    { "id": "reciprocity", "route": "/reciprocity" },
+
+    // A driven state, for error paths or specific inputs.
+    {
+      "id": "reciprocity-negative",
+      "route": "/reciprocity",
+      "viewport": "mobile",
+      "theme": "high-contrast",
+      "actions": [
+        { "fill": "#duration", "value": "-5" },
+        { "waitFor": "[role=alert]" }
+      ]
+    }
+  ]
+}
+```
+
+**Shot fields.** `id` (required, becomes the filename and the image's alt text),
+`route` (required), `viewport` (`desktop` = 1280×918, `mobile` = 390×844;
+default `desktop`), `theme` (one of the app's real themes — `light`, `dark`,
+`darkroom`, `high-contrast`; default `dark`), `actions` (optional).
+
+**Action vocabulary** — deliberately four verbs, no more. Anything needing more
+than this should be a story for a human, not a screenshot.
+
+| Action | Meaning |
+|---|---|
+| `{ "fill": <selector>, "value": <string> }` | Set an input's value |
+| `{ "click": <selector> }` | Click an element |
+| `{ "select": <selector>, "value": <string> }` | Choose a `<select>` option |
+| `{ "waitFor": <selector> }` | Block until the element is visible |
+
+**Output.** `<outDir>/<id>.webp`, plus a `manifest.json` listing each shot's id,
+route, viewport, theme, and file path. The skill reads the manifest to pair
+before/after shots by `id`.
+
+**Failure behavior.** A shot whose `waitFor` times out or whose selector is
+missing fails loudly — it writes no file, records the error in the manifest, and
+the script exits non-zero at the end. A missing "before" shot is legitimate (new
+page); a missing "after" shot means the shot list is wrong and the human needs
+to know.
+
+**Where output goes.** `.pr-screenshots/` at the repo root, added to
+`.gitignore`. It must be *inside the repo*, not `/tmp`: MCP browser backends can
+only read upload files within their configured workspace root, and a `/tmp` path
+fails with `Access denied: path … is not within any of the configured workspace
+roots`. (This is the same constraint `github-upload-image-to-pr` documents in
+its Step 0.)
+
+### Component 2: `.claude/skills/pr-screenshots/SKILL.md`
+
+**Step 1 — Is this change visual?**
+
+Visual if the diff touches any of:
+- `apps/dorkroom/src/**` (routes, components, styles)
+- `packages/ui/**` (shared components, theme tokens)
+- a calculator hook in `packages/logic/**` whose result is displayed
+  (`use-*-calculator.ts`, `use-light-meter-solver.ts`, and the
+  `border-calculator/` directory)
+
+Not visual if the diff only touches `api/`, `packages/api/**`, tests, configs,
+docs, or CI. In that case, state in the PR description that the change has no
+rendered output — do not silently omit the section.
+
+**Step 2 — Map the diff to routes and author the shot list.**
+
+Route files live in `apps/dorkroom/src/routes/` and map 1:1 to paths
+(`reciprocity.tsx` → `/reciprocity`). A changed shared component or logic hook
+maps to every route that consumes it; find consumers by grepping for the export.
+
+Default matrix: **desktop × dark**, one shot per affected route.
+
+Widen only for cause:
+- Diff touches layout or responsive classes → add `mobile`.
+- Diff touches theme tokens, colors, or a specific theme's stylesheet → add the
+  affected theme(s), and only when the difference is notable enough to be worth
+  a reviewer's attention. A change to `high-contrast` tokens gets a
+  `high-contrast` shot, not all four themes.
+
+Add an `actions` block only when the default state doesn't show the change —
+error states, or a calculation that needs specific inputs.
+
+**Step 3 — Capture "after".**
+
+Start the dev server (`bun run dev`, port 4200) and run the driver against it
+with `outDir: .pr-screenshots/after`.
+
+**Step 4 — Capture "before".**
+
+Create a `git worktree` at the merge-base (`git merge-base HEAD <base>`), which
+never touches the working tree — no stashing, no risk of losing uncommitted
+work. Install deps in the worktree, run its dev server on `PORT=4201`, capture
+the same shot list to `.pr-screenshots/before`, then remove the worktree.
+
+Two shortcuts, both explicit:
+- A shot whose route or selector doesn't exist at the merge-base is a *new*
+  page or control. It has no before. Record it as new; don't fail.
+- `--before-url https://dorkroom.art` captures "before" from production instead
+  of building the merge-base locally. Valid only when the PR's base is `main`
+  and `main` is deployed — worth it because the worktree install is the slowest
+  step in the whole flow.
+
+**Step 5 — Upload.**
+
+Run `scripts/github-upload-attachment.ts`, which returns
+`user-attachments/assets/…` URLs.
+
+**Playwright is the backend**, for the same reason the capture driver uses it: it
+launches its own browser, needs no already-running Chrome, and can run headless.
+That makes the whole flow one dependency (the `playwright` package already in
+`devDependencies`) and one process the skill fully controls, rather than
+something that only works when the user happens to have the right browser open
+with the right MCP attached.
+
+The catch is authentication — GitHub's upload endpoint needs a logged-in
+session, and a fresh browser has none. Solve it with a **persistent user-data-dir**
+(`chromium.launchPersistentContext('~/.dorkroom/gh-upload-profile')`):
+
+- If the profile has no valid GitHub session, launch **headed**, navigate to
+  `https://github.com/login`, and ask the user to log in once. The session
+  persists in the profile.
+- Every subsequent run launches **headless** against that profile and uploads
+  without interaction.
+
+The profile lives outside the repo and holds a real GitHub session, so treat it
+like a credential: never commit it, never copy it into the repo tree.
+
+If the script ever breaks (GitHub changes its markup), the installed
+`github-upload-image-to-pr` skill documents the same mechanics for a
+drive-the-browser-by-hand fallback.
+
+**Step 6 — Embed.**
+
+Append a `## Screenshots` section to the PR body via `gh pr edit`, as a table
+pairing before and after by shot id:
+
+```markdown
+## Screenshots
+
+### `/reciprocity` — desktop, dark
+
+| Before | After |
+|---|---|
+| <img width="600" alt="reciprocity before" src="https://github.com/user-attachments/assets/…" /> | <img width="600" alt="reciprocity after" src="https://github.com/user-attachments/assets/…" /> |
+```
+
+New pages get a single-column **After** table with a note that the route is new.
+
+### Component 3: `CLAUDE.md`
+
+A new top-level **Pull Requests** section:
+
+> Any PR that changes rendered output — a route, a shared component, a theme
+> token, or a calculator's displayed result — must include before/after
+> screenshots of the affected routes in its description. Use the
+> `pr-screenshots` skill, which captures them and uploads them to GitHub
+> without committing anything to the repo. If a PR has no rendered output, say
+> so in the description rather than omitting the section.
+
+## Two repo fixes this depends on
+
+**1. `.gitignore` silently swallows new skills.** It blanket-ignores `.claude/*`
+with no negations; the skills currently tracked (`ast-grep`, `pr`, …) survive
+only because they predate that rule. A new skill added today is ignored, never
+committed, and never reaches the team — which would defeat the entire point of
+this work. Add negations for `.claude/skills/`, `agents/`, `hooks/`, and
+`settings.json`, keeping `settings.local.json` and `worktrees/` ignored.
+
+**2. That un-ignoring exposes vendored skill bundles to the linters.** oxlint and
+Biome both honor `.gitignore`, so un-ignoring `.claude/skills/` puts vendored
+files (e.g. `impeccable/scripts/live-browser.js`, ~13k lines) into their scope
+and `bun run lint` starts failing. Exclude `.claude` explicitly in
+`.oxlintrc.json` and `biome.json`.
+
+Notably `doctor.config.json` needs *no* change — React Doctor scans workspace
+packages, and `.claude` isn't one.
+
+## Testing
+
+The driver is a script with real I/O, so the test is a real run, not a unit
+test:
+
+1. On a branch with a known UI change, run the full skill and confirm the PR
+   body renders both images.
+2. Confirm `.pr-screenshots/` is gitignored and `git status` is clean afterward.
+3. Confirm the merge-base worktree is removed even when capture fails (the
+   script must clean up in a `finally`).
+4. Confirm a non-visual diff (e.g. an `api/` change) is correctly skipped.
+5. Confirm the upload runs headless on the second run — i.e. the persistent
+   profile really did retain the GitHub session after the one headed login.
+
+## Risks
+
+- **The worktree install is slow.** Mitigated by `--before-url`, and by the fact
+  that most PRs affect one or two routes.
+- **`actions` selectors drift.** A shot list is written per-PR and thrown away,
+  so drift is bounded — it can't rot the way a committed E2E suite does.
+- **Upload depends on browser automation against GitHub's UI**, which changes
+  occasionally. That fragility is inherited from `github-upload-image-to-pr`,
+  which already documents the selectors and their fallbacks. Moving to a
+  self-launched Playwright browser doesn't add fragility — it removes the
+  separate failure mode of "the required MCP isn't attached right now".
+- **The persistent profile can go stale** (session expires, GitHub forces
+  re-auth). The skill must detect a logged-out profile and fall back to a headed
+  login prompt rather than failing with an opaque upload error.

--- a/scripts/github-upload-attachment.ts
+++ b/scripts/github-upload-attachment.ts
@@ -1,0 +1,226 @@
+/**
+ * Upload local images to GitHub and get back permanent CDN URLs, without
+ * committing them to the repo.
+ *
+ * GitHub has no API for image uploads. The only way in is the browser: dropping
+ * a file on a comment box uploads it immediately and rewrites the box to
+ * reference a permanent `user-attachments/assets/...` URL. That URL survives
+ * even if the comment is never submitted — so we upload, harvest the URLs, and
+ * clear the box without posting anything.
+ *
+ * Auth uses a persistent browser profile outside the repo. Log in once, headed;
+ * every run after that is headless.
+ *
+ *   bun run scripts/github-upload-attachment.ts --login
+ *   bun run scripts/github-upload-attachment.ts --pr 42 a.webp b.webp
+ *
+ * Prints {"<path>": "<url>", ...} to stdout on success.
+ */
+import { homedir } from 'node:os';
+import { isAbsolute, join, resolve } from 'node:path';
+import { type BrowserContext, chromium, type Page } from 'playwright';
+
+// Outside the repo on purpose: this profile holds a live GitHub session and
+// must never be committed or copied into the working tree.
+const PROFILE_DIR = join(homedir(), '.dorkroom', 'gh-upload-profile');
+
+const ASSET_URL =
+  /https:\/\/github\.com\/user-attachments\/assets\/[0-9a-fA-F-]+/g;
+
+// GitHub moves this markup around every so often; try the stable id first, then
+// progressively looser selectors.
+const COMMENT_BOX = [
+  '#new_comment_field',
+  'textarea[name="comment[body]"]',
+  'textarea[id*="comment"]',
+].join(', ');
+
+const UPLOAD_TIMEOUT_MS = 60_000;
+const LOGIN_TIMEOUT_MS = 300_000;
+
+async function sh(cmd: string[]): Promise<string> {
+  const proc = Bun.spawn(cmd, { stdout: 'pipe', stderr: 'pipe' });
+  const [out, err] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  if ((await proc.exited) !== 0) {
+    throw new Error(`\`${cmd.join(' ')}\` failed: ${err.trim()}`);
+  }
+  return out.trim();
+}
+
+async function open(headless: boolean): Promise<BrowserContext> {
+  return chromium.launchPersistentContext(PROFILE_DIR, { headless });
+}
+
+/** GitHub stamps the logged-in user into a meta tag on every page. */
+async function loggedInUser(page: Page): Promise<string | null> {
+  const user = await page
+    .locator('meta[name="user-login"]')
+    .first()
+    .getAttribute('content')
+    .catch(() => null);
+  return user || null;
+}
+
+async function login() {
+  const context = await open(false);
+  try {
+    const page = await context.newPage();
+    await page.goto('https://github.com/login');
+    console.log(
+      'A browser window is open. Log into GitHub there.\n' +
+        'Waiting for the session (up to 5 minutes)...'
+    );
+    const deadline = Date.now() + LOGIN_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const user = await loggedInUser(page);
+      if (user) {
+        console.log(
+          `Logged in as ${user}. Session saved — future runs are headless.`
+        );
+        return;
+      }
+      await page.waitForTimeout(2_000);
+    }
+    throw new Error('Timed out waiting for login.');
+  } finally {
+    // Give GitHub's cookie writes a moment to flush to the profile on disk
+    // before we tear the context down, or the session won't actually persist.
+    await new Promise((r) => setTimeout(r, 1_000));
+    await context.close();
+  }
+}
+
+/**
+ * Hand one file to GitHub and wait for it to come back as a URL.
+ *
+ * `seen` carries the URLs already in the comment box, so a batch upload can
+ * tell which URL belongs to which file: whatever is new is this file's.
+ */
+async function uploadOne(
+  page: Page,
+  file: string,
+  seen: Set<string>
+): Promise<string> {
+  // The real <input type="file"> is display:none, so it can't be clicked — but
+  // setInputFiles doesn't need visibility, only attachment. That skips the
+  // whole dropzone-click / file-chooser dance.
+  await page.locator('input[type="file"]').first().setInputFiles(file);
+
+  // GitHub parks an `![Uploading file.webp…]()` placeholder in the box and
+  // swaps it for the real reference when the upload lands — 1-5s, no event to
+  // hook, so poll for the URL rather than sleeping a fixed interval.
+  const deadline = Date.now() + UPLOAD_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const value = await page.locator(COMMENT_BOX).first().inputValue();
+    const fresh = [...value.matchAll(ASSET_URL)]
+      .map((m) => m[0])
+      .filter((url) => !seen.has(url));
+    if (fresh.length > 0) {
+      const url = fresh[0] as string;
+      seen.add(url);
+      return url;
+    }
+    // GitHub replaces the placeholder with a "Failed to upload" note rather
+    // than surfacing an error, so a rejected file would otherwise just hang
+    // until the timeout.
+    if (/failed/i.test(value)) {
+      throw new Error(`GitHub rejected ${file}: ${value.trim()}`);
+    }
+    await page.waitForTimeout(500);
+  }
+  throw new Error(`Timed out waiting for GitHub to accept ${file}.`);
+}
+
+async function upload(prNumber: string, files: string[]) {
+  const repo = await sh([
+    'gh',
+    'repo',
+    'view',
+    '--json',
+    'nameWithOwner',
+    '-q',
+    '.nameWithOwner',
+  ]);
+  const url = `https://github.com/${repo}/pull/${prNumber}`;
+
+  const context = await open(true);
+  try {
+    const page = await context.newPage();
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+
+    const user = await loggedInUser(page);
+    if (!user) {
+      throw new Error(
+        'Not logged into GitHub in the upload profile.\n' +
+          'Run: bun run scripts/github-upload-attachment.ts --login'
+      );
+    }
+
+    const box = page.locator(COMMENT_BOX).first();
+    if ((await box.count()) === 0) {
+      throw new Error(
+        `No comment box on ${url}. Is the PR locked, or the number wrong?`
+      );
+    }
+
+    const seen = new Set<string>();
+    const urls: Record<string, string> = {};
+    for (const file of files) {
+      urls[file] = await uploadOne(page, file, seen);
+      console.error(`uploaded ${file}`);
+    }
+
+    // Leave no draft behind. The `input` event matters: without it GitHub's
+    // draft autosave keeps the staged markup and resurrects it on next load.
+    await box.evaluate((el: HTMLTextAreaElement) => {
+      el.value = '';
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    console.log(JSON.stringify(urls, null, 2));
+  } finally {
+    await context.close();
+  }
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+
+  if (argv.includes('--login')) {
+    await login();
+    return;
+  }
+
+  const prIndex = argv.indexOf('--pr');
+  const prNumber = prIndex === -1 ? undefined : argv[prIndex + 1];
+  const files = argv
+    .filter((a, i) => i !== prIndex && i !== prIndex + 1 && !a.startsWith('--'))
+    .map((f) => (isAbsolute(f) ? f : resolve(f)));
+
+  if (!prNumber || files.length === 0) {
+    throw new Error(
+      'Usage:\n' +
+        '  bun run scripts/github-upload-attachment.ts --login\n' +
+        '  bun run scripts/github-upload-attachment.ts --pr <number> <file>...'
+    );
+  }
+  for (const file of files) {
+    if (!(await Bun.file(file).exists())) {
+      throw new Error(`No such file: ${file}`);
+    }
+  }
+  await upload(prNumber, files);
+}
+
+// Every failure here is something the operator has to act on (log in, fix a
+// path, pass a PR number). A Bun stack trace buries that, so print the message
+// and nothing else.
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/pr-screenshots.ts
+++ b/scripts/pr-screenshots.ts
@@ -1,0 +1,275 @@
+/**
+ * Capture the screenshots a PR needs to show what it changed.
+ *
+ * Pure mechanism: given a shot list and a running server, it writes WebP files.
+ * It knows nothing about git, diffs, or pull requests — the `pr-screenshots`
+ * skill decides *what* to shoot and calls this to actually shoot it.
+ *
+ * Usage:
+ *   bun run scripts/pr-screenshots.ts <shot-list.json>
+ *   bun run scripts/pr-screenshots.ts <shot-list.json> --base-url http://localhost:4201 --out-dir .pr-screenshots/before
+ *
+ * CLI flags override the equivalent keys in the shot list, which lets the same
+ * list be replayed against the merge-base server for the "before" capture.
+ */
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, isAbsolute, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { type Browser, chromium, type Page } from 'playwright';
+import sharp from 'sharp';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Matches scripts/screenshot-homepage.ts: WebP q90 keeps UI text and gradients
+// crisp at roughly a tenth of the equivalent PNG. GitHub renders WebP inline.
+const WEBP_QUALITY = 90;
+
+const VIEWPORTS = {
+  desktop: { width: 1280, height: 918 },
+  mobile: { width: 390, height: 844 },
+} as const;
+
+// The dev server floats overlays over the app that a reviewer must never see in
+// a screenshot: the TanStack Query devtools button (.tsqd-*), the Router
+// devtools, and the Vercel toolbar. They're dev-only, so hiding them makes the
+// shot look like production rather than like someone's laptop.
+const HIDE_DEV_OVERLAYS = `
+  [class*="tsqd-"],
+  [class*="tsrd-"],
+  #vercel-live-feedback,
+  vercel-live-feedback,
+  [data-vercel-toolbar] { display: none !important; }
+`;
+
+// The four real themes, matching packages/ui/src/contexts/theme-context.tsx.
+// 'system' is deliberately excluded: a screenshot must be deterministic, and
+// 'system' defers to the headless browser's prefers-color-scheme.
+const THEMES = ['light', 'dark', 'darkroom', 'high-contrast'] as const;
+
+const THEME_STORAGE_KEY = 'dorkroom-theme';
+
+type Viewport = keyof typeof VIEWPORTS;
+type Theme = (typeof THEMES)[number];
+
+type Action =
+  | { fill: string; value: string }
+  | { click: string }
+  | { select: string; value: string }
+  | { waitFor: string };
+
+interface Shot {
+  id: string;
+  route: string;
+  viewport?: Viewport;
+  theme?: Theme;
+  actions?: Action[];
+}
+
+interface ShotList {
+  baseUrl?: string;
+  outDir?: string;
+  shots: Shot[];
+}
+
+interface ShotResult {
+  id: string;
+  route: string;
+  viewport: Viewport;
+  theme: Theme;
+  /** Repo-relative path to the captured image, or null when the shot failed. */
+  file: string | null;
+  /** Why the shot failed. A failed shot is not necessarily fatal — see below. */
+  error?: string;
+}
+
+function parseArgs(argv: string[]) {
+  const [listPath, ...rest] = argv;
+  if (!listPath) {
+    throw new Error(
+      'Usage: bun run scripts/pr-screenshots.ts <shot-list.json> [--base-url URL] [--out-dir DIR]'
+    );
+  }
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < rest.length; i += 2) {
+    const key = rest[i];
+    const value = rest[i + 1];
+    if (!key?.startsWith('--') || value === undefined) {
+      throw new Error(`Malformed flag near "${key}"`);
+    }
+    flags[key.slice(2)] = value;
+  }
+  return {
+    listPath,
+    baseUrl: flags['base-url'],
+    outDir: flags['out-dir'],
+  };
+}
+
+/**
+ * Validate the shot list up front. A typo in a theme name should fail before we
+ * spend a minute booting a browser and capturing 11 other shots.
+ */
+function validate(list: ShotList): asserts list is ShotList {
+  if (!Array.isArray(list.shots) || list.shots.length === 0) {
+    throw new Error('Shot list has no shots.');
+  }
+  const seen = new Set<string>();
+  for (const shot of list.shots) {
+    if (!shot.id) throw new Error('Every shot needs an id.');
+    if (seen.has(shot.id)) {
+      throw new Error(`Duplicate shot id "${shot.id}" — ids become filenames.`);
+    }
+    seen.add(shot.id);
+    if (!shot.route?.startsWith('/')) {
+      throw new Error(`Shot "${shot.id}": route must start with "/".`);
+    }
+    if (shot.viewport && !(shot.viewport in VIEWPORTS)) {
+      throw new Error(
+        `Shot "${shot.id}": unknown viewport "${shot.viewport}". Use ${Object.keys(VIEWPORTS).join(' or ')}.`
+      );
+    }
+    if (shot.theme && !THEMES.includes(shot.theme)) {
+      throw new Error(
+        `Shot "${shot.id}": unknown theme "${shot.theme}". Use one of ${THEMES.join(', ')}.`
+      );
+    }
+  }
+}
+
+async function runAction(page: Page, action: Action, shotId: string) {
+  if ('fill' in action) {
+    await page.locator(action.fill).first().fill(action.value);
+  } else if ('click' in action) {
+    await page.locator(action.click).first().click();
+  } else if ('select' in action) {
+    await page.locator(action.select).first().selectOption(action.value);
+  } else if ('waitFor' in action) {
+    await page
+      .locator(action.waitFor)
+      .first()
+      .waitFor({ state: 'visible', timeout: 15_000 });
+  } else {
+    throw new Error(
+      `Shot "${shotId}": unknown action ${JSON.stringify(action)}. ` +
+        'Supported: fill, click, select, waitFor.'
+    );
+  }
+}
+
+async function capture(
+  browser: Browser,
+  shot: Shot,
+  baseUrl: string,
+  outDir: string
+): Promise<ShotResult> {
+  const viewport = shot.viewport ?? 'desktop';
+  const theme = shot.theme ?? 'dark';
+  const result: Omit<ShotResult, 'file' | 'error'> = {
+    id: shot.id,
+    route: shot.route,
+    viewport,
+    theme,
+  };
+
+  const context = await browser.newContext({
+    viewport: VIEWPORTS[viewport],
+    deviceScaleFactor: 2,
+    // Belt and braces: the app resolves the 'system' theme from this, and any
+    // component reading prefers-color-scheme directly should agree with the
+    // theme we're forcing below.
+    colorScheme: theme === 'light' ? 'light' : 'dark',
+    reducedMotion: 'reduce',
+  });
+
+  try {
+    // The app persists the theme under this key and applies it as
+    // <html data-theme="...">. Seeding it before any script runs avoids a
+    // first-paint flash of the wrong theme landing in the screenshot.
+    await context.addInitScript(
+      ([key, value]) => {
+        localStorage.setItem(key, value);
+      },
+      [THEME_STORAGE_KEY, theme] as const
+    );
+
+    const page = await context.newPage();
+    await page.goto(`${baseUrl}${shot.route}`, {
+      waitUntil: 'networkidle',
+      timeout: 60_000,
+    });
+
+    for (const action of shot.actions ?? []) {
+      await runAction(page, action, shot.id);
+    }
+
+    await page.addStyleTag({ content: HIDE_DEV_OVERLAYS });
+    await page.evaluate(() => document.fonts.ready);
+
+    const png = await page.screenshot(); // viewport-only, not full-page
+    const file = join(outDir, `${shot.id}.webp`);
+    await sharp(png).webp({ quality: WEBP_QUALITY }).toFile(join(ROOT, file));
+
+    console.log(`  ✓ ${shot.id}  (${shot.route}, ${viewport}, ${theme})`);
+    return { ...result, file };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`  ✗ ${shot.id}  ${message.split('\n')[0]}`);
+    return { ...result, file: null, error: message };
+  } finally {
+    await context.close();
+  }
+}
+
+const args = parseArgs(process.argv.slice(2));
+const list: ShotList = await Bun.file(args.listPath).json();
+validate(list);
+
+const baseUrl = (
+  args.baseUrl ??
+  list.baseUrl ??
+  'http://localhost:4200'
+).replace(/\/$/, '');
+const outDir = args.outDir ?? list.outDir ?? '.pr-screenshots';
+if (isAbsolute(outDir)) {
+  // Upload backends can only read files inside the workspace root, so the
+  // output has to stay repo-relative. See the skill's Step 5.
+  throw new Error(`--out-dir must be repo-relative, got "${outDir}".`);
+}
+
+await mkdir(join(ROOT, outDir), { recursive: true });
+
+console.log(`Capturing ${list.shots.length} shot(s) from ${baseUrl}`);
+const browser = await chromium.launch();
+let results: ShotResult[];
+try {
+  results = [];
+  for (const shot of list.shots) {
+    results.push(await capture(browser, shot, baseUrl, outDir));
+  }
+} finally {
+  await browser.close();
+}
+
+const manifestPath = join(outDir, 'manifest.json');
+await writeFile(
+  join(ROOT, manifestPath),
+  `${JSON.stringify({ baseUrl, shots: results }, null, 2)}\n`
+);
+
+const failed = results.filter((r) => !r.file);
+console.log(
+  `\n${results.length - failed.length}/${results.length} captured → ${manifestPath}`
+);
+
+// A failed shot is fatal *here* but not necessarily to the caller: when
+// replaying this list against the merge-base, a route that doesn't exist yet is
+// expected to fail. The skill reads the manifest and decides. Exiting non-zero
+// keeps an unnoticed typo in a shot list from silently producing a PR with no
+// screenshots.
+if (failed.length > 0) {
+  console.error(
+    `\n${failed.length} shot(s) failed. If this was the "before" capture, a ` +
+      'missing route or selector may just mean the UI is new — check the manifest.'
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
Adds a `pr-screenshots` skill so any PR that changes rendered output carries before/after screenshots of the affected routes. A reviewer sees the result instead of imagining it from the diff.

**No rendered output changes in this PR — no screenshots.** (Tooling only. Stating it explicitly, per the rule this PR adds.)

## What's here

- **`scripts/pr-screenshots.ts`** — Playwright capture driver. Takes a shot-list JSON (route, viewport, theme, optional `fill`/`click`/`select`/`waitFor` actions), writes WebP. Hides dev-only overlays (the TanStack Query devtools button) so shots look like production, not like someone's laptop.
- **`scripts/github-upload-attachment.ts`** — uploads to GitHub's CDN via a persistent Playwright profile. **Nothing is committed to the repo.** GitHub has no upload API, but a file dropped on a comment box mints a permanent `user-attachments/assets/…` URL that survives even though the comment is never posted. Log in once (`--login`); headless after that.
- **`.claude/skills/pr-screenshots/`** — the workflow: diff → affected routes → shot list → before (merge-base worktree) / after → upload → PR body.
- **`CLAUDE.md`** — makes screenshots a standing rule. A PR with no rendered output must say so, rather than silently omitting the section.

Default matrix is desktop × dark, one shot per affected route; it widens to mobile only when the diff touches layout, and to another theme only when the diff touches that theme.

## Verified end to end

Exercised on a real draft PR (#148, since closed): 5 routes captured against both this branch and a `git worktree` at the merge-base, 10 images uploaded headlessly, before/after table rendered from the CDN.

All five pairs came out byte-identical there — correctly, since that branch held render-preserving refactors. I falsified the null result before trusting it: injecting a visible string change made the harness report `DIFFERS`, confirming it detects real changes rather than screenshotting the same tree twice.

## Repo fixes this needed

**`.gitignore` blanket-ignored `.claude/*` with no negations, so any new skill was silently uncommittable** — the tracked ones (`ast-grep`, `pr`, …) survive only because they predate that rule. Without this fix, this very skill would never have reached the repo. Added negations for `skills/`, `agents/`, `hooks/`, `settings.json`, keeping `settings.local.json` and `worktrees/` ignored.

That un-ignoring puts vendored skill bundles into oxlint's and Biome's scope (both honor `.gitignore`), so `.claude` is now excluded in both configs.

## Two stale assumptions this turned up

- **The dev server is not on port 4200.** `@vercel/microfrontends` assigns it (4503 today) and ignores `PORT`, so both `vite.config.ts` and CLAUDE.md's "check port 4200 first!" are misleading. The skill parses the port from the server's output.
- **The two dev servers can't run concurrently.** The microfrontends proxy claims a fixed port and exits with `Port is not available` rather than picking another, so before/after captures run sequentially. (Bare `vite` *does* increment — which is what misled me initially.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)