### PR TITLE
fix(react): restore React Doctor 100/100 against the 0.7.7 ruleset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,6 @@ permissions:
   actions: read
   contents: read
 
-# Environment variables for Turbo Remote Caching
-# Set TURBO_TOKEN as a repository secret and TURBO_TEAM as a repository variable
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -69,4 +63,11 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run quality checks (lint, test, build, typecheck)
+        # Turbo Remote Caching secrets are scoped to this step only, so they
+        # are never present in the environment during `bun install` (which
+        # executes package lifecycle scripts). Set TURBO_TOKEN as a repository
+        # secret and TURBO_TEAM as a repository variable.
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ vars.TURBO_TEAM }}
         run: bun run test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,16 @@ npx react-doctor@latest --verbose         # unpinned; track the latest ruleset
   usage (e.g. `turbo-ignore` in `scripts/should-deploy.sh`, `lucide-static` in
   `apps/mobile/scripts/generate-tab-icons.mjs`) — so it reports those as
   "unused" false-positives. Circular-import detection stays on.
+- **`react-doctor/no-impure-state-updater` is also ignored** (added 2026-07-13,
+  react-doctor 0.7.7). The rule is meant to catch side effects inside a
+  `setX(prev => …)` updater callback, but it fires on any plain event handler
+  that calls a setter alongside anything else — e.g.
+  `openDetailDrawer(view) { setDetailView(view); setIsDetailOpen(true); }`.
+  Those handlers are typed `=> void` and are never passed to a setter, so they
+  cannot be updaters; its own suggested remedy ("move this into the event
+  handler") is already satisfied. It flagged 48 sites here, all false positives,
+  while flagging none of the repo's ~49 real updater callbacks. **Re-check on
+  each react-doctor upgrade** and drop the ignore once upstream fixes it.
 
 ## Documentation
 

--- a/apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
+++ b/apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
@@ -372,14 +372,19 @@ export default function DevelopmentRecipesPage() {
     onShareCombination: handleShareCombination,
   });
 
-  // Update ref on each render to keep handlers current
-  columnHandlersRef.current = {
-    isFavorite: handleCheckFavorite,
-    onToggleFavorite: handleToggleFavorite,
-    onEditCustomRecipe: handleEditCustomRecipe,
-    onDeleteCustomRecipe: handleDeleteCustomRecipe,
-    onShareCombination: handleShareCombination,
-  };
+  // Update ref after each commit to keep handlers current. This runs in an
+  // effect rather than during render because render must stay pure — the
+  // column wrappers below only read columnHandlersRef.current from event
+  // handlers (post-render), so a same-tick effect assignment is equivalent.
+  useEffect(() => {
+    columnHandlersRef.current = {
+      isFavorite: handleCheckFavorite,
+      onToggleFavorite: handleToggleFavorite,
+      onEditCustomRecipe: handleEditCustomRecipe,
+      onDeleteCustomRecipe: handleDeleteCustomRecipe,
+      onShareCombination: handleShareCombination,
+    };
+  });
 
   // Create stable columns - wrapper functions read from ref at call time
   const columns = useMemo(

--- a/apps/dorkroom/src/app/pages/development-recipes/hooks/useUrlStateSync.ts
+++ b/apps/dorkroom/src/app/pages/development-recipes/hooks/useUrlStateSync.ts
@@ -74,77 +74,37 @@ export function useUrlStateSync(props: UseUrlStateSyncProps): void {
     setIsFiltersSidebarCollapsed,
   } = props;
 
-  // Capture all setters and lookup functions in a stable ref so they never
-  // appear in the effect's dependency array. These values are written on every
-  // render but the effect only reads them when it fires (after isLoaded +
-  // recipesByUuid are ready), so we always get the current version.
-  const settersRef = useRef({
-    setSelectedFilm,
-    setSelectedDeveloper,
-    setDilutionFilter,
-    setIsoFilter,
-    setDeveloperTypeFilter,
-    setFavoritesOnly,
-    setCustomRecipeFilter,
-    setSharedRecipeView,
-    setSharedRecipeSource,
-    setIsSharedRecipeModalOpen,
-    setDetailView,
-    setIsDetailOpen,
-    setIsFiltersSidebarCollapsed,
-    getFilmById,
-    getDeveloperById,
-  });
-  settersRef.current = {
-    setSelectedFilm,
-    setSelectedDeveloper,
-    setDilutionFilter,
-    setIsoFilter,
-    setDeveloperTypeFilter,
-    setFavoritesOnly,
-    setCustomRecipeFilter,
-    setSharedRecipeView,
-    setSharedRecipeSource,
-    setIsSharedRecipeModalOpen,
-    setDetailView,
-    setIsDetailOpen,
-    setIsFiltersSidebarCollapsed,
-    getFilmById,
-    getDeveloperById,
-  };
-
+  // The setters are all useState dispatchers and the lookups are useCallback-memoized,
+  // so every value below is referentially stable. They can be listed as honest effect
+  // deps directly — no latest-ref indirection needed.
   const urlStateAppliedRef = useRef(false);
 
   // Effect 1: Apply filter state from URL (film, developer, filters).
-  // Depends only on isLoaded and the stable initialUrlState reference.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: settersRef is stable by design; initialUrlState is stable after load
   useEffect(() => {
     if (!isLoaded || !initialUrlState.fromUrl || urlStateAppliedRef.current) {
       return;
     }
 
-    const s = settersRef.current;
-
     if (initialUrlState.selectedFilm) {
-      s.setSelectedFilm(initialUrlState.selectedFilm);
+      setSelectedFilm(initialUrlState.selectedFilm);
     }
     if (initialUrlState.selectedDeveloper) {
-      s.setSelectedDeveloper(initialUrlState.selectedDeveloper);
+      setSelectedDeveloper(initialUrlState.selectedDeveloper);
     }
     if (initialUrlState.dilutionFilter) {
-      s.setDilutionFilter(initialUrlState.dilutionFilter);
+      setDilutionFilter(initialUrlState.dilutionFilter);
     }
     if (initialUrlState.isoFilter) {
-      s.setIsoFilter(initialUrlState.isoFilter);
+      setIsoFilter(initialUrlState.isoFilter);
     }
     if (initialUrlState.developerTypeFilter) {
-      s.setDeveloperTypeFilter(initialUrlState.developerTypeFilter);
+      setDeveloperTypeFilter(initialUrlState.developerTypeFilter);
     }
     if (initialUrlState.favoritesOnly) {
-      s.setFavoritesOnly(true);
+      setFavoritesOnly(true);
     }
     if (initialUrlState.customRecipeFilter) {
-      s.setCustomRecipeFilter(
+      setCustomRecipeFilter(
         initialUrlState.customRecipeFilter as
           | 'all'
           | 'hide-custom'
@@ -152,12 +112,21 @@ export function useUrlStateSync(props: UseUrlStateSyncProps): void {
           | 'official'
       );
     }
-  }, [isLoaded, initialUrlState]);
+  }, [
+    isLoaded,
+    initialUrlState,
+    setSelectedFilm,
+    setSelectedDeveloper,
+    setDilutionFilter,
+    setIsoFilter,
+    setDeveloperTypeFilter,
+    setFavoritesOnly,
+    setCustomRecipeFilter,
+  ]);
 
   // Effect 2: Handle shared custom recipe from URL.
   // Runs after Effect 1 has had a chance to set filters; marks applied only
   // when a shared custom recipe is present (early-exit path).
-  // biome-ignore lint/correctness/useExhaustiveDependencies: settersRef is stable by design
   useEffect(() => {
     if (!isLoaded || !initialUrlState.fromUrl || urlStateAppliedRef.current) {
       return;
@@ -166,16 +135,21 @@ export function useUrlStateSync(props: UseUrlStateSyncProps): void {
       return;
     }
 
-    const s = settersRef.current;
-    s.setSharedRecipeView(sharedCustomRecipeView);
-    s.setSharedRecipeSource('custom');
-    s.setIsSharedRecipeModalOpen(true);
+    setSharedRecipeView(sharedCustomRecipeView);
+    setSharedRecipeSource('custom');
+    setIsSharedRecipeModalOpen(true);
     urlStateAppliedRef.current = true;
-  }, [isLoaded, initialUrlState, sharedCustomRecipeView]);
+  }, [
+    isLoaded,
+    initialUrlState,
+    sharedCustomRecipeView,
+    setSharedRecipeView,
+    setSharedRecipeSource,
+    setIsSharedRecipeModalOpen,
+  ]);
 
   // Effect 3: Handle API recipe lookup from URL (requires recipesByUuid to be populated).
   // Depends on recipesByUuid so it retries after data loads.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: settersRef is stable by design
   useEffect(() => {
     if (!isLoaded || !initialUrlState.fromUrl || urlStateAppliedRef.current) {
       return;
@@ -196,29 +170,40 @@ export function useUrlStateSync(props: UseUrlStateSyncProps): void {
       return;
     }
 
-    const s = settersRef.current;
     const recipeView: DevelopmentCombinationView = {
       combination: recipe,
-      film: s.getFilmById(recipe.filmStockId),
-      developer: s.getDeveloperById(recipe.developerId),
+      film: getFilmById(recipe.filmStockId),
+      developer: getDeveloperById(recipe.developerId),
       source: 'api',
       canShare: true,
     };
 
-    if (initialUrlState.isDirectSelection) {
-      s.setDetailView(recipeView);
-      s.setIsDetailOpen(true);
-      s.setIsFiltersSidebarCollapsed?.(true);
-    } else if (initialUrlState.isSharedApiRecipe) {
-      s.setDetailView(recipeView);
-      s.setIsDetailOpen(true);
-      s.setIsFiltersSidebarCollapsed?.(true);
+    if (
+      initialUrlState.isDirectSelection ||
+      initialUrlState.isSharedApiRecipe
+    ) {
+      setDetailView(recipeView);
+      setIsDetailOpen(true);
+      setIsFiltersSidebarCollapsed?.(true);
     } else {
-      s.setSharedRecipeView(recipeView);
-      s.setSharedRecipeSource('shared');
-      s.setIsSharedRecipeModalOpen(true);
+      setSharedRecipeView(recipeView);
+      setSharedRecipeSource('shared');
+      setIsSharedRecipeModalOpen(true);
     }
 
     urlStateAppliedRef.current = true;
-  }, [isLoaded, initialUrlState, sharedCustomRecipeView, recipesByUuid]);
+  }, [
+    isLoaded,
+    initialUrlState,
+    sharedCustomRecipeView,
+    recipesByUuid,
+    getFilmById,
+    getDeveloperById,
+    setDetailView,
+    setIsDetailOpen,
+    setIsFiltersSidebarCollapsed,
+    setSharedRecipeView,
+    setSharedRecipeSource,
+    setIsSharedRecipeModalOpen,
+  ]);
 }

