### PR TITLE
docs(spec): top-level ISO filter + orphaned sub-filter params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ ds-bundle/
 
 # Visual brainstorming companion scratch files
 .superpowers/
+
+# PR screenshot capture scratch (uploaded to GitHub CDN, never committed)
+.pr-screenshots/

--- a/apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
+++ b/apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
@@ -528,7 +528,6 @@ export default function DevelopmentRecipesPage() {
               onClearFilters={clearFilters}
               showDeveloperTypeFilter={!selectedDeveloper}
               showDilutionFilter={!!selectedDeveloper}
-              showIsoFilter={!!selectedFilm}
               defaultCollapsed={true}
               favoritesOnly={favoritesOnly}
               onFavoritesOnlyChange={setFavoritesOnly}
@@ -610,7 +609,6 @@ export default function DevelopmentRecipesPage() {
                 onClearSelections={clearSelections}
                 showDeveloperTypeFilter={!selectedDeveloper}
                 showDilutionFilter={!!selectedDeveloper}
-                showIsoFilter={!!selectedFilm}
                 onCollapsedChange={setIsFiltersSidebarCollapsed}
                 collapsed={isFiltersSidebarCollapsed}
                 defaultCollapsed={false}

--- a/docs/superpowers/plans/2026-07-14-top-level-iso-filter.md
+++ b/docs/superpowers/plans/2026-07-14-top-level-iso-filter.md
@@ -1,0 +1,618 @@
+# Top-level ISO Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make ISO a top-level filter on the development-recipes page (always visible, always filtering, surviving a film change), and stop applying sub-filter URL params that arrive without their parent.
+
+**Architecture:** Four small changes in `@dorkroom/logic` (the ISO option list, the ISO filter predicate, the film setter, and the URL-state memo) plus one prop removal in the app. No new files, no new dependencies. Each change is driven by a failing test in an existing test file.
+
+**Tech Stack:** React 19, TypeScript, Vitest + `@testing-library/react`, TanStack Query, Turborepo, Graphite (`gt`) for the stacked PR.
+
+Spec: `docs/superpowers/specs/2026-07-14-top-level-iso-filter-design.md`
+
+## Global Constraints
+
+- Never use `any` — use specific types or `unknown`.
+- Never import internal package paths — use `@dorkroom/ui`, `@dorkroom/logic`, `@dorkroom/api`.
+- Branch is `advisor/018-top-level-iso-filter`, stacked on `advisor/017-url-search-coercion` via Graphite. Commit with `gt modify -c -a -m "..."`, never `git commit`.
+- Conventional commit messages, short.
+- The gate is `bun run test` (lint + test + build + typecheck) and must be 20/20.
+- React Doctor must stay **100/100 on all four projects**: `npx react-doctor@latest -y --json --json-out /tmp/rd.json` then read `.projects[].score.score`.
+- Do not push and do not open a PR without explicit user approval.
+
+## Reference: existing test data
+
+`packages/logic/src/hooks/development-recipes/__tests__/use-development-recipes.test.ts`
+already defines the mocks every logic task below reuses. Do not redefine them.
+
+- Films: `hp5-plus` (isoSpeed 400), `tri-x-400` (400), `neopan-400` (400)
+- Combinations (filmSlug, shootingIso):
+  `hp5-plus`/400, `tri-x-400`/200, `neopan-400`/800,
+  `hp5-plus`/1600, `tri-x-400`/100, `neopan-400`/400
+
+So the distinct catalogue ISOs, ascending, are: **100, 200, 400, 800, 1600**.
+
+The file already has a `beforeEach` that mocks `useFilms` / `useDevelopers` /
+`useCombinations`, and a `wrapper` built from `QueryClientProvider`. Reuse both.
+
+---
+
+### Task 1: ISO options are the whole catalogue, box speed only with a film
+
+**Files:**
+- Modify: `packages/logic/src/hooks/development-recipes/use-development-recipes.ts:392-423`
+- Test: `packages/logic/src/hooks/development-recipes/__tests__/use-development-recipes.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `getAvailableISOs(): { label: string; value: string }[]` — unchanged signature, new behaviour. Returns `All ISOs` first, then `Box speed (N)` **only when a film is selected**, then every catalogue ISO ascending as `{ label: '400', value: '400' }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append this `describe` block inside the existing `describe('useDevelopmentRecipes', ...)`
+in `__tests__/use-development-recipes.test.ts`:
+
+```ts
+  describe('getAvailableISOs', () => {
+    it('offers every catalogue ISO when no film is selected', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      expect(result.current.getAvailableISOs()).toEqual([
+        { label: 'All ISOs', value: '' },
+        { label: '100', value: '100' },
+        { label: '200', value: '200' },
+        { label: '400', value: '400' },
+        { label: '800', value: '800' },
+        { label: '1600', value: '1600' },
+      ]);
+    });
+
+    it('adds box speed once a film is selected, keeping the full ISO list', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      act(() => {
+        result.current.setSelectedFilm(mockFilms[0]);
+      });
+
+      // The numeric options stay global — they do not narrow to HP5's ISOs —
+      // so an ISO chosen before the film change is still representable.
+      expect(result.current.getAvailableISOs()).toEqual([
+        { label: 'All ISOs', value: '' },
+        { label: 'Box speed (400)', value: 'boxspeed' },
+        { label: '100', value: '100' },
+        { label: '200', value: '200' },
+        { label: '400', value: '400' },
+        { label: '800', value: '800' },
+        { label: '1600', value: '1600' },
+      ]);
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+```bash
+bun run test:unit "use-development-recipes"
+```
+
+Expected: both new tests FAIL. The first fails with `expected [] to deeply equal
+[...]` (today `availableISOs` returns `[]` with no film); the second fails because
+the numeric list is currently narrowed to HP5's ISOs (`400`, `1600`) instead of the
+full catalogue.
+
+- [ ] **Step 3: Rewrite `availableISOs`**
+
+In `use-development-recipes.ts`, replace the whole `availableISOs` memo
+(currently lines 392-423) with:
+
+```ts
+  const availableISOs = useMemo((): {
+    label: string;
+    value: string;
+  }[] => {
+    const isos = [{ label: 'All ISOs', value: '' }];
+
+    // Box speed is defined relative to the selected film's rated speed, so it is
+    // only offered when there is a film to be relative to.
+    if (selectedFilm) {
+      isos.push({
+        label: `Box speed (${selectedFilm.isoSpeed})`,
+        value: 'boxspeed',
+      });
+    }
+
+    // ISO is a top-level filter, so the numeric options are every shooting ISO in
+    // the catalogue rather than just the selected film's. That keeps a chosen ISO
+    // representable when the film changes — which it must be, since selecting a
+    // film no longer clears it.
+    const isoSet = new Set<number>();
+    allCombinations.forEach((combo) => {
+      isoSet.add(combo.shootingIso);
+    });
+
+    Array.from(isoSet)
+      .sort((a, b) => a - b)
+      .forEach((iso) => {
+        isos.push({ label: iso.toString(), value: iso.toString() });
+      });
+
+    return isos;
+  }, [selectedFilm, allCombinations]);
+```
+
+- [ ] **Step 4: Remove the now-unused helper import if it is orphaned**
+
+`getAllSlugsForFilm` was used by the old memo. Check whether anything else still
+uses it:
+
+```bash
+grep -n "getAllSlugsForFilm" packages/logic/src/hooks/development-recipes/use-development-recipes.ts
+```
+
+If the only remaining hit is the `import` line, delete that import. If other call
+sites remain, leave it alone.
+
+- [ ] **Step 5: Run the tests and confirm they pass**
+
+```bash
+bun run test:unit "use-development-recipes"
+```
+
+Expected: PASS, including every pre-existing test in the file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+gt modify -c -a -m "feat(recipes): offer every catalogue ISO, not just the selected film's"
+```
+
+---
+
+### Task 2: A numeric ISO filters without a film; box speed is a no-op without one
+
+**Files:**
+- Modify: `packages/logic/src/hooks/development-recipes/use-development-recipes.ts` (the "Filter by ISO" block, currently `if (isoFilter && selectedFilm) {`)
+- Test: `packages/logic/src/hooks/development-recipes/__tests__/use-development-recipes.test.ts`
+
+**Interfaces:**
+- Consumes: `getAvailableISOs` from Task 1 (not called here, but the same hook).
+- Produces: `filteredCombinations` now honours `isoFilter` with no film selected. `setIsoFilter(value: string)` is unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside `describe('useDevelopmentRecipes', ...)`:
+
+```ts
+  describe('ISO filtering without a film', () => {
+    it('filters on a numeric ISO with no film selected', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      act(() => {
+        result.current.setIsoFilter('400');
+      });
+
+      // hp5-plus/400 and neopan-400/400 — across two different films.
+      expect(result.current.filteredCombinations).toHaveLength(2);
+      expect(
+        result.current.filteredCombinations.every(
+          (combo) => combo.shootingIso === 400
+        )
+      ).toBe(true);
+    });
+
+    it('treats box speed as a no-op with no film selected', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+      const total = result.current.filteredCombinations.length;
+
+      act(() => {
+        result.current.setIsoFilter('boxspeed');
+      });
+
+      // Box speed means "this film's rated speed" — with no film there is
+      // nothing to compare against, so it must not silently drop everything.
+      expect(result.current.filteredCombinations).toHaveLength(total);
+    });
+
+    it('still resolves box speed against the selected film', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      act(() => {
+        result.current.setSelectedFilm(mockFilms[0]); // hp5-plus, rated 400
+      });
+      act(() => {
+        result.current.setIsoFilter('boxspeed');
+      });
+
+      // Of HP5's two recipes (400 and 1600), only the 400 is at box speed.
+      expect(result.current.filteredCombinations).toHaveLength(1);
+      expect(result.current.filteredCombinations[0].shootingIso).toBe(400);
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+```bash
+bun run test:unit "use-development-recipes"
+```
+
+Expected: the first test FAILS (`expected 6 to be 2`) because `isoFilter` is
+ignored without a film. The second and third should already pass — that is fine and
+expected; they are regression cover for behaviour we must not break.
+
+- [ ] **Step 3: Ungate the filter**
+
+Replace the "Filter by ISO" block in `use-development-recipes.ts`:
+
+```ts
+    // Filter by ISO. A numeric ISO is absolute, so it filters on its own. Box
+    // speed is relative to the selected film's rated speed, so with no film there
+    // is nothing to compare against and it is a no-op rather than a wipeout.
+    if (isoFilter) {
+      if (isoFilter === 'boxspeed') {
+        if (selectedFilm) {
+          combinations = combinations.filter(
+            (combo) => combo.shootingIso === selectedFilm.isoSpeed
+          );
+        }
+      } else {
+        combinations = combinations.filter(
+          (combo) => combo.shootingIso.toString() === isoFilter
+        );
+      }
+    }
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+```bash
+bun run test:unit "use-development-recipes"
+```
+
+Expected: PASS, all three, plus every pre-existing test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -a -m "feat(recipes): let a numeric ISO filter without a film selected"
+```
+
+---
+
+### Task 3: Selecting a film no longer clears the ISO filter
+
+**Files:**
+- Modify: `packages/logic/src/hooks/development-recipes/use-development-recipes.ts:244-247`
+- Test: `packages/logic/src/hooks/development-recipes/__tests__/use-development-recipes.test.ts`
+
+**Interfaces:**
+- Consumes: the ungated filter from Task 2 (this test asserts the two together).
+- Produces: `setSelectedFilm(film: Film | null): void` — same signature, no longer clears `isoFilter`. `setSelectedDeveloper` still clears `dilutionFilter` and must stay that way.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `describe('useDevelopmentRecipes', ...)`:
+
+```ts
+  describe('ISO survives a film change', () => {
+    it('keeps the ISO filter when a film is selected', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      act(() => {
+        result.current.setIsoFilter('400');
+      });
+      act(() => {
+        result.current.setSelectedFilm(mockFilms[0]); // hp5-plus
+      });
+
+      // A top-level filter must not be silently reset by another control.
+      expect(result.current.isoFilter).toBe('400');
+      // HP5 has exactly one recipe at ISO 400.
+      expect(result.current.filteredCombinations).toHaveLength(1);
+    });
+
+    it('still clears the dilution filter when a developer is selected', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      act(() => {
+        result.current.setDilutionFilter('1+9');
+      });
+      act(() => {
+        result.current.setSelectedDeveloper(mockDevelopers[0]);
+      });
+
+      // Dilution stays a sub-filter of developer — this behaviour is deliberate.
+      expect(result.current.dilutionFilter).toBe('');
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests and confirm the first fails**
+
+```bash
+bun run test:unit "use-development-recipes"
+```
+
+Expected: the first test FAILS with `expected '' to be '400'` — `setSelectedFilm`
+currently wipes the ISO. The dilution test should already PASS (regression cover).
+
+- [ ] **Step 3: Drop the side-effect**
+
+In `use-development-recipes.ts`, replace:
+
+```ts
+  const setSelectedFilm = useCallback((film: Film | null) => {
+    setSelectedFilmState(film);
+    setIsoFilter('');
+  }, []);
+```
+
+with:
+
+```ts
+  // ISO is a top-level filter and deliberately survives a film change, so this no
+  // longer clears it. (setSelectedDeveloper still clears the dilution filter —
+  // dilution remains scoped to its developer.)
+  const setSelectedFilm = useCallback((film: Film | null) => {
+    setSelectedFilmState(film);
+  }, []);
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+```bash
+bun run test:unit "use-development-recipes"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -a -m "feat(recipes): keep the ISO filter when the film changes"
+```
+
+---
+
+### Task 4: Orphaned box-speed and dilution params are not applied
+
+**Files:**
+- Modify: `packages/logic/src/hooks/development-recipes/use-recipe-url-state.ts:385-391`
+- Test: `packages/logic/src/hooks/development-recipes/__tests__/use-recipe-url-state.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `initialUrlState.isoFilter` is left unset for `?iso=boxspeed` with no resolvable film; `initialUrlState.dilutionFilter` is left unset for `?dilution=…` with no resolvable developer. A numeric `?iso=` still sets `isoFilter` with no film.
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `__tests__/use-recipe-url-state.test.ts`. It already mocks `window.location`
+via a `mockLocation` object with a `search` field — set `mockLocation.search`
+before rendering, following the existing tests in that file.
+
+Append a new `describe` block inside the top-level `describe('useRecipeUrlState', ...)`:
+
+```ts
+  describe('orphaned sub-filter params', () => {
+    it('ignores box speed with no film in the URL', () => {
+      mockLocation.search = '?iso=boxspeed';
+
+      const { result } = renderHook(() =>
+        useRecipeUrlState(mockFilms, mockDevelopers, mockCurrentState)
+      );
+
+      // Box speed is relative to a film; on its own it cannot mean anything, so
+      // it must not land in state where it would be invisible and inert.
+      expect(result.current.initialUrlState.isoFilter).toBeUndefined();
+    });
+
+    it('keeps a numeric ISO with no film in the URL', () => {
+      mockLocation.search = '?iso=400';
+
+      const { result } = renderHook(() =>
+        useRecipeUrlState(mockFilms, mockDevelopers, mockCurrentState)
+      );
+
+      expect(result.current.initialUrlState.isoFilter).toBe('400');
+    });
+
+    it('ignores a dilution with no developer in the URL', () => {
+      mockLocation.search = '?dilution=1%2B9';
+
+      const { result } = renderHook(() =>
+        useRecipeUrlState(mockFilms, mockDevelopers, mockCurrentState)
+      );
+
+      expect(result.current.initialUrlState.dilutionFilter).toBeUndefined();
+    });
+  });
+```
+
+`mockCurrentState` is the fixture the existing tests in this file already pass as
+the third argument (defined at `use-recipe-url-state.test.ts:68`). Reuse it as-is —
+do not introduce a new fixture.
+
+- [ ] **Step 2: Run the tests and confirm two fail**
+
+```bash
+bun run test:unit "use-recipe-url-state"
+```
+
+Expected: the box-speed test FAILS (`expected 'boxspeed' to be undefined`) and the
+dilution test FAILS (`expected '1+9' to be undefined`). The numeric-ISO test should
+already PASS — regression cover that the guard is not too broad.
+
+- [ ] **Step 3: Guard the two orphan cases**
+
+In `use-recipe-url-state.ts`, inside the `initialUrlState` memo, replace:
+
+```ts
+    if (validation.sanitized.dilution) {
+      state.dilutionFilter = validation.sanitized.dilution;
+    }
+
+    if (validation.sanitized.iso) {
+      state.isoFilter = validation.sanitized.iso;
+    }
+```
+
+with:
+
+```ts
+    // A dilution is defined relative to a developer — "1+9" means different things
+    // for different developers — so it is meaningless without one. Applying it
+    // anyway would leave a filter in state that has no control and does nothing.
+    if (validation.sanitized.dilution && state.selectedDeveloper) {
+      state.dilutionFilter = validation.sanitized.dilution;
+    }
+
+    // A numeric ISO is absolute and stands on its own. Box speed is relative to
+    // the selected film, so it is only meaningful alongside one.
+    if (validation.sanitized.iso) {
+      if (validation.sanitized.iso !== 'boxspeed' || state.selectedFilm) {
+        state.isoFilter = validation.sanitized.iso;
+      }
+    }
+```
+
+This relies on `state.selectedFilm` / `state.selectedDeveloper` already having been
+resolved earlier in the same memo — they are, immediately above this block. Do not
+reorder them.
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+```bash
+bun run test:unit "use-recipe-url-state"
+```
+
+Expected: PASS, all three, plus the 35 pre-existing tests in the file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gt modify -c -a -m "fix(recipes): ignore sub-filter URL params that arrive without their parent"
+```
+
+---
+
+### Task 5: The ISO control is always visible
+
+**Files:**
+- Modify: `apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx:531` and `:613`
+
+**Interfaces:**
+- Consumes: `getAvailableISOs()` from Task 1, which now returns a populated list with no film selected — that is what makes the always-visible control meaningful.
+- Produces: no API change. `CollapsibleFilters`' `showIsoFilter` prop already defaults to `true`, so removing the prop is sufficient.
+
+- [ ] **Step 1: Remove the gating prop at both call sites**
+
+There are two: the desktop sidebar (~line 531) and the mobile sheet (~line 613).
+In each, delete this single line:
+
+```tsx
+              showIsoFilter={!!selectedFilm}
+```
+
+Leave the neighbouring `showDilutionFilter={!!selectedDeveloper}` untouched —
+dilution stays a sub-filter of its developer.
+
+Confirm both are gone:
+
+```bash
+grep -n "showIsoFilter" apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Run the gate**
+
+```bash
+bun run test
+```
+
+Expected: `Tasks: 20 successful, 20 total`. If `selectedFilm` is now an unused
+variable in that file, the lint step will say so — it is still used elsewhere on the
+page, so it should not be, but fix it if flagged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+gt modify -c -a -m "feat(recipes): always show the ISO filter control"
+```
+
+---
+
+### Task 6: Verify end to end and prepare the PR
+
+**Files:** none modified — this task is verification only.
+
+- [ ] **Step 1: Run the full gate**
+
+```bash
+bun run test
+```
+
+Expected: `Tasks: 20 successful, 20 total`.
+
+- [ ] **Step 2: Run React Doctor and confirm no regression**
+
+```bash
+npx --yes react-doctor@latest -y --json --json-out /tmp/rd.json > /dev/null 2>&1
+jq -r '.projects[] | "\(.project.projectName): \(.score.score)"' /tmp/rd.json
+```
+
+Expected: 100 for all four projects. Note that Task 3 removes a chained state
+update, so if anything the score should improve, never drop.
+
+- [ ] **Step 3: Drive the real app**
+
+Start the dev server (`bun run dev`) and check each of these against the URL bar and
+the rendered page:
+
+| URL | Expected |
+| --- | --- |
+| `/development` | ISO control visible with no film selected, showing "All ISOs" |
+| `/development?iso=400` | ISO control shows 400; every result is ISO 400; badge counts it |
+| `/development?film=hp5-plus&iso=400` | both applied; ISO not dropped |
+| `/development?iso=boxspeed` | ignored; `iso` gone from the URL; badge does not count it |
+| `/development?dilution=1%2B9` | ignored; `dilution` gone from the URL |
+| Pick a film while ISO is set | ISO persists; "Box speed (N)" appears in the list |
+| Pick a developer while dilution is set | dilution still clears (unchanged) |
+
+- [ ] **Step 4: Capture before/after screenshots**
+
+This changes rendered output — the ISO control now appears where it did not before —
+so the repo's PR rule requires screenshots. Use the `pr-screenshots` skill, which
+captures the affected route from the merge-base and from HEAD and uploads to
+GitHub's CDN (nothing is committed to the repo).
+
+- [ ] **Step 5: Ask before pushing**
+
+Do not push or open a PR without explicit approval. When approved:
+
+```bash
+gt submit --no-interactive
+```
+
+The PR body should state the behaviour table from the spec, note that ISO options
+are now global even with a film selected (and that this is a deliberate trade-off),
+and attach the before/after screenshots.
+
+---
+
+## Self-review
+
+Checked against `docs/superpowers/specs/2026-07-14-top-level-iso-filter-design.md`:
+
+- Spec §1 (`availableISOs` always populated, contextual box speed, global numeric list) → Task 1.
+- Spec §2 (filtering ungated, box speed no-op without film) → Task 2.
+- Spec §3 (`setSelectedFilm` stops clearing ISO; dilution keeps its clear) → Task 3.
+- Spec §4 (control always visible, both call sites, dilution gating untouched) → Task 5.
+- Spec §5 (orphaned box speed and dilution not applied; URL and badge follow for free) → Task 4.
+- Spec "Testing" → the tests in Tasks 1-4 cover every listed case.
+- Spec "Notes" (screenshots required) → Task 6 Step 4.
+
+No placeholders. Names used consistently across tasks: `availableISOs`,
+`getAvailableISOs`, `setSelectedFilm`, `setIsoFilter`, `isoFilter`,
+`filteredCombinations`, `initialUrlState.isoFilter`, `initialUrlState.dilutionFilter`,
+`showIsoFilter`.

--- a/docs/superpowers/plans/2026-07-14-top-level-iso-filter.md
+++ b/docs/superpowers/plans/2026-07-14-top-level-iso-filter.md
@@ -616,3 +616,29 @@ No placeholders. Names used consistently across tasks: `availableISOs`,
 `getAvailableISOs`, `setSelectedFilm`, `setIsoFilter`, `isoFilter`,
 `filteredCombinations`, `initialUrlState.isoFilter`, `initialUrlState.dilutionFilter`,
 `showIsoFilter`.
+
+---
+
+### Task 7: Clean an orphaned param out of the URL on load
+
+Added during execution. Browser verification showed orphaned params are correctly
+ignored (not applied, not counted, control clearable) but **linger in the URL**.
+
+Root cause: the UI→URL sync effect is guarded by `isInitializedRef` — a **ref**, so
+flipping it does not re-run the effect — and its dependencies are only
+`currentState.*` fields. For a lone orphan nothing enters state, so no dependency
+changes, so the effect never re-runs after initialisation and never rewrites the URL.
+The spec's claim that no URL cleanup was needed holds only when some *other* filter
+also lands and triggers the sync.
+
+**Files:**
+- Modify: `packages/logic/src/hooks/development-recipes/use-recipe-url-state.ts`
+- Test: `packages/logic/src/hooks/development-recipes/__tests__/use-recipe-url-state.test.ts`
+
+**Fix:** promote the initialised flag to state alongside the existing ref, and add it
+to the sync effect's dependencies, so the canonical URL is written once after
+initialisation even when no filter changed. The ref must stay — `updateUrl` reads it
+synchronously inside its debounce timeout.
+
+Acceptance: loading `?iso=boxspeed` (no film) or `?dilution=1%2B9` (no developer)
+leaves the URL with that param removed, and every existing URL-state test stays green.

--- a/docs/superpowers/specs/2026-07-14-top-level-iso-filter-design.md
+++ b/docs/superpowers/specs/2026-07-14-top-level-iso-filter-design.md
@@ -49,15 +49,22 @@ When a film **is** selected, additionally offer `{ label: 'Box speed (N)', value
 'boxspeed' }` immediately after "All ISOs", as it does today. Box speed is the one
 genuinely film-relative option and is worth keeping.
 
-**The numeric list stays global even when a film is selected** — it does *not*
-narrow to that film's ISOs as it does today. This is forced by the decision below
-that ISO survives a film change: the control must always be able to display the
-value it is holding.
+**With a film selected, the numeric options are that film's ISOs — plus the
+currently-selected ISO if it is not among them.**
 
-Accepted trade-off: with a film selected, the list now includes ISOs that yield
-zero results for that film, where today it only ever showed that film's ISOs. This
-is the honest cost of a top-level filter, and the zero-result state is visible and
-clearable rather than silent.
+The union is what makes "ISO survives a film change" safe: the control must always
+be able to display the value it is holding, or a carried-over ISO would become
+invisible and unclearable — the very bug this spec exists to remove. The union
+guarantees that without the cost of listing every catalogue ISO against a film that
+has no recipes at most of them.
+
+(Revised during implementation. The first version of this spec used the full
+catalogue list whenever a film was selected. That also satisfies representability,
+but it fills the list with options that yield zero results — and because
+`availableISOs` is shared with the iOS app, it did so there too, where the ISO
+control is only ever shown *with* a film. The union is strictly better on both
+platforms: on iOS it is a no-op, because that app clears the ISO filter itself on
+every film pick, so there is never a carried-over value to union in.)
 
 ### 2. Filtering — ungated for numeric ISO
 

--- a/docs/superpowers/specs/2026-07-14-top-level-iso-filter-design.md
+++ b/docs/superpowers/specs/2026-07-14-top-level-iso-filter-design.md
@@ -1,0 +1,157 @@
+# Top-level ISO filter (and orphaned sub-filter params)
+
+Date: 2026-07-14
+Status: Approved, not yet implemented
+
+## Problem
+
+A deep-linked `?iso=400` with no film is applied to page state and counted in the
+filter badge, but has **no visible control and does not filter**. The user cannot
+see it, cannot clear it, and cannot tell why the badge says one thing and the
+results say another. State and UI disagree.
+
+This surfaced while verifying the search-param fix (PR #151). It is not caused by
+that PR — it is the existing design showing through:
+
+- `showIsoFilter={!!selectedFilm}` — the ISO control only renders with a film.
+- `availableISOs` returns `[]` with no film.
+- Filtering is guarded: `if (isoFilter && selectedFilm)`.
+- `setSelectedFilm()` deliberately clears the ISO filter.
+
+ISO is a sub-filter of film. Dilution is the identical pattern under developer
+(`showDilutionFilter={!!selectedDeveloper}`, `if (dilutionFilter && selectedDeveloper)`,
+and `setSelectedDeveloper()` clears it), so `?dilution=1+9` with no developer has
+the same defect.
+
+## Decision
+
+**Promote ISO to a top-level filter.** Leave dilution a sub-filter of developer,
+and simply stop applying it when orphaned.
+
+Dilution is not promoted because a dilution value is developer-relative — `1+9`
+means different things for different developers — so a combined global list would
+mix incomparable values and mislead. ISO has no such problem: `shootingIso` is an
+absolute number, and there are only 19 distinct values across all 1,020 recipes
+(25, 50, 64, 80, 100, 125, 200, 250, 320, 400, 500, 600, 800, 1000, 1600, 3200,
+6400, 12500, 25000), which is a perfectly reasonable select list.
+
+## Design
+
+### 1. `availableISOs` — always populated
+
+`packages/logic/src/hooks/development-recipes/use-development-recipes.ts`
+
+Currently returns `[]` when no film is selected. It will instead always return the
+distinct `shootingIso` values across **all** combinations, sorted ascending and
+prefixed with `{ label: 'All ISOs', value: '' }`.
+
+When a film **is** selected, additionally offer `{ label: 'Box speed (N)', value:
+'boxspeed' }` immediately after "All ISOs", as it does today. Box speed is the one
+genuinely film-relative option and is worth keeping.
+
+**The numeric list stays global even when a film is selected** — it does *not*
+narrow to that film's ISOs as it does today. This is forced by the decision below
+that ISO survives a film change: the control must always be able to display the
+value it is holding.
+
+Accepted trade-off: with a film selected, the list now includes ISOs that yield
+zero results for that film, where today it only ever showed that film's ISOs. This
+is the honest cost of a top-level filter, and the zero-result state is visible and
+clearable rather than silent.
+
+### 2. Filtering — ungated for numeric ISO
+
+Same file, in the filter pipeline (currently `if (isoFilter && selectedFilm)`):
+
+```
+if (isoFilter) {
+  if (isoFilter === 'boxspeed') {
+    // Relative to the film's rated speed; a no-op without a film.
+    if (selectedFilm) {
+      keep combos where combo.shootingIso === selectedFilm.isoSpeed
+    }
+  } else {
+    keep combos where String(combo.shootingIso) === isoFilter
+  }
+}
+```
+
+### 3. `setSelectedFilm` stops clearing the ISO filter
+
+Same file. Delete the `setIsoFilter('')` side-effect inside `setSelectedFilm`.
+A top-level filter must not be silently reset by another control — that is what
+makes it top-level, and it is why a deep link carrying both `?film=` and `?iso=`
+currently loses the ISO.
+
+Dilution keeps its equivalent behaviour: `setSelectedDeveloper()` still clears
+`dilutionFilter`, because dilution remains developer-scoped.
+
+### 4. The ISO control is always visible
+
+`apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx`
+
+Drop `showIsoFilter={!!selectedFilm}` at both call sites (desktop sidebar, mobile
+sheet). The `showIsoFilter` prop on `CollapsibleFilters` already defaults to
+`true`, so removing the prop is sufficient. Leave `showDilutionFilter={!!selectedDeveloper}`
+untouched.
+
+### 5. Orphaned sub-filter params are not applied
+
+`packages/logic/src/hooks/development-recipes/use-recipe-url-state.ts`, in the
+`initialUrlState` memo:
+
+- `?iso=boxspeed` with no resolvable film → do not set `isoFilter`.
+- `?dilution=…` with no resolvable developer → do not set `dilutionFilter`.
+
+A numeric `?iso=` needs no guard — after this change it is meaningful on its own.
+
+No separate URL or badge cleanup is required. The existing UI→URL sync effect
+writes `urlParams.iso = currentState.isoFilter || ''` and
+`urlParams.dilution = currentState.dilutionFilter || ''`, so a filter that never
+enters state is automatically absent from both the URL and the badge count.
+
+The resulting invariant: **state = what you can see and clear.**
+
+## Behaviour after the change
+
+| URL | Before | After |
+| --- | --- | --- |
+| `?iso=400` | invisible, inert, counted in badge | ISO control shows 400; results filtered to ISO 400 |
+| `?film=hp5&iso=400` | ISO dropped by `setSelectedFilm` | both applied |
+| `?iso=boxspeed` | invisible, inert, counted | ignored; cleaned from URL |
+| `?film=hp5&iso=boxspeed` | applied | applied (unchanged) |
+| `?dilution=1+9` | invisible, inert, counted | ignored; cleaned from URL |
+| `?developer=xtol&dilution=1+9` | applied | applied (unchanged) |
+| Select a film while ISO is set | ISO silently cleared | ISO persists |
+
+## Testing
+
+`@dorkroom/logic`:
+
+- `availableISOs` returns the full global list with no film selected.
+- `availableISOs` includes `Box speed (N)` only when a film is selected.
+- A numeric ISO filter narrows results with no film selected.
+- `boxspeed` is a no-op with no film selected.
+- Selecting a film preserves an existing ISO filter.
+
+URL state:
+
+- `?iso=boxspeed` with no film does not set `isoFilter`.
+- `?dilution=…` with no developer does not set `dilutionFilter`.
+- `?iso=400` with no film does set `isoFilter`.
+
+Existing development-recipes tests must stay green.
+
+## Out of scope
+
+- Promoting dilution to a top-level filter (see Decision).
+- The `brand=ilford` case-sensitivity mismatch on `/films` (separate pre-existing
+  bug, unrelated to sub-filter scoping).
+
+## Notes
+
+This changes rendered output — the ISO control now appears where it previously did
+not. Per the repo's PR rule, the PR needs before/after screenshots via the
+`pr-screenshots` skill.
+
+Stacks on `advisor/017-url-search-coercion` (PR #151).

--- a/packages/logic/src/hooks/development-recipes/__tests__/use-development-recipes.test.ts
+++ b/packages/logic/src/hooks/development-recipes/__tests__/use-development-recipes.test.ts
@@ -670,4 +670,36 @@ describe('useDevelopmentRecipes', () => {
       expect(result.current.filteredCombinations[0].shootingIso).toBe(400);
     });
   });
+
+  describe('ISO survives a film change', () => {
+    it('keeps the ISO filter when a film is selected', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      act(() => {
+        result.current.setIsoFilter('400');
+      });
+      act(() => {
+        result.current.setSelectedFilm(mockFilms[0]); // hp5-plus
+      });
+
+      // A top-level filter must not be silently reset by another control.
+      expect(result.current.isoFilter).toBe('400');
+      // HP5 has exactly one recipe at ISO 400.
+      expect(result.current.filteredCombinations).toHaveLength(1);
+    });
+
+    it('still clears the dilution filter when a developer is selected', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      act(() => {
+        result.current.setDilutionFilter('1+9');
+      });
+      act(() => {
+        result.current.setSelectedDeveloper(mockDevelopers[0]);
+      });
+
+      // Dilution stays a sub-filter of developer — this behaviour is deliberate.
+      expect(result.current.dilutionFilter).toBe('');
+    });
+  });
 });

--- a/packages/logic/src/hooks/development-recipes/__tests__/use-development-recipes.test.ts
+++ b/packages/logic/src/hooks/development-recipes/__tests__/use-development-recipes.test.ts
@@ -624,4 +624,50 @@ describe('useDevelopmentRecipes', () => {
       ]);
     });
   });
+
+  describe('ISO filtering without a film', () => {
+    it('filters on a numeric ISO with no film selected', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      act(() => {
+        result.current.setIsoFilter('400');
+      });
+
+      // hp5-plus/400 and neopan-400/400 — across two different films.
+      expect(result.current.filteredCombinations).toHaveLength(2);
+      expect(
+        result.current.filteredCombinations.every(
+          (combo) => combo.shootingIso === 400
+        )
+      ).toBe(true);
+    });
+
+    it('treats box speed as a no-op with no film selected', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+      const total = result.current.filteredCombinations.length;
+
+      act(() => {
+        result.current.setIsoFilter('boxspeed');
+      });
+
+      // Box speed means "this film's rated speed" — with no film there is
+      // nothing to compare against, so it must not silently drop everything.
+      expect(result.current.filteredCombinations).toHaveLength(total);
+    });
+
+    it('still resolves box speed against the selected film', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      act(() => {
+        result.current.setSelectedFilm(mockFilms[0]); // hp5-plus, rated 400
+      });
+      act(() => {
+        result.current.setIsoFilter('boxspeed');
+      });
+
+      // Of HP5's two recipes (400 and 1600), only the 400 is at box speed.
+      expect(result.current.filteredCombinations).toHaveLength(1);
+      expect(result.current.filteredCombinations[0].shootingIso).toBe(400);
+    });
+  });
 });

--- a/packages/logic/src/hooks/development-recipes/__tests__/use-development-recipes.test.ts
+++ b/packages/logic/src/hooks/development-recipes/__tests__/use-development-recipes.test.ts
@@ -587,9 +587,9 @@ describe('useDevelopmentRecipes', () => {
     it('unions a carried-over numeric isoFilter the selected film does not offer', () => {
       const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
 
-      // setSelectedFilm still clears isoFilter at this point in the plan, so the
-      // film must be selected first and the carried-over ISO set second, to
-      // simulate an ISO surviving a later film change.
+      // Select the film first, then set an ISO the film doesn't offer, to
+      // simulate an ISO surviving a later film change (setSelectedFilm no
+      // longer clears isoFilter).
       act(() => {
         result.current.setSelectedFilm(mockFilms[0]); // HP5 Plus
       });
@@ -604,6 +604,53 @@ describe('useDevelopmentRecipes', () => {
         { label: '800', value: '800' },
         { label: '1600', value: '1600' },
       ]);
+    });
+
+    it('unions a carried-over numeric isoFilter set before any film is selected, and keeps it selected once a non-offering film is chosen', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      // The real user journey the union exists for: set an ISO with no film
+      // selected yet, then pick a film that doesn't offer that ISO. The ISO
+      // must remain visible in the options and remain the selected value.
+      act(() => {
+        result.current.setIsoFilter('160'); // Not in the catalogue at all
+      });
+
+      expect(result.current.getAvailableISOs()).toEqual([
+        { label: 'All ISOs', value: '' },
+        { label: '100', value: '100' },
+        { label: '160', value: '160' },
+        { label: '200', value: '200' },
+        { label: '400', value: '400' },
+        { label: '800', value: '800' },
+        { label: '1600', value: '1600' },
+      ]);
+
+      act(() => {
+        result.current.setSelectedFilm(mockFilms[0]); // HP5 Plus, no 160 combination
+      });
+
+      expect(result.current.isoFilter).toBe('160');
+      expect(result.current.getAvailableISOs()).toEqual([
+        { label: 'All ISOs', value: '' },
+        { label: 'Box speed (400)', value: 'boxspeed' },
+        { label: '160', value: '160' },
+        { label: '400', value: '400' },
+        { label: '1600', value: '1600' },
+      ]);
+    });
+
+    it('unions a carried-over numeric isoFilter with no film selected, even when not in the catalogue', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      act(() => {
+        result.current.setIsoFilter('160'); // Valid ISO, but no fixture recipe is shot at it
+      });
+
+      expect(result.current.getAvailableISOs()).toContainEqual({
+        label: '160',
+        value: '160',
+      });
     });
 
     it('does not union isoFilter="boxspeed" into the numeric options', () => {

--- a/packages/logic/src/hooks/development-recipes/__tests__/use-development-recipes.test.ts
+++ b/packages/logic/src/hooks/development-recipes/__tests__/use-development-recipes.test.ts
@@ -567,22 +567,59 @@ describe('useDevelopmentRecipes', () => {
       ]);
     });
 
-    it('adds box speed once a film is selected, keeping the full ISO list', () => {
+    it('narrows to the selected film’s own ISOs, plus box speed', () => {
       const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
 
       act(() => {
-        result.current.setSelectedFilm(mockFilms[0]);
+        result.current.setSelectedFilm(mockFilms[0]); // HP5 Plus
       });
 
-      // The numeric options stay global — they do not narrow to HP5's ISOs —
-      // so an ISO chosen before the film change is still representable.
+      // HP5 Plus's own combinations are c1 (400) and c4 (1600); other films'
+      // ISOs (200, 800, 100) are not offered once a film narrows the list.
       expect(result.current.getAvailableISOs()).toEqual([
         { label: 'All ISOs', value: '' },
         { label: 'Box speed (400)', value: 'boxspeed' },
-        { label: '100', value: '100' },
-        { label: '200', value: '200' },
+        { label: '400', value: '400' },
+        { label: '1600', value: '1600' },
+      ]);
+    });
+
+    it('unions a carried-over numeric isoFilter the selected film does not offer', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      // setSelectedFilm still clears isoFilter at this point in the plan, so the
+      // film must be selected first and the carried-over ISO set second, to
+      // simulate an ISO surviving a later film change.
+      act(() => {
+        result.current.setSelectedFilm(mockFilms[0]); // HP5 Plus
+      });
+      act(() => {
+        result.current.setIsoFilter('800'); // HP5 has no 800 combination
+      });
+
+      expect(result.current.getAvailableISOs()).toEqual([
+        { label: 'All ISOs', value: '' },
+        { label: 'Box speed (400)', value: 'boxspeed' },
         { label: '400', value: '400' },
         { label: '800', value: '800' },
+        { label: '1600', value: '1600' },
+      ]);
+    });
+
+    it('does not union isoFilter="boxspeed" into the numeric options', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      act(() => {
+        result.current.setSelectedFilm(mockFilms[0]); // HP5 Plus
+      });
+      act(() => {
+        result.current.setIsoFilter('boxspeed');
+      });
+
+      expect(result.current.getAvailableISOs()).toEqual([
+        { label: 'All ISOs', value: '' },
+        { label: 'Box speed (400)', value: 'boxspeed' },
+        { label: '400', value: '400' },
         { label: '1600', value: '1600' },
       ]);
     });

--- a/packages/logic/src/hooks/development-recipes/__tests__/use-development-recipes.test.ts
+++ b/packages/logic/src/hooks/development-recipes/__tests__/use-development-recipes.test.ts
@@ -552,4 +552,39 @@ describe('useDevelopmentRecipes', () => {
       ]);
     });
   });
+
+  describe('getAvailableISOs', () => {
+    it('offers every catalogue ISO when no film is selected', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      expect(result.current.getAvailableISOs()).toEqual([
+        { label: 'All ISOs', value: '' },
+        { label: '100', value: '100' },
+        { label: '200', value: '200' },
+        { label: '400', value: '400' },
+        { label: '800', value: '800' },
+        { label: '1600', value: '1600' },
+      ]);
+    });
+
+    it('adds box speed once a film is selected, keeping the full ISO list', () => {
+      const { result } = renderHook(() => useDevelopmentRecipes(), { wrapper });
+
+      act(() => {
+        result.current.setSelectedFilm(mockFilms[0]);
+      });
+
+      // The numeric options stay global — they do not narrow to HP5's ISOs —
+      // so an ISO chosen before the film change is still representable.
+      expect(result.current.getAvailableISOs()).toEqual([
+        { label: 'All ISOs', value: '' },
+        { label: 'Box speed (400)', value: 'boxspeed' },
+        { label: '100', value: '100' },
+        { label: '200', value: '200' },
+        { label: '400', value: '400' },
+        { label: '800', value: '800' },
+        { label: '1600', value: '1600' },
+      ]);
+    });
+  });
 });

--- a/packages/logic/src/hooks/development-recipes/__tests__/use-recipe-url-state.test.ts
+++ b/packages/logic/src/hooks/development-recipes/__tests__/use-recipe-url-state.test.ts
@@ -740,5 +740,72 @@ describe('useRecipeUrlState', () => {
 
       expect(result.current.initialUrlState.dilutionFilter).toBeUndefined();
     });
+
+    it('strips a lone orphaned iso=boxspeed param from the URL once film/developer data arrives', () => {
+      // Films/developers load asynchronously in the real app: the hook first
+      // mounts with empty lists (initialUrlState stays {}, so the hook never
+      // initializes), then re-renders once the lists arrive. currentState
+      // itself never changes across this transition, because the orphan iso
+      // param never gets applied to it — so a fix that only re-syncs the URL
+      // when currentState.* changes would miss this entirely.
+      vi.useFakeTimers();
+      mockLocation.search = '?iso=boxspeed';
+
+      const { rerender } = renderHook(
+        ({ films, developers }) =>
+          useRecipeUrlState(films, developers, mockCurrentState),
+        {
+          initialProps: {
+            films: [] as typeof mockFilms,
+            developers: [] as typeof mockDevelopers,
+          },
+        }
+      );
+
+      rerender({ films: mockFilms, developers: mockDevelopers });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      // The orphan param is never applied to state, so nothing else would ever
+      // trigger a URL rewrite — the canonical URL must still be written once
+      // after initialization so the stale param doesn't linger.
+      expect(mockReplaceState).toHaveBeenCalled();
+      const lastCall =
+        mockReplaceState.mock.calls[mockReplaceState.mock.calls.length - 1];
+      expect(lastCall[2]).not.toContain('iso');
+
+      vi.useRealTimers();
+    });
+
+    it('strips a lone orphaned dilution param from the URL once film/developer data arrives', () => {
+      vi.useFakeTimers();
+      mockLocation.search = '?dilution=1%2B9';
+
+      const { rerender } = renderHook(
+        ({ films, developers }) =>
+          useRecipeUrlState(films, developers, mockCurrentState),
+        {
+          initialProps: {
+            films: [] as typeof mockFilms,
+            developers: [] as typeof mockDevelopers,
+          },
+        }
+      );
+
+      rerender({ films: mockFilms, developers: mockDevelopers });
+
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(mockReplaceState).toHaveBeenCalled();
+      const lastCall =
+        mockReplaceState.mock.calls[mockReplaceState.mock.calls.length - 1];
+      expect(lastCall[2]).not.toContain('dilution');
+
+      vi.useRealTimers();
+    });
   });
 });

--- a/packages/logic/src/hooks/development-recipes/__tests__/use-recipe-url-state.test.ts
+++ b/packages/logic/src/hooks/development-recipes/__tests__/use-recipe-url-state.test.ts
@@ -270,7 +270,10 @@ describe('useRecipeUrlState', () => {
     });
 
     it('should handle valid dilution format: stock', () => {
-      mockLocation.search = '?dilution=stock';
+      // A developer is included because dilution is developer-relative and is
+      // ignored without one (see 'orphaned sub-filter params' below) — this
+      // test is about the format regex accepting "stock", not that guard.
+      mockLocation.search = '?developer=dd-x&dilution=stock';
 
       const { result } = renderHook(() =>
         useRecipeUrlState(mockFilms, mockDevelopers, mockCurrentState)
@@ -280,7 +283,7 @@ describe('useRecipeUrlState', () => {
     });
 
     it('should handle valid dilution format: 1:1', () => {
-      mockLocation.search = '?dilution=1:1';
+      mockLocation.search = '?developer=dd-x&dilution=1:1';
 
       const { result } = renderHook(() =>
         useRecipeUrlState(mockFilms, mockDevelopers, mockCurrentState)
@@ -291,7 +294,7 @@ describe('useRecipeUrlState', () => {
 
     it('should handle valid dilution format: 1+1', () => {
       // URL encode + as %2B since + is decoded as space in URLs
-      mockLocation.search = '?dilution=1%2B1';
+      mockLocation.search = '?developer=dd-x&dilution=1%2B1';
 
       const { result } = renderHook(() =>
         useRecipeUrlState(mockFilms, mockDevelopers, mockCurrentState)
@@ -301,7 +304,7 @@ describe('useRecipeUrlState', () => {
     });
 
     it('should handle valid dilution format: 100', () => {
-      mockLocation.search = '?dilution=100';
+      mockLocation.search = '?developer=dd-x&dilution=100';
 
       const { result } = renderHook(() =>
         useRecipeUrlState(mockFilms, mockDevelopers, mockCurrentState)
@@ -702,6 +705,40 @@ describe('useRecipeUrlState', () => {
       expect(lastCall[2]).toContain('iso=800');
 
       vi.useRealTimers();
+    });
+  });
+
+  describe('orphaned sub-filter params', () => {
+    it('ignores box speed with no film in the URL', () => {
+      mockLocation.search = '?iso=boxspeed';
+
+      const { result } = renderHook(() =>
+        useRecipeUrlState(mockFilms, mockDevelopers, mockCurrentState)
+      );
+
+      // Box speed is relative to a film; on its own it cannot mean anything, so
+      // it must not land in state where it would be invisible and inert.
+      expect(result.current.initialUrlState.isoFilter).toBeUndefined();
+    });
+
+    it('keeps a numeric ISO with no film in the URL', () => {
+      mockLocation.search = '?iso=400';
+
+      const { result } = renderHook(() =>
+        useRecipeUrlState(mockFilms, mockDevelopers, mockCurrentState)
+      );
+
+      expect(result.current.initialUrlState.isoFilter).toBe('400');
+    });
+
+    it('ignores a dilution with no developer in the URL', () => {
+      mockLocation.search = '?dilution=1%2B9';
+
+      const { result } = renderHook(() =>
+        useRecipeUrlState(mockFilms, mockDevelopers, mockCurrentState)
+      );
+
+      expect(result.current.initialUrlState.dilutionFilter).toBeUndefined();
     });
   });
 });

--- a/packages/logic/src/hooks/development-recipes/__tests__/use-recipe-url-state.test.ts
+++ b/packages/logic/src/hooks/development-recipes/__tests__/use-recipe-url-state.test.ts
@@ -731,6 +731,19 @@ describe('useRecipeUrlState', () => {
       expect(result.current.initialUrlState.isoFilter).toBe('400');
     });
 
+    it('canonicalizes a numeric-prefixed ISO to the parsed integer instead of storing the raw string', () => {
+      mockLocation.search = '?iso=400abc';
+
+      const { result } = renderHook(() =>
+        useRecipeUrlState(mockFilms, mockDevelopers, mockCurrentState)
+      );
+
+      // parseInt('400abc', 10) === 400, which is in range, so the value must
+      // be accepted — but it must be normalised to '400', not stored as the
+      // raw 'iso=400abc' string, which the equality filter would never match.
+      expect(result.current.initialUrlState.isoFilter).toBe('400');
+    });
+
     it('ignores a dilution with no developer in the URL', () => {
       mockLocation.search = '?dilution=1%2B9';
 

--- a/packages/logic/src/hooks/development-recipes/use-development-recipes.ts
+++ b/packages/logic/src/hooks/development-recipes/use-development-recipes.ts
@@ -568,12 +568,16 @@ export const useDevelopmentRecipes = (
       });
     }
 
-    // Filter by ISO
-    if (isoFilter && selectedFilm) {
+    // Filter by ISO. A numeric ISO is absolute, so it filters on its own. Box
+    // speed is relative to the selected film's rated speed, so with no film there
+    // is nothing to compare against and it is a no-op rather than a wipeout.
+    if (isoFilter) {
       if (isoFilter === 'boxspeed') {
-        combinations = combinations.filter(
-          (combo) => combo.shootingIso === selectedFilm.isoSpeed
-        );
+        if (selectedFilm) {
+          combinations = combinations.filter(
+            (combo) => combo.shootingIso === selectedFilm.isoSpeed
+          );
+        }
       } else {
         combinations = combinations.filter(
           (combo) => combo.shootingIso.toString() === isoFilter

--- a/packages/logic/src/hooks/development-recipes/use-development-recipes.ts
+++ b/packages/logic/src/hooks/development-recipes/use-development-recipes.ts
@@ -404,14 +404,34 @@ export const useDevelopmentRecipes = (
       });
     }
 
-    // ISO is a top-level filter, so the numeric options are every shooting ISO in
-    // the catalogue rather than just the selected film's. That keeps a chosen ISO
-    // representable when the film changes — which it must be, since selecting a
-    // film no longer clears it.
     const isoSet = new Set<number>();
-    allCombinations.forEach((combo) => {
-      isoSet.add(combo.shootingIso);
-    });
+
+    if (selectedFilm) {
+      // Narrow to the selected film's own shooting ISOs (alias-aware, matching
+      // getCombinationsForFilm's slug resolution).
+      const slugSet = new Set(getAllSlugsForFilm(selectedFilm));
+      allCombinations.forEach((combo) => {
+        if (slugSet.has(combo.filmStockId) || slugSet.has(combo.filmSlug)) {
+          isoSet.add(combo.shootingIso);
+        }
+      });
+
+      // Union in a carried-over numeric ISO filter so it stays visible and
+      // clearable even if the newly selected film doesn't offer it — otherwise
+      // it becomes an invisible, unclearable filter once selecting a film no
+      // longer resets it.
+      if (isoFilter && isoFilter !== 'boxspeed') {
+        const carriedIso = Number(isoFilter);
+        if (!Number.isNaN(carriedIso)) {
+          isoSet.add(carriedIso);
+        }
+      }
+    } else {
+      // No film selected — offer every shooting ISO in the catalogue.
+      allCombinations.forEach((combo) => {
+        isoSet.add(combo.shootingIso);
+      });
+    }
 
     Array.from(isoSet)
       .sort((a, b) => a - b)
@@ -420,7 +440,7 @@ export const useDevelopmentRecipes = (
       });
 
     return isos;
-  }, [selectedFilm, allCombinations]);
+  }, [selectedFilm, allCombinations, isoFilter]);
 
   const getAvailableISOs = useCallback(() => availableISOs, [availableISOs]);
 

--- a/packages/logic/src/hooks/development-recipes/use-development-recipes.ts
+++ b/packages/logic/src/hooks/development-recipes/use-development-recipes.ts
@@ -393,23 +393,23 @@ export const useDevelopmentRecipes = (
     label: string;
     value: string;
   }[] => {
-    if (!selectedFilm) return [];
+    const isos = [{ label: 'All ISOs', value: '' }];
 
-    const isos = [
-      { label: 'All ISOs', value: '' },
-      {
+    // Box speed is defined relative to the selected film's rated speed, so it is
+    // only offered when there is a film to be relative to.
+    if (selectedFilm) {
+      isos.push({
         label: `Box speed (${selectedFilm.isoSpeed})`,
         value: 'boxspeed',
-      },
-    ];
+      });
+    }
+
+    // ISO is a top-level filter, so the numeric options are every shooting ISO in
+    // the catalogue rather than just the selected film's. That keeps a chosen ISO
+    // representable when the film changes — which it must be, since selecting a
+    // film no longer clears it.
     const isoSet = new Set<number>();
-
-    const slugSet = new Set(getAllSlugsForFilm(selectedFilm));
-    const combinations = allCombinations.filter(
-      (combo) => slugSet.has(combo.filmStockId) || slugSet.has(combo.filmSlug)
-    );
-
-    combinations.forEach((combo) => {
+    allCombinations.forEach((combo) => {
       isoSet.add(combo.shootingIso);
     });
 

--- a/packages/logic/src/hooks/development-recipes/use-development-recipes.ts
+++ b/packages/logic/src/hooks/development-recipes/use-development-recipes.ts
@@ -396,19 +396,16 @@ export const useDevelopmentRecipes = (
     value: string;
   }[] => {
     const isos = [{ label: 'All ISOs', value: '' }];
+    const isoSet = new Set<number>();
 
-    // Box speed is defined relative to the selected film's rated speed, so it is
-    // only offered when there is a film to be relative to.
     if (selectedFilm) {
+      // Box speed is defined relative to the selected film's rated speed, so
+      // it is only offered when there is a film to be relative to.
       isos.push({
         label: `Box speed (${selectedFilm.isoSpeed})`,
         value: 'boxspeed',
       });
-    }
 
-    const isoSet = new Set<number>();
-
-    if (selectedFilm) {
       // Narrow to the selected film's own shooting ISOs (alias-aware, matching
       // getCombinationsForFilm's slug resolution).
       const slugSet = new Set(getAllSlugsForFilm(selectedFilm));
@@ -417,22 +414,24 @@ export const useDevelopmentRecipes = (
           isoSet.add(combo.shootingIso);
         }
       });
-
-      // Union in a carried-over numeric ISO filter so it stays visible and
-      // clearable even if the newly selected film doesn't offer it — otherwise
-      // it becomes an invisible, unclearable filter once selecting a film no
-      // longer resets it.
-      if (isoFilter && isoFilter !== 'boxspeed') {
-        const carriedIso = Number(isoFilter);
-        if (!Number.isNaN(carriedIso)) {
-          isoSet.add(carriedIso);
-        }
-      }
     } else {
       // No film selected — offer every shooting ISO in the catalogue.
       allCombinations.forEach((combo) => {
         isoSet.add(combo.shootingIso);
       });
+    }
+
+    // Union in a carried-over numeric ISO filter so it stays visible and
+    // clearable even if it isn't among the options above — whether that's
+    // because the newly selected film doesn't offer it, or because it was
+    // set before any film was selected and isn't a catalogue ISO at all.
+    // Without this, the <select> renders blank while the badge still counts
+    // an active filter, with no way to see or clear it.
+    if (isoFilter && isoFilter !== 'boxspeed') {
+      const carriedIso = Number(isoFilter);
+      if (!Number.isNaN(carriedIso)) {
+        isoSet.add(carriedIso);
+      }
     }
 
     Array.from(isoSet)

--- a/packages/logic/src/hooks/development-recipes/use-development-recipes.ts
+++ b/packages/logic/src/hooks/development-recipes/use-development-recipes.ts
@@ -241,9 +241,11 @@ export const useDevelopmentRecipes = (
       (initialUrlState?.selectedDeveloper as Developer | undefined) || null
     );
 
+  // ISO is a top-level filter and deliberately survives a film change, so this no
+  // longer clears it. (setSelectedDeveloper still clears the dilution filter —
+  // dilution remains scoped to its developer.)
   const setSelectedFilm = useCallback((film: Film | null) => {
     setSelectedFilmState(film);
-    setIsoFilter('');
   }, []);
 
   const setSelectedDeveloper = useCallback((developer: Developer | null) => {

--- a/packages/logic/src/hooks/development-recipes/use-recipe-url-state.ts
+++ b/packages/logic/src/hooks/development-recipes/use-recipe-url-state.ts
@@ -382,12 +382,19 @@ export const useRecipeUrlState = (
       }
     }
 
-    if (validation.sanitized.dilution) {
+    // A dilution is defined relative to a developer — "1+9" means different things
+    // for different developers — so it is meaningless without one. Applying it
+    // anyway would leave a filter in state that has no control and does nothing.
+    if (validation.sanitized.dilution && state.selectedDeveloper) {
       state.dilutionFilter = validation.sanitized.dilution;
     }
 
+    // A numeric ISO is absolute and stands on its own. Box speed is relative to
+    // the selected film, so it is only meaningful alongside one.
     if (validation.sanitized.iso) {
-      state.isoFilter = validation.sanitized.iso;
+      if (validation.sanitized.iso !== 'boxspeed' || state.selectedFilm) {
+        state.isoFilter = validation.sanitized.iso;
+      }
     }
 
     if (validation.sanitized.developerType) {

--- a/packages/logic/src/hooks/development-recipes/use-recipe-url-state.ts
+++ b/packages/logic/src/hooks/development-recipes/use-recipe-url-state.ts
@@ -315,6 +315,14 @@ export const useRecipeUrlState = (
     getServerUrlSnapshot
   );
   const isInitializedRef = useRef(false);
+  // React state mirror of isInitializedRef. The ref alone can't retrigger the
+  // URL-sync effect below — flipping a ref doesn't change dependencies — so a
+  // lone orphaned sub-filter param (which never touches currentState) would
+  // leave a stale param in the URL forever. This flag goes in that effect's
+  // dependency array so it fires once after initialization even when nothing
+  // in currentState changed. Setting it to `true` when it's already `true` is
+  // a no-op React bails out of (Object.is comparison), so this cannot loop.
+  const [isInitialized, setIsInitialized] = useState(false);
   const updateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const paramsRef = useRef(params);
 
@@ -446,6 +454,7 @@ export const useRecipeUrlState = (
   useEffect(() => {
     if (initialUrlState.fromUrl) {
       isInitializedRef.current = true;
+      setIsInitialized(true);
     }
   }, [initialUrlState]);
 
@@ -641,6 +650,10 @@ export const useRecipeUrlState = (
     currentState.customRecipeFilter,
     currentState.favoritesOnly,
     currentState.selectedRecipeId,
+    // Ensures the canonical URL is written once right after initialization,
+    // even when a lone orphaned sub-filter param means none of the
+    // currentState fields above ever change.
+    isInitialized,
     updateUrl,
   ]);
 

--- a/packages/logic/src/hooks/development-recipes/use-recipe-url-state.ts
+++ b/packages/logic/src/hooks/development-recipes/use-recipe-url-state.ts
@@ -202,7 +202,11 @@ export const validateUrlParams = (
       ) {
         errors.push('Invalid ISO value');
       } else {
-        sanitized.iso = params.iso;
+        // Store the canonicalised integer, not the raw input — otherwise a
+        // value like '400abc' passes the range check (parseInt is lenient)
+        // but never matches shootingIso.toString() downstream, silently
+        // emptying the results with no visible or clearable cause.
+        sanitized.iso = String(isoNum);
       }
     }
   }


### PR DESCRIPTION
Makes **ISO a genuine top-level filter** on the development-recipes page, and stops applying sub-filter URL params that arrive without their parent.

Found while verifying #151: a deep-linked `?iso=400` with no film was applied to state and counted in the filter badge — but had **no visible control and did not filter**. You couldn't see it, couldn't clear it, and the badge contradicted the results.

The cause was deliberate design, not an oversight: ISO was a *sub-filter of film* (`showIsoFilter={!!selectedFilm}`, `availableISOs` returned `[]` with no film, filtering was guarded by `if (isoFilter && selectedFilm)`, and `setSelectedFilm` cleared it). Dilution is the same pattern under developer.

## What changed

1. **`availableISOs` is always populated.** No film → every catalogue ISO. Film → that film's ISOs, **union any carried-over ISO** so a value that survives a film change stays visible and clearable. `Box speed (N)` is offered only with a film — it's the one genuinely film-relative option.
2. **A numeric ISO filters on its own.** `boxspeed` remains a no-op without a film (it means "equals *this film's* rated speed"), rather than wiping the list.
3. **`setSelectedFilm` no longer clears the ISO.** A top-level filter must not be silently reset by another control. `setSelectedDeveloper` **still** clears dilution — that asymmetry is intentional; dilution stays developer-scoped.
4. **Orphans are not applied.** `?iso=boxspeed` with no film, `?dilution=…` with no developer.
5. **The ISO control is always visible.**
6. **Orphaned params are cleaned out of the URL on load.** The UI→URL sync effect was keyed on a *ref*, so it never re-ran when nothing entered state — an ignored param lingered in the URL. It now rewrites once after init.

## Screenshots

### `/development?iso=1600` — desktop, dark

The clearest view of the bug. Before: badge says **1 filter**, there is **no ISO control**, and the results are **unfiltered** (1,020 pairings, ISOs 250/200/400). After: the ISO control shows 1600 and the list is genuinely filtered to 78 ISO-1600 recipes across multiple films.

| Before | After |
|---|---|
| <img width="500" alt="iso-deeplink-no-film before" src="https://github.com/user-attachments/assets/afe6a758-1438-4796-b9dc-d93d2ced20c5" /> | <img width="500" alt="iso-deeplink-no-film after" src="https://github.com/user-attachments/assets/042c14b4-df94-47ea-ae9b-8d96993efc8f" /> |

### `/development` — desktop, dark

The ISO control now exists with no film selected.

| Before | After |
|---|---|
| <img width="500" alt="iso-control-no-film before" src="https://github.com/user-attachments/assets/4baaf2d2-d7e8-44da-9ed6-4fad19e22e6e" /> | <img width="500" alt="iso-control-no-film after" src="https://github.com/user-attachments/assets/c1404dd5-1c0f-41a6-9cd6-9a86bab1b02b" /> |

### `/development?film=rollei-retro-400s&iso=1600` — desktop, dark

Before, `setSelectedFilm` wiped the ISO, so only the film applied. After, both survive.

| Before | After |
|---|---|
| <img width="500" alt="iso-survives-film before" src="https://github.com/user-attachments/assets/f6e94138-75c3-46f6-be1c-c00145ad2e8e" /> | <img width="500" alt="iso-survives-film after" src="https://github.com/user-attachments/assets/dc576f12-d72e-4059-bf73-44b7e4f6e470" /> |

## Two bugs this branch introduced, and fixed

The final review caught these — both were the *same class of bug this PR exists to kill*, and both were made worse by ungating the filter (previously they were merely inert; afterwards they silently emptied the results list):

- **`?iso=160`** — Portra 160 is a real speed with no recipes in the catalogue, so it was a valid-but-absent option. The union only ran in the film-selected branch, so with no film the control rendered **blank**, the badge said 1, and results went to **zero** with nothing explaining why. The union now runs in both branches.
- **`?iso=400abc`** — `validateUrlParams` range-checked `parseInt` but stored the **raw** string, so `'400abc'` matched nothing. It now stores the canonical integer (`?iso=400abc` → `?iso=400`). Note it *canonicalises* rather than rejects: rejecting pushes to `errors`, which makes the whole memo return `{}` and would drop **every other param** in the deep link.

Both verified in a browser, not just in tests.

## iOS

`@dorkroom/logic` is shared with the iOS app, which is the real blast radius here. It is **unaffected**: `recipe-list-screen.tsx` clears the ISO itself at every film pick/clear, and only shows its ISO control with a film — so ISO can never be orphaned there, and the union is a no-op.

This is also why the ISO option list is the film-scoped **union** rather than the full catalogue: the first design listed every catalogue ISO whenever a film was selected, which would have filled the iOS picker with dead options.

## Verification

- `bun run test` — 20/20 (lint, test, build, typecheck)
- React Doctor — **100/100** on all four projects, 0 diagnostics
- Browser-verified: ISO visible with no film; `?iso=1600` filters across films; ISO survives a film change; `?iso=boxspeed` / `?dilution=1+9` ignored **and** stripped from the URL; legitimate params (`?iso=1600&favorites=true`) preserved.

Spec: `docs/superpowers/specs/2026-07-14-top-level-iso-filter-design.md`
Plan: `docs/superpowers/plans/2026-07-14-top-level-iso-filter.md`

⚠️ No CHANGELOG entry or CalVer bump — consistent with #150/#151, on the assumption those happen when the stack lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