--- a/apps/dorkroom/src/app/pages/films/films-page.tsx
+++ b/apps/dorkroom/src/app/pages/films/films-page.tsx
@@ -193,6 +193,7 @@ export default function FilmsPage() {
   const urlFilm = useMemo(() => {
     if (!urlFilmSlug) return null;
     return films.find((f) => f.slug === urlFilmSlug) ?? null;
+    // eslint-disable-next-line react-doctor/exhaustive-deps -- react-doctor reports "stale searchParams.film" via alias tracing through urlFilmSlug, but urlFilmSlug IS searchParams.film re-derived every render (line 189, not memoized); adding searchParams.film directly is flagged as a redundant dep by react-hooks/exhaustive-deps
   }, [films, urlFilmSlug]);
 
   // Sync URL params to filter state when URL changes (back/forward navigation, bookmarks).
@@ -282,6 +283,7 @@ export default function FilmsPage() {
     if (urlFilm) {
       setSelectedFilm(urlFilm);
     }
+    // eslint-disable-next-line react-doctor/exhaustive-deps -- same alias-tracing false positive as the urlFilm useMemo above: urlFilmSlug already IS searchParams.film re-derived every render, so it's already covered
   }, [urlFilm, urlFilmSlug, isLoading]);
 
   // Debounced URL sync (500ms)

--- a/apps/dorkroom/src/app/pages/home-page.tsx
+++ b/apps/dorkroom/src/app/pages/home-page.tsx
@@ -186,8 +186,8 @@ export function HomePage() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 auto-rows-fr">
           {CALCULATORS.map((tool, index) => (
             <ToolCard
-              {...tool}
               key={tool.title}
+              {...tool}
               as={Link}
               href={tool.href}
               className={

--- a/apps/dorkroom/src/app/pages/mat-calculator/mat-calculator-page.tsx
+++ b/apps/dorkroom/src/app/pages/mat-calculator/mat-calculator-page.tsx
@@ -285,7 +285,7 @@ function MatSidebar({
       >
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           {guideBarCuts.map((c) => (
-            <GuideBarCard {...c} key={c.title} />
+            <GuideBarCard key={c.title} {...c} />
           ))}
         </div>
       </CalculatorCard>

--- a/apps/mobile/src/components/meter/meter-readout.tsx
+++ b/apps/mobile/src/components/meter/meter-readout.tsx
@@ -1,6 +1,6 @@
 import * as Haptics from 'expo-haptics';
 import { SymbolView } from 'expo-symbols';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 // PanResponder is intentional here: the scrubber deliberately avoids a react-native-gesture-handler dependency, commits the value live on each stop crossing (one re-render per stop, gated by the haptic tick — the smooth glide rides an Animated.Value the overlay wheel binds to, not React state). Migrating to Gesture.Pan() would be an invasive, behavior-changing rewrite of the gesture/animation pipeline for no functional gain. The type-only Animated import is erased at runtime, so there's no UI-thread animation that reanimated would improve.
 /* eslint-disable react-doctor/rn-prefer-reanimated, react-doctor/rn-no-panresponder -- intentional PanResponder + JS Animated pipeline; see note above */
 import {
@@ -297,56 +297,65 @@ function ValueScrubber({
   // A disabled setting (e.g. ISO while locked to the roll's EI) swallows the
   // gesture and prompts instead of scrubbing. Kept in refs the once-created
   // PanResponder reads, so the check happens in the gesture handler itself.
+  // Refreshed in an effect (not during render) for the same reason as
+  // `controller` above: render must stay pure, and these are only ever read
+  // later, from the gesture handlers.
   const disabledRef = useRef(field.disabled);
-  disabledRef.current = field.disabled;
   const onBlockedRef = useRef(field.onBlocked);
-  onBlockedRef.current = field.onBlocked;
   const onTapHintRef = useRef(onTapHint);
-  onTapHintRef.current = onTapHint;
-
-  const panRef = useRef<ReturnType<typeof PanResponder.create>>(null);
-  panRef.current ??= PanResponder.create({
-    onStartShouldSetPanResponder: () => true,
-    onMoveShouldSetPanResponder: () => true,
-    onPanResponderTerminationRequest: () => false,
-    onPanResponderGrant: () => {
-      if (disabledRef.current) {
-        onBlockedRef.current?.();
-        return;
-      }
-      controller.current.prepare();
-      clearHoldTimer();
-      holdTimer.current = setTimeout(() => {
-        holdTimer.current = null;
-        controller.current.begin();
-      }, HOLD_TO_SCRUB_MS);
-    },
-    onPanResponderMove: (_e, g) => {
-      if (disabledRef.current) return;
-      const moved = Math.hypot(g.dx, g.dy);
-      if (!scrubbing.current && moved >= DRAG_TO_SCRUB_PX) {
-        clearHoldTimer();
-        controller.current.begin();
-      }
-      controller.current.move(g);
-    },
-    onPanResponderRelease: () => {
-      if (disabledRef.current) return;
-      clearHoldTimer();
-      if (scrubbing.current) {
-        controller.current.end();
-      } else {
-        dragY.setValue(0);
-        onTapHintRef.current();
-      }
-    },
-    onPanResponderTerminate: () => {
-      if (disabledRef.current) return;
-      clearHoldTimer();
-      controller.current.cancel();
-    },
+  useEffect(() => {
+    disabledRef.current = field.disabled;
+    onBlockedRef.current = field.onBlocked;
+    onTapHintRef.current = onTapHint;
   });
-  const pan = panRef.current;
+
+  // Created once and reused for the component's lifetime (a lazy useState
+  // initializer, not a ref write in render, so it stays pure) — Fast Refresh
+  // survives because the handlers below close over the refs above, not over
+  // `field` directly.
+  const [pan] = useState(() =>
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      onPanResponderTerminationRequest: () => false,
+      onPanResponderGrant: () => {
+        if (disabledRef.current) {
+          onBlockedRef.current?.();
+          return;
+        }
+        controller.current.prepare();
+        clearHoldTimer();
+        holdTimer.current = setTimeout(() => {
+          holdTimer.current = null;
+          controller.current.begin();
+        }, HOLD_TO_SCRUB_MS);
+      },
+      onPanResponderMove: (_e, g) => {
+        if (disabledRef.current) return;
+        const moved = Math.hypot(g.dx, g.dy);
+        if (!scrubbing.current && moved >= DRAG_TO_SCRUB_PX) {
+          clearHoldTimer();
+          controller.current.begin();
+        }
+        controller.current.move(g);
+      },
+      onPanResponderRelease: () => {
+        if (disabledRef.current) return;
+        clearHoldTimer();
+        if (scrubbing.current) {
+          controller.current.end();
+        } else {
+          dragY.setValue(0);
+          onTapHintRef.current();
+        }
+      },
+      onPanResponderTerminate: () => {
+        if (disabledRef.current) return;
+        clearHoldTimer();
+        controller.current.cancel();
+      },
+    })
+  );
 
   return (
     <View

--- a/apps/mobile/src/components/meter/scrub-overlay.tsx
+++ b/apps/mobile/src/components/meter/scrub-overlay.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useState } from 'react';
 // eslint-disable-next-line react-doctor/rn-prefer-reanimated -- JS-thread Animated is intentional: the drag is a JS-thread PanResponder (no gesture-handler) and reanimated's worklet babel plugin isn't wired up; the ruler commits on release so there are no React re-renders during the drag, keeping the glide smooth.
 import { Animated, Text, View } from 'react-native';
 import { readoutText as MONO } from '@/theme/tokens';
@@ -10,9 +10,8 @@ import { SCRUB_COL_WIDTH, SCRUB_GAP } from './scrub-math';
  * (writer) and the ruler (reader). Lives here so the screen needn't import
  * Animated directly. Carries the live combined drag offset in px (right/up +). */
 export function useDragOffset() {
-  const ref = useRef<Animated.Value>(null);
-  ref.current ??= new Animated.Value(0);
-  return ref.current;
+  const [value] = useState(() => new Animated.Value(0));
+  return value;
 }
 
 const SHADOW = {

--- a/apps/mobile/src/hooks/use-meter-iso-lock.ts
+++ b/apps/mobile/src/hooks/use-meter-iso-lock.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useMMKVBoolean } from 'react-native-mmkv';
 import { useMeterRoll } from '@/hooks/use-meter-roll';
 import { LOCK_ISO_TO_ROLL_KEY, meterStorage } from '@/lib/meter-settings';
@@ -8,25 +8,31 @@ interface MeterIsoLock {
   rollIso: number | undefined;
   /** True when the meter ISO is currently pinned to the roll's EI. */
   isoLocked: boolean;
-  toggleLock: () => void;
+  /**
+   * The EI to pin the solver to, or undefined when unlocked. Pass straight to
+   * `useLightMeterSolver`'s `isoOverride`.
+   */
+  lockedIso: number | undefined;
+  /** Flip the lock. Unlocking leaves the solver wherever the lock had it. */
+  setLocked: (locked: boolean) => void;
 }
 
 /**
  * Locks the meter's ISO to the rated EI of the roll the meter is logging to (the
  * one shown in the roll pill — not merely the first active roll, so a second
- * active roll can't hijack the EI). While locked, the solver ISO is kept equal to
- * that EI (scrubbing it snaps back); unlock to meter at a different EI. Lock
- * state is persisted (default on).
+ * active roll can't hijack the EI). While locked, the solver derives its ISO from
+ * that EI via `lockedIso`; unlock to meter at a different EI. Lock state is
+ * persisted (default on).
  *
  * When `linked` is false (the film-log integration is turned off in meter
  * settings) the roll is ignored entirely: `rollIso` is undefined and nothing
  * locks, so the meter ISO is freely scrubbable.
+ *
+ * This hook deliberately knows nothing about the solver: it reports the EI to pin
+ * to, and the screen feeds that into `useLightMeterSolver`. Pushing the EI up into
+ * the solver from an effect here would cost an extra render on every change.
  */
-export function useMeterIsoLock(
-  solverIso: number,
-  setSolverIso: (iso: number) => void,
-  linked: boolean
-): MeterIsoLock {
+export function useMeterIsoLock(linked: boolean): MeterIsoLock {
   const { roll } = useMeterRoll();
   const rollIso = linked ? roll?.iso : undefined;
   const [lockRaw, setLockIso] = useMMKVBoolean(
@@ -35,16 +41,15 @@ export function useMeterIsoLock(
   );
   const isoLocked = (lockRaw ?? true) && rollIso != null;
 
-  useEffect(() => {
-    if (isoLocked && rollIso != null && solverIso !== rollIso) {
-      setSolverIso(rollIso);
-    }
-  }, [isoLocked, rollIso, solverIso, setSolverIso]);
-
-  const toggleLock = useCallback(
-    () => setLockIso(!isoLocked),
-    [isoLocked, setLockIso]
+  const setLocked = useCallback(
+    (locked: boolean) => setLockIso(locked),
+    [setLockIso]
   );
 
-  return { rollIso, isoLocked, toggleLock };
+  return {
+    rollIso,
+    isoLocked,
+    lockedIso: isoLocked ? rollIso : undefined,
+    setLocked,
+  };
 }

--- a/apps/mobile/src/screens/development/recipe-views.ts
+++ b/apps/mobile/src/screens/development/recipe-views.ts
@@ -38,6 +38,10 @@ export function filterRecipeViews(
   const q = query.trim();
   if (!q && !tag) return views;
   return views.filter((view) => {
+    // Scans each view's own short tag list, not one shared array. Building a Set per view
+    // would cost an allocation per item to replace a handful of comparisons — strictly
+    // slower. Suppressed as a false positive rather than "fixed".
+    // eslint-disable-next-line react-doctor/js-set-map-lookups -- see above
     if (tag && !(view.combination.tags ?? []).includes(tag)) return false;
     if (!q) return true;
     const film = view.film ? `${view.film.brand} ${view.film.name}` : '';

--- a/apps/mobile/src/screens/meter-screen.tsx
+++ b/apps/mobile/src/screens/meter-screen.tsx
@@ -227,17 +227,24 @@ export function MeterScreen() {
   const { flashStyle, triggerFlash } = useShutterFlash();
   // Seed the solver from the last persisted locked setting + ISO (read once).
   const initialSettings = useMemo(() => getMeterSettings(), []);
-  const solver = useLightMeterSolver(meter.ev, initialSettings);
   const isFocused = useIsFocused();
   // When off, all film-log integration is hidden (clean standalone meter).
   const [linkFilmLog] = useLinkFilmLog();
   // Lock the meter ISO to the active roll's rated EI (default on, tap to unlock);
-  // skipped entirely while the film-log link is off.
-  const { rollIso, isoLocked, toggleLock } = useMeterIsoLock(
-    solver.iso,
-    solver.setIso,
-    linkFilmLog
-  );
+  // skipped entirely while the film-log link is off. Resolved before the solver so
+  // the locked EI can be derived into it rather than written back from an effect.
+  const { rollIso, isoLocked, lockedIso, setLocked } =
+    useMeterIsoLock(linkFilmLog);
+  const solver = useLightMeterSolver(meter.ev, initialSettings, lockedIso);
+  const { setIso } = solver;
+  const toggleLock = useCallback(() => {
+    // Commit the pinned EI as we unlock, so the meter stays on the EI the user has
+    // been metering at instead of snapping back to the ISO from before the lock.
+    if (isoLocked && rollIso != null) {
+      setIso(rollIso);
+    }
+    setLocked(!isoLocked);
+  }, [isoLocked, rollIso, setIso, setLocked]);
   const { message: toastMessage, show: showToast } = useToast();
   const onIsoBlocked = useCallback(
     () => showToast('Unlock EI in the upper left to pick an ISO'),

--- a/apps/mobile/src/screens/meter-screen.tsx
+++ b/apps/mobile/src/screens/meter-screen.tsx
@@ -215,10 +215,14 @@ export function MeterScreen() {
   const { hasPermission, requestPermission } = meter;
   // Still-photo output for the shutter; kept in a ref so the capture hook reads
   // the latest instance without re-subscribing each render. Force JPEG (the iOS
-  // default is HEIC, which Skia's grayscale pass can't decode).
+  // default is HEIC, which Skia's grayscale pass can't decode). Refreshed in an
+  // effect rather than during render, since render must stay pure — the ref is
+  // only read later, from the capture hook's own handler.
   const photoOutput = usePhotoOutput({ containerFormat: 'jpeg' });
   const photoOutputRef = useRef<CameraPhotoOutput | null>(photoOutput);
-  photoOutputRef.current = photoOutput;
+  useEffect(() => {
+    photoOutputRef.current = photoOutput;
+  });
   const capture = useMeterCapture(photoOutputRef);
   const { flashStyle, triggerFlash } = useShutterFlash();
   // Seed the solver from the last persisted locked setting + ISO (read once).

--- a/doctor.config.json
+++ b/doctor.config.json
@@ -11,7 +11,8 @@
       "deslop/unused-file",
       "deslop/unused-export",
       "deslop/unused-dependency",
-      "deslop/unused-dev-dependency"
+      "deslop/unused-dev-dependency",
+      "react-doctor/no-impure-state-updater"
     ]
   }
 }

--- a/packages/logic/src/hooks/border-calculator/__tests__/use-paper-dimension-input.test.ts
+++ b/packages/logic/src/hooks/border-calculator/__tests__/use-paper-dimension-input.test.ts
@@ -1,0 +1,183 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePaperDimensionInput } from '../use-paper-dimension-input';
+
+/**
+ * Characterization tests for the paper dimension input hook.
+ *
+ * The display string is shown in the *current unit* while the parent stores
+ * inches, so these cover both the identity case (inches) and a converting case
+ * (centimetres) to pin the round-trip.
+ */
+
+const INCHES = {
+  toDisplay: (inches: number) => inches,
+  toInches: (value: number) => value,
+};
+
+const CM = {
+  toDisplay: (inches: number) => inches * 2.54,
+  toInches: (cm: number) => cm / 2.54,
+};
+
+function setup(
+  overrides: Partial<Parameters<typeof usePaperDimensionInput>[0]> = {}
+) {
+  const onWidthChange = vi.fn();
+  const onHeightChange = vi.fn();
+
+  const utils = renderHook(
+    (props: { initialWidth: number; initialHeight: number }) =>
+      usePaperDimensionInput({
+        initialWidth: props.initialWidth,
+        initialHeight: props.initialHeight,
+        toDisplay: INCHES.toDisplay,
+        toInches: INCHES.toInches,
+        onWidthChange,
+        onHeightChange,
+        ...overrides,
+      }),
+    { initialProps: { initialWidth: 8, initialHeight: 10 } }
+  );
+
+  return { ...utils, onWidthChange, onHeightChange };
+}
+
+describe('usePaperDimensionInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('seeds the inputs from the initial dimensions', () => {
+    const { result } = setup();
+
+    expect(result.current.paperWidthInput).toBe('8');
+    expect(result.current.paperHeightInput).toBe('10');
+    expect(result.current.isEditingPaperWidth).toBe(false);
+    expect(result.current.isEditingPaperHeight).toBe(false);
+  });
+
+  it('renders the initial dimensions in display units', () => {
+    const { result } = renderHook(() =>
+      usePaperDimensionInput({
+        initialWidth: 8,
+        initialHeight: 10,
+        toDisplay: CM.toDisplay,
+        toInches: CM.toInches,
+        onWidthChange: vi.fn(),
+        onHeightChange: vi.fn(),
+      })
+    );
+
+    expect(result.current.paperWidthInput).toBe('20.32');
+    expect(result.current.paperHeightInput).toBe('25.4');
+  });
+
+  it('follows external dimension changes while not editing', () => {
+    const { result, rerender } = setup();
+
+    rerender({ initialWidth: 11, initialHeight: 14 });
+
+    expect(result.current.paperWidthInput).toBe('11');
+    expect(result.current.paperHeightInput).toBe('14');
+  });
+
+  it('does not clobber the typed value while editing', () => {
+    const { result, rerender } = setup();
+
+    act(() => result.current.handlePaperWidthChange('9.5'));
+    // Parent echoes the pushed value back in.
+    rerender({ initialWidth: 9.5, initialHeight: 10 });
+
+    expect(result.current.paperWidthInput).toBe('9.5');
+    expect(result.current.isEditingPaperWidth).toBe(true);
+  });
+
+  it('pushes valid keystrokes to the parent immediately', () => {
+    const { result, onWidthChange } = setup();
+
+    act(() => result.current.handlePaperWidthChange('9.5'));
+
+    expect(onWidthChange).toHaveBeenCalledWith(9.5);
+    expect(result.current.paperWidthInput).toBe('9.5');
+  });
+
+  it('converts to inches before pushing when a unit conversion is active', () => {
+    const onWidthChange = vi.fn();
+    const { result } = renderHook(() =>
+      usePaperDimensionInput({
+        initialWidth: 8,
+        initialHeight: 10,
+        toDisplay: CM.toDisplay,
+        toInches: CM.toInches,
+        onWidthChange,
+        onHeightChange: vi.fn(),
+      })
+    );
+
+    act(() => result.current.handlePaperWidthChange('25.4'));
+
+    expect(onWidthChange).toHaveBeenCalledWith(10);
+  });
+
+  it.each([
+    '',
+    '   ',
+    '12.',
+  ])('keeps incomplete input %o visible without pushing it to the parent', (value) => {
+    const { result, onWidthChange } = setup();
+
+    act(() => result.current.handlePaperWidthChange(value));
+
+    expect(result.current.paperWidthInput).toBe(value);
+    expect(onWidthChange).not.toHaveBeenCalled();
+  });
+
+  it('reformats to the canonical display value on blur', () => {
+    const { result, onWidthChange, rerender } = setup();
+
+    act(() => result.current.handlePaperWidthChange('9.5000'));
+    rerender({ initialWidth: 9.5, initialHeight: 10 });
+    act(() => result.current.handlePaperWidthBlur());
+
+    expect(onWidthChange).toHaveBeenLastCalledWith(9.5);
+    expect(result.current.paperWidthInput).toBe('9.5');
+    expect(result.current.isEditingPaperWidth).toBe(false);
+  });
+
+  it.each([
+    '',
+    '  ',
+    'abc',
+  ])('reverts to the last committed dimension when blurring on %o', (value) => {
+    const { result } = setup();
+
+    act(() => result.current.handlePaperWidthChange(value));
+    act(() => result.current.handlePaperWidthBlur());
+
+    expect(result.current.paperWidthInput).toBe('8');
+    expect(result.current.isEditingPaperWidth).toBe(false);
+  });
+
+  it('tracks height independently of width', () => {
+    const { result, onHeightChange, onWidthChange } = setup();
+
+    act(() => result.current.handlePaperHeightChange('14'));
+
+    expect(onHeightChange).toHaveBeenCalledWith(14);
+    expect(onWidthChange).not.toHaveBeenCalled();
+    expect(result.current.paperHeightInput).toBe('14');
+    expect(result.current.isEditingPaperHeight).toBe(true);
+    expect(result.current.isEditingPaperWidth).toBe(false);
+    expect(result.current.paperWidthInput).toBe('8');
+  });
+
+  it('reverts height to the last committed dimension on invalid blur', () => {
+    const { result } = setup();
+
+    act(() => result.current.handlePaperHeightChange('nope'));
+    act(() => result.current.handlePaperHeightBlur());
+
+    expect(result.current.paperHeightInput).toBe('10');
+  });
+});

--- a/packages/logic/src/hooks/border-calculator/use-paper-dimension-input.ts
+++ b/packages/logic/src/hooks/border-calculator/use-paper-dimension-input.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { formatForDisplay } from '../../utils/precision';
 
 /**
@@ -42,15 +42,18 @@ export function usePaperDimensionInput({
   onWidthChange,
   onHeightChange,
 }: UsePaperDimensionInputProps): UsePaperDimensionInputReturn {
-  // Local string state for custom paper dimensions (in display units)
-  const [paperWidthInput, setPaperWidthInput] = useState(() =>
-    formatForDisplay(toDisplay(initialWidth))
-  );
-  const [paperHeightInput, setPaperHeightInput] = useState(() =>
-    formatForDisplay(toDisplay(initialHeight))
-  );
-  const [isEditingPaperWidth, setIsEditingPaperWidth] = useState(false);
-  const [isEditingPaperHeight, setIsEditingPaperHeight] = useState(false);
+  // While the user is typing we hold their raw keystrokes as a "draft"; the rest
+  // of the time the input is simply derived from the committed dimension. Keeping
+  // the committed value derived (rather than mirrored into state by an effect)
+  // means an external change — a preset, a unit switch — shows up on the next
+  // render instead of costing a second one.
+  const [widthDraft, setWidthDraft] = useState<string | null>(null);
+  const [heightDraft, setHeightDraft] = useState<string | null>(null);
+
+  const paperWidthInput =
+    widthDraft ?? formatForDisplay(toDisplay(initialWidth));
+  const paperHeightInput =
+    heightDraft ?? formatForDisplay(toDisplay(initialHeight));
 
   // Helper to validate and convert input to inches
   const validateAndConvert = (value: string): number | null => {
@@ -67,27 +70,9 @@ export function usePaperDimensionInput({
     return null;
   };
 
-  // Sync local state when parent state or unit changes (but not while editing)
-  useEffect(() => {
-    if (!isEditingPaperWidth) {
-      const displayValue = toDisplay(initialWidth);
-      // Round to 3 decimals to avoid floating point artifacts
-      setPaperWidthInput(formatForDisplay(displayValue));
-    }
-  }, [initialWidth, toDisplay, isEditingPaperWidth]);
-
-  useEffect(() => {
-    if (!isEditingPaperHeight) {
-      const displayValue = toDisplay(initialHeight);
-      // Round to 3 decimals to avoid floating point artifacts
-      setPaperHeightInput(formatForDisplay(displayValue));
-    }
-  }, [initialHeight, toDisplay, isEditingPaperHeight]);
-
   // Handle width input change
   const handlePaperWidthChange = (value: string) => {
-    setIsEditingPaperWidth(true);
-    setPaperWidthInput(value);
+    setWidthDraft(value);
 
     // Push valid changes to parent state immediately for live recomputation
     const inches = validateAndConvert(value);
@@ -96,28 +81,20 @@ export function usePaperDimensionInput({
     }
   };
 
-  // Handle width blur - convert to inches when stable
+  // Handle width blur - convert to inches when stable. Dropping the draft falls
+  // back to the derived display value, which reformats away typing artifacts
+  // ("9.5000" → "9.5") and reverts empty or invalid input to the last commit.
   const handlePaperWidthBlur = () => {
-    setIsEditingPaperWidth(false);
     const inches = validateAndConvert(paperWidthInput);
     if (inches !== null) {
       onWidthChange(inches);
-      // Format the display value to avoid floating point precision artifacts
-      const displayValue = toDisplay(inches);
-      setPaperWidthInput(formatForDisplay(displayValue));
-    } else if (paperWidthInput === '' || /^\s*$/.test(paperWidthInput)) {
-      // Reset to current value if empty
-      setPaperWidthInput(formatForDisplay(toDisplay(initialWidth)));
-    } else {
-      // Reset to current value if invalid
-      setPaperWidthInput(formatForDisplay(toDisplay(initialWidth)));
     }
+    setWidthDraft(null);
   };
 
   // Handle height input change
   const handlePaperHeightChange = (value: string) => {
-    setIsEditingPaperHeight(true);
-    setPaperHeightInput(value);
+    setHeightDraft(value);
 
     // Push valid changes to parent state immediately for live recomputation
     const inches = validateAndConvert(value);
@@ -126,29 +103,20 @@ export function usePaperDimensionInput({
     }
   };
 
-  // Handle height blur - convert to inches when stable
+  // Handle height blur - see handlePaperWidthBlur.
   const handlePaperHeightBlur = () => {
-    setIsEditingPaperHeight(false);
     const inches = validateAndConvert(paperHeightInput);
     if (inches !== null) {
       onHeightChange(inches);
-      // Format the display value to avoid floating point precision artifacts
-      const displayValue = toDisplay(inches);
-      setPaperHeightInput(formatForDisplay(displayValue));
-    } else if (paperHeightInput === '' || /^\s*$/.test(paperHeightInput)) {
-      // Reset to current value if empty
-      setPaperHeightInput(formatForDisplay(toDisplay(initialHeight)));
-    } else {
-      // Reset to current value if invalid
-      setPaperHeightInput(formatForDisplay(toDisplay(initialHeight)));
     }
+    setHeightDraft(null);
   };
 
   return {
     paperWidthInput,
     paperHeightInput,
-    isEditingPaperWidth,
-    isEditingPaperHeight,
+    isEditingPaperWidth: widthDraft !== null,
+    isEditingPaperHeight: heightDraft !== null,
     handlePaperWidthChange,
     handlePaperWidthBlur,
     handlePaperHeightChange,

--- a/packages/logic/src/hooks/development-recipes/use-development-table.ts
+++ b/packages/logic/src/hooks/development-recipes/use-development-table.ts
@@ -9,7 +9,7 @@ import {
   type SortingState,
   useReactTable,
 } from '@tanstack/react-table';
-import { useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 
 export interface DevelopmentCombinationView {
   combination: Combination;
@@ -133,10 +133,6 @@ export function useDevelopmentTable({
     [pageIndex]
   );
 
-  // Keep a ref to the latest isFavorite so the Set can be rebuilt when it changes
-  const isFavoriteRef = useRef(isFavorite);
-  isFavoriteRef.current = isFavorite;
-
   // Pre-compute the full set of favorite IDs from the current rows.
   // This is O(n) once per rows/isFavorite change, eliminating the repeated
   // isFavorite() calls that made sorting O(n log n * k).
@@ -144,13 +140,11 @@ export function useDevelopmentTable({
     const set = new Set<string>();
     for (const row of rows) {
       const key = getCombinationKey(row);
-      if (isFavoriteRef.current(key)) {
+      if (isFavorite(key)) {
         set.add(key);
       }
     }
     return set;
-    // Re-compute when rows change OR when isFavorite identity changes (e.g., after toggle)
-    // oxlint-disable-next-line react-hooks/exhaustive-deps -- isFavorite kept intentionally to trigger rebuild on identity change (read via ref inside)
   }, [rows, isFavorite]);
 
   const favoriteSortingFn = useMemo(

--- a/packages/logic/src/hooks/development-recipes/use-recipe-url-state.ts
+++ b/packages/logic/src/hooks/development-recipes/use-recipe-url-state.ts
@@ -1,5 +1,12 @@
 import type { Combination, Developer, Film } from '@dorkroom/api';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import type {
   InitialUrlState,
   RecipeUrlParams,
@@ -75,15 +82,50 @@ const parseSearchParams = (searchParams: URLSearchParams): RecipeUrlParams => {
 };
 
 /**
- * Read the current browser URL and extract managed query parameters.
+ * The browser URL is an external store: it changes from browser navigation
+ * (popstate) and from our own history writes. Modelling it as a real store and
+ * reading it with `useSyncExternalStore` avoids the stale/torn values you get
+ * from mirroring it into `useState` via an effect.
  */
-const getCurrentParams = (): RecipeUrlParams => {
-  if (typeof window === 'undefined') {
-    return {};
-  }
+const EMPTY_PARAMS: RecipeUrlParams = {};
 
-  return parseSearchParams(new URLSearchParams(window.location.search));
+const urlListeners = new Set<() => void>();
+
+/**
+ * `pushState`/`replaceState` do not fire `popstate`, so our own history writes
+ * must notify subscribers explicitly.
+ */
+const notifyUrlChanged = (): void => {
+  for (const listener of urlListeners) {
+    listener();
+  }
 };
+
+const subscribeToUrl = (onStoreChange: () => void): (() => void) => {
+  urlListeners.add(onStoreChange);
+  window.addEventListener('popstate', onStoreChange);
+  return () => {
+    urlListeners.delete(onStoreChange);
+    window.removeEventListener('popstate', onStoreChange);
+  };
+};
+
+// Cached so the snapshot stays referentially stable between actual URL changes.
+// Returning a fresh object each call would make useSyncExternalStore re-render
+// forever.
+let cachedSearch: string | null = null;
+let cachedParams: RecipeUrlParams = EMPTY_PARAMS;
+
+const getUrlSnapshot = (): RecipeUrlParams => {
+  const search = window.location.search;
+  if (search !== cachedSearch) {
+    cachedSearch = search;
+    cachedParams = parseSearchParams(new URLSearchParams(search));
+  }
+  return cachedParams;
+};
+
+const getServerUrlSnapshot = (): RecipeUrlParams => EMPTY_PARAMS;
 
 /**
  * Find a film entity by slug helper.
@@ -267,8 +309,10 @@ export const useRecipeUrlState = (
   },
   recipesByUuid?: Map<string, Combination>
 ): UseRecipeUrlStateReturn => {
-  const [params, setParams] = useState<RecipeUrlParams>(() =>
-    getCurrentParams()
+  const params = useSyncExternalStore(
+    subscribeToUrl,
+    getUrlSnapshot,
+    getServerUrlSnapshot
   );
   const isInitializedRef = useRef(false);
   const updateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -277,21 +321,6 @@ export const useRecipeUrlState = (
   useEffect(() => {
     paramsRef.current = params;
   }, [params]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return undefined;
-    }
-
-    const handlePopState = () => {
-      setParams(getCurrentParams());
-    };
-
-    window.addEventListener('popstate', handlePopState);
-    return () => {
-      window.removeEventListener('popstate', handlePopState);
-    };
-  }, []);
 
   const { decodeSharedCustomRecipe, isCustomRecipeUrl } =
     useCustomRecipeSharing();
@@ -401,9 +430,17 @@ export const useRecipeUrlState = (
       }
     }
 
-    isInitializedRef.current = true;
     return state;
   }, [params, films, developers]);
+
+  // Mark initialized only once the derived state has committed. Writing this
+  // during the memo would leak the flag from renders React replays or discards.
+  // Declared before the URL-sync effect below so that effect still observes it.
+  useEffect(() => {
+    if (initialUrlState.fromUrl) {
+      isInitializedRef.current = true;
+    }
+  }, [initialUrlState]);
 
   const updateUrl = useCallback((newParams: Partial<RecipeUrlParams>) => {
     if (updateTimeoutRef.current) {
@@ -440,7 +477,8 @@ export const useRecipeUrlState = (
         searchString ? `?${searchString}` : ''
       }${window.location.hash ?? ''}`;
       window.history.replaceState(null, '', newUrl);
-      setParams(parseSearchParams(searchParams));
+      // replaceState doesn't fire popstate — tell the store to re-read the URL.
+      notifyUrlChanged();
     }, 300);
   }, []);
 

--- a/packages/logic/src/hooks/use-light-meter-solver.ts
+++ b/packages/logic/src/hooks/use-light-meter-solver.ts
@@ -46,12 +46,21 @@ export interface LightMeterSolverInitialState {
  *
  * @param ev - Metered scene EV at ISO 100, or null/NaN when unavailable
  * @param initial - Optional starting controls (e.g. persisted); read once on mount
+ * @param isoOverride - Pins the ISO while set (e.g. locked to a film roll's rated
+ *   EI). The solver derives its ISO from this rather than having a caller write it
+ *   back through `setIso` from an effect, which would cost an extra render and can
+ *   momentarily solve against a stale ISO. `setIso` still writes the underlying
+ *   value, so a caller can commit the pinned EI before releasing the override.
  */
 export const useLightMeterSolver = (
   ev: number | null,
-  initial?: LightMeterSolverInitialState
+  initial?: LightMeterSolverInitialState,
+  isoOverride?: number
 ): UseLightMeterSolver => {
-  const [iso, setIso] = useState(initial?.iso ?? DEFAULT_CAMERA_EXPOSURE_ISO);
+  const [isoState, setIso] = useState(
+    initial?.iso ?? DEFAULT_CAMERA_EXPOSURE_ISO
+  );
+  const iso = isoOverride ?? isoState;
   const [priority, setPriority] = useState<MeterPriority>(
     initial?.priority ?? 'aperture'
   );

--- a/packages/ui/src/components/border-calculator/mobile-border-calculator.tsx
+++ b/packages/ui/src/components/border-calculator/mobile-border-calculator.tsx
@@ -703,6 +703,7 @@ export function MobileBorderCalculator({
       formatDimensions,
       currentSettings,
     }),
+    // eslint-disable-next-line react-doctor/exhaustive-deps -- react-doctor reports "stale dimensionData.paperSizeWarning" via alias tracing through paperSizeWarning, but paperSizeWarning (line 333) IS `calculation?.paperSizeWarning ?? dimensionData.paperSizeWarning` re-derived every render; adding dimensionData.paperSizeWarning directly is flagged as a redundant dep by react-hooks/exhaustive-deps
     [
       form,
       formValues,

--- a/packages/ui/src/components/border-calculator/mobile-border-calculator.tsx
+++ b/packages/ui/src/components/border-calculator/mobile-border-calculator.tsx
@@ -898,6 +898,7 @@ export function MobileBorderCalculator({
                 } as React.CSSProperties
               }
               title="Share preset"
+              aria-label="Share preset"
             >
               <Share className="size-5" />
             </button>

--- a/packages/ui/src/components/border-calculator/presets-section.tsx
+++ b/packages/ui/src/components/border-calculator/presets-section.tsx
@@ -45,6 +45,7 @@ export function PresetsSection() {
             disabled={isSharing || isGeneratingShareUrl}
             className="rounded-full border p-2 transition focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50 disabled:cursor-not-allowed text-[color:var(--color-text-primary)] border-[color:var(--color-border-secondary)] bg-[rgba(var(--color-background-rgb),0.08)] hover:bg-[rgba(var(--color-background-rgb),0.14)] focus-visible:ring-[color:var(--color-focus-ring)]"
             title="Share preset"
+            aria-label="Share preset"
           >
             {isGeneratingShareUrl ? (
               <svg
@@ -76,6 +77,7 @@ export function PresetsSection() {
             onClick={() => setIsEditingPreset(true)}
             className="rounded-full border p-2 transition focus-visible:outline-none focus-visible:ring-2 text-[color:var(--color-text-primary)] border-[color:var(--color-border-secondary)] bg-[rgba(var(--color-background-rgb),0.08)] hover:bg-[rgba(var(--color-background-rgb),0.14)] focus-visible:ring-[color:var(--color-focus-ring)]"
             title="Edit preset"
+            aria-label="Edit preset"
           >
             <Save className="size-4" />
           </button>

--- a/packages/ui/src/components/border-calculator/sections/border-size-section.tsx
+++ b/packages/ui/src/components/border-calculator/sections/border-size-section.tsx
@@ -38,6 +38,7 @@ export function BorderSizeSection({ onClose }: BorderSizeSectionProps) {
           type="button"
           onClick={onClose}
           className="rounded-lg border border-white/20 bg-white/5 p-2 text-white transition hover:bg-white/10"
+          aria-label="Close border size"
         >
           <X className="size-5" />
         </button>

--- a/packages/ui/src/components/border-calculator/sections/paper-size-section.tsx
+++ b/packages/ui/src/components/border-calculator/sections/paper-size-section.tsx
@@ -165,6 +165,7 @@ export function PaperSizeSection({ onClose }: PaperSizeSectionProps) {
           type="button"
           onClick={onClose}
           className="rounded-lg border border-white/20 bg-white/5 p-2 text-white transition hover:bg-white/10"
+          aria-label="Close paper & image size"
         >
           <X className="size-5" />
         </button>

--- a/packages/ui/src/components/border-calculator/sections/position-offsets-section.tsx
+++ b/packages/ui/src/components/border-calculator/sections/position-offsets-section.tsx
@@ -30,6 +30,7 @@ export function PositionOffsetsSection({
           type="button"
           onClick={onClose}
           className="rounded-lg border border-white/20 bg-white/5 p-2 text-white transition hover:bg-white/10"
+          aria-label="Close position & offsets"
         >
           <X className="size-5" />
         </button>

--- a/packages/ui/src/components/border-calculator/sections/presets-section.tsx
+++ b/packages/ui/src/components/border-calculator/sections/presets-section.tsx
@@ -68,6 +68,7 @@ export function PresetsSection({
           type="button"
           onClick={onClose}
           className="rounded-lg border border-primary bg-border-muted p-2 text-primary transition hoverable-action-btn"
+          aria-label="Close presets"
         >
           <X className="size-5" />
         </button>
@@ -186,6 +187,7 @@ export function PresetsSection({
                           type="button"
                           onClick={() => startEdit(preset)}
                           className="rounded p-1 text-white/70 transition hover:bg-white/10 hover:text-white"
+                          aria-label={`Edit ${preset.name}`}
                         >
                           <Save className="size-4" />
                         </button>
@@ -193,6 +195,7 @@ export function PresetsSection({
                           type="button"
                           onClick={() => onDeletePreset(preset.id)}
                           className="rounded p-1 text-red-400 transition hover:bg-red-500/10 hover:text-red-300"
+                          aria-label={`Delete ${preset.name}`}
                         >
                           <Trash2 className="size-4" />
                         </button>

--- a/packages/ui/src/components/development-recipes/table-columns.tsx
+++ b/packages/ui/src/components/development-recipes/table-columns.tsx
@@ -545,6 +545,11 @@ export const createTableColumns = (
                   ? 'View on FilmDev.org'
                   : 'View source'
               }
+              aria-label={
+                isFilmDevOrgUrl(combination.infoSource)
+                  ? 'View on FilmDev.org'
+                  : 'View source'
+              }
               className="inline-flex items-center"
               style={{ color: 'var(--color-text-tertiary)' }}
               onClick={(e) => {

--- a/packages/ui/src/components/films/film-image.tsx
+++ b/packages/ui/src/components/films/film-image.tsx
@@ -1,5 +1,5 @@
 import { Film } from 'lucide-react';
-import { type FC, useEffect, useRef, useState } from 'react';
+import { type FC, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { cn } from '../../lib/cn';
 
 interface FilmImageProps {
@@ -60,14 +60,20 @@ export const FilmImage: FC<FilmImageProps> = ({
 }) => {
   // Single consolidated state so the per-src reset is one update.
   const [state, setState] = useState<ImageState>(() => getInitialState(src));
-  // Track the previous src in a ref and reset state during render when it
-  // changes, instead of in an effect. See
-  // https://react.dev/learn/you-might-not-need-an-effect
-  const prevSrcRef = useRef(src);
-  if (src !== prevSrcRef.current) {
-    prevSrcRef.current = src;
+  // Reset state when src changes (skipping the initial mount, since useState
+  // above already initializes correctly for it). A layout effect — not a
+  // render-time ref write, which react-doctor's no-ref-current-in-render rule
+  // flags, since render must stay pure — runs synchronously after the DOM
+  // update but before the browser paints, so there's no visible flash of the
+  // previous src's state.
+  const isFirstRender = useRef(true);
+  useLayoutEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
     setState(getInitialState(src));
-  }
+  }, [src]);
 
   const { hasError, isLoading, hasTimedOut } = state;
   const dimension = sizeMap[size];

--- a/packages/ui/src/components/share-modal.tsx
+++ b/packages/ui/src/components/share-modal.tsx
@@ -243,6 +243,7 @@ function WebLinkSection({
           <button
             type="button"
             onClick={onCopy}
+            aria-label={copySuccess ? 'Copied web link' : 'Copy web link'}
             className={cn(
               'px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2'
             )}

--- a/packages/ui/src/components/theme-toggle.tsx
+++ b/packages/ui/src/components/theme-toggle.tsx
@@ -181,14 +181,14 @@ export function ThemeToggle({
   }, [isOpen]);
 
   // Toggle the dropdown via pointer. Reset focus tracking when opening to
-  // match the previous reset-on-open behavior.
+  // match the previous reset-on-open behavior. The ref write happens here,
+  // in the event handler, rather than inside the state updater — updaters
+  // must stay pure since React may invoke them more than once.
   const toggleOpen = () => {
-    setIsOpen((prev) => {
-      if (!prev) {
-        focusedIndexRef.current = -1;
-      }
-      return !prev;
-    });
+    if (!isOpen) {
+      focusedIndexRef.current = -1;
+    }
+    setIsOpen((prev) => !prev);
   };
 
   const handleThemeChange = (newTheme: Theme) => {

--- a/packages/ui/src/hooks/use-responsive-tier.ts
+++ b/packages/ui/src/hooks/use-responsive-tier.ts
@@ -45,6 +45,10 @@ export function useResponsiveTier(): ResponsiveTierResult {
     return getTier(window.innerWidth);
   });
 
+  // Both subscribe paths below return a cleanup (removeEventListener / removeListener);
+  // the rule is thrown by the `typeof window` guard, whose early return subscribes to
+  // nothing. Suppressed as a false positive rather than "fixed".
+  // eslint-disable-next-line react-doctor/effect-needs-cleanup -- see above
   useEffect(() => {
     if (typeof window === 'undefined') return;
 

--- a/packages/ui/src/hooks/useIsMobile.ts
+++ b/packages/ui/src/hooks/useIsMobile.ts
@@ -16,6 +16,10 @@ export function useIsMobile(maxWidth = 768): boolean {
     return window.matchMedia(`(max-width: ${maxWidth}px)`).matches;
   });
 
+  // Both subscribe paths below return a cleanup (removeEventListener / removeListener);
+  // the rule is thrown by the `typeof window` guard, whose early return subscribes to
+  // nothing. Suppressed as a false positive rather than "fixed".
+  // eslint-disable-next-line react-doctor/effect-needs-cleanup -- see above
   useEffect(() => {
     if (typeof window === 'undefined') {
       return;


### PR DESCRIPTION
Restores React Doctor to **100/100 on all four projects** against the 0.7.7 ruleset, which introduced rules that didn't exist when #147 was written.

Baseline on `main` was 51 / 67 / 34 / 43 (source / mobile / logic / ui) — `main` itself was nowhere near 100, so this is the ruleset moving, not a regression.

## The bulk of it was a broken rule

`no-impure-state-updater` produced **48 of the 59 findings, and every one is a false positive.** The rule is meant to catch side effects inside a `setX(prev => …)` updater callback, but it fires on any plain event handler that calls a setter alongside anything else:

```ts
const openDetailDrawer = (view: DevelopmentCombinationView) => {
  setDetailView(view);      // ← flagged
  setIsDetailOpen(true);
};
```

These handlers are typed `=> void` and are never passed to a setter, so they cannot be updaters — and the rule's own suggested remedy ("move this into the event handler") is already satisfied. It flagged 48 non-updaters while flagging none of the repo's ~49 genuine updater callbacks.

Ignored repo-wide in `doctor.config.json`, matching the existing `deslop/unused-*` precedent (disabled for the same reason: the analysis is wrong for this repo). Rationale and a re-check-on-upgrade note are in `CLAUDE.md`.

## Real bugs fixed

- **`use-recipe-url-state`** — the URL (an external store) was mirrored into `useState` through a `popstate` effect, and a ref was written **inside a `useMemo`**. Now read via `useSyncExternalStore` with a cached, referentially-stable snapshot; initialization is marked from an effect. `pushState`/`replaceState` don't fire `popstate`, so our own history writes notify the store explicitly. All 35 existing tests pass unchanged.
- **`useUrlStateSync`** — `settersRef.current = {…}` written during render. The setters are `useState` dispatchers and the lookups are `useCallback`-memoized, so they were always safe to list as deps. Ref deleted, along with three `biome-ignore` suppressions it was propping up.
- **`use-development-table`** — a latest-ref written during render that was inert (the memo already depended on `isFavorite`). Removed, with its `exhaustive-deps` suppression.
- **`use-paper-dimension-input`** — two effects mirroring parent state into the input. Now derived from a draft-or-committed value. The hook had **no tests**: added 15 characterization tests, verified green against the *old* implementation first, then refactored — they pass unchanged.
- **`use-meter-iso-lock` / `use-light-meter-solver`** — the lock pushed the roll's EI up into the solver from an effect. Inverted: the lock reports `lockedIso`, the solver accepts it as an `isoOverride` and derives its ISO, and the effect is gone.

## Other false positives (suppressed inline, with rationale)

- `effect-needs-cleanup` ×2 — both subscribe paths already return a cleanup; the rule is thrown by the `typeof window` guard, whose early return subscribes to nothing.
- `js-set-map-lookups` — scans each view's own short tag list, not one shared array. A `Set` per view trades an allocation for a handful of comparisons — strictly slower.

## Verification

- `bun run test` — 20/20 tasks (lint, test, build, typecheck)
- React Doctor — **100 / 100 / 100 / 100**, zero diagnostics
- Mobile typecheck run explicitly with generated Expo route types present

**No rendered output changes** — these are behavior-preserving refactors, so no screenshots.

> ⚠️ **Needs on-device verification.** The meter ISO lock touches the live camera screen, which isn't unit-testable (MMKV/native). Please smoke-test: lock/unlock the EI, switch rolls, toggle the film-log link. Note the deliberate behavior preservation — the old effect wrote `rollIso` into solver state, so unlocking left the ISO put; deriving it would snap the meter back to the pre-lock ISO, so `toggleLock` now commits the pinned EI before releasing the lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
