### PR TITLE
fix(react): split providers from context modules for React Doctor 100/100

### DIFF
--- a/apps/dorkroom/src/app/pages/development-recipes/context/index.ts
+++ b/apps/dorkroom/src/app/pages/development-recipes/context/index.ts
@@ -4,17 +4,17 @@ export type {
   RecipeDataState,
   RecipeModalsActions,
   RecipeModalsState,
-  RecipeProviderProps,
   RecipeUIState,
 } from './recipe-context';
 export {
   RecipeActionsContext,
   RecipeDataContext,
   RecipeModalsContext,
-  RecipeProvider,
   RecipeUIContext,
   useRecipeActionsContext,
   useRecipeDataContext,
   useRecipeModalsContext,
   useRecipeUIContext,
 } from './recipe-context';
+export type { RecipeProviderProps } from './recipe-provider';
+export { RecipeProvider } from './recipe-provider';

--- a/apps/dorkroom/src/app/pages/development-recipes/context/recipe-context.tsx
+++ b/apps/dorkroom/src/app/pages/development-recipes/context/recipe-context.tsx
@@ -5,7 +5,7 @@ import type {
   FilmdevMappingResult,
 } from '@dorkroom/logic';
 import type { DevelopmentCombinationView } from '@dorkroom/ui';
-import { createContext, type ReactNode, use } from 'react';
+import { createContext, use } from 'react';
 
 /**
  * Modal state for the development recipes page.
@@ -135,7 +135,6 @@ export interface RecipeContextValue {
  * Context for recipe modals state and actions.
  * Separated to allow independent updates.
  */
-// eslint-disable-next-line react-doctor/only-export-components -- dedicated context module: contexts/hooks/provider co-located by design, not a component file with stray exports
 export const RecipeModalsContext = createContext<
   (RecipeModalsState & RecipeModalsActions) | null
 >(null);
@@ -144,21 +143,18 @@ export const RecipeModalsContext = createContext<
  * Context for recipe data.
  * Separated to allow independent updates.
  */
-// eslint-disable-next-line react-doctor/only-export-components -- dedicated context module: contexts/hooks/provider co-located by design, not a component file with stray exports
 export const RecipeDataContext = createContext<RecipeDataState | null>(null);
 
 /**
  * Context for recipe actions.
  * Actions are stable references that don't change often.
  */
-// eslint-disable-next-line react-doctor/only-export-components -- dedicated context module: contexts/hooks/provider co-located by design, not a component file with stray exports
 export const RecipeActionsContext = createContext<RecipeActions | null>(null);
 
 /**
  * Context for UI state.
  * Contains mobile detection, animations, etc.
  */
-// eslint-disable-next-line react-doctor/only-export-components -- dedicated context module: contexts/hooks/provider co-located by design, not a component file with stray exports
 export const RecipeUIContext = createContext<RecipeUIState | null>(null);
 
 /**
@@ -213,47 +209,4 @@ export function useRecipeUIContext() {
     throw new Error('useRecipeUIContext must be used within a RecipeProvider');
   }
   return context;
-}
-
-/**
- * Props for the RecipeProvider component.
- */
-export interface RecipeProviderProps {
-  children: ReactNode;
-  modals: RecipeModalsState & RecipeModalsActions;
-  data: RecipeDataState;
-  actions: RecipeActions;
-  ui: RecipeUIState;
-}
-
-/**
- * Provider component that makes recipe context available to children.
- *
- * This allows incremental adoption: wrap parts of the component tree
- * with this provider to enable context-based access to recipe state.
- *
- * @example
- * ```tsx
- * <RecipeProvider modals={modals} data={data} actions={actions} ui={ui}>
- *   <RecipeModals />
- *   <RecipeResultsSection />
- * </RecipeProvider>
- * ```
- */
-export function RecipeProvider({
-  children,
-  modals,
-  data,
-  actions,
-  ui,
-}: RecipeProviderProps) {
-  return (
-    <RecipeModalsContext value={modals}>
-      <RecipeDataContext value={data}>
-        <RecipeActionsContext value={actions}>
-          <RecipeUIContext value={ui}>{children}</RecipeUIContext>
-        </RecipeActionsContext>
-      </RecipeDataContext>
-    </RecipeModalsContext>
-  );
 }

--- a/apps/dorkroom/src/app/pages/development-recipes/context/recipe-provider.tsx
+++ b/apps/dorkroom/src/app/pages/development-recipes/context/recipe-provider.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from 'react';
+import {
+  type RecipeActions,
+  RecipeActionsContext,
+  RecipeDataContext,
+  type RecipeDataState,
+  type RecipeModalsActions,
+  RecipeModalsContext,
+  type RecipeModalsState,
+  RecipeUIContext,
+  type RecipeUIState,
+} from './recipe-context';
+
+/**
+ * Props for the RecipeProvider component.
+ */
+export interface RecipeProviderProps {
+  children: ReactNode;
+  modals: RecipeModalsState & RecipeModalsActions;
+  data: RecipeDataState;
+  actions: RecipeActions;
+  ui: RecipeUIState;
+}
+
+/**
+ * Provider component that makes recipe context available to children.
+ *
+ * This allows incremental adoption: wrap parts of the component tree
+ * with this provider to enable context-based access to recipe state.
+ *
+ * @example
+ * ```tsx
+ * <RecipeProvider modals={modals} data={data} actions={actions} ui={ui}>
+ *   <RecipeModals />
+ *   <RecipeResultsSection />
+ * </RecipeProvider>
+ * ```
+ */
+export function RecipeProvider({
+  children,
+  modals,
+  data,
+  actions,
+  ui,
+}: RecipeProviderProps) {
+  return (
+    <RecipeModalsContext value={modals}>
+      <RecipeDataContext value={data}>
+        <RecipeActionsContext value={actions}>
+          <RecipeUIContext value={ui}>{children}</RecipeUIContext>
+        </RecipeActionsContext>
+      </RecipeDataContext>
+    </RecipeModalsContext>
+  );
+}

--- a/apps/mobile/src/components/meter/scrub-overlay.tsx
+++ b/apps/mobile/src/components/meter/scrub-overlay.tsx
@@ -1,18 +1,9 @@
-import { useState } from 'react';
 // eslint-disable-next-line react-doctor/rn-prefer-reanimated -- JS-thread Animated is intentional: the drag is a JS-thread PanResponder (no gesture-handler) and reanimated's worklet babel plugin isn't wired up; the ruler commits on release so there are no React re-renders during the drag, keeping the glide smooth.
 import { Animated, Text, View } from 'react-native';
 import { readoutText as MONO } from '@/theme/tokens';
 import { BlurPanel } from './blur-panel';
 import type { ScrubField } from './meter-readout';
 import { SCRUB_COL_WIDTH, SCRUB_GAP } from './scrub-math';
-
-/** Creates the stable drag-offset value shared between the active scrubber
- * (writer) and the ruler (reader). Lives here so the screen needn't import
- * Animated directly. Carries the live combined drag offset in px (right/up +). */
-export function useDragOffset() {
-  const [value] = useState(() => new Animated.Value(0));
-  return value;
-}
 
 const SHADOW = {
   textShadowColor: 'rgba(0,0,0,0.85)',

--- a/apps/mobile/src/components/meter/use-drag-offset.ts
+++ b/apps/mobile/src/components/meter/use-drag-offset.ts
@@ -1,0 +1,11 @@
+import { useState } from 'react';
+// eslint-disable-next-line react-doctor/rn-prefer-reanimated -- JS-thread Animated is intentional: the drag is a JS-thread PanResponder (no gesture-handler) and reanimated's worklet babel plugin isn't wired up; the ruler commits on release so there are no React re-renders during the drag, keeping the glide smooth.
+import { Animated } from 'react-native';
+
+/** Creates the stable drag-offset value shared between the active scrubber
+ * (writer) and the ruler (reader). Lives here so the screen needn't import
+ * Animated directly. Carries the live combined drag offset in px (right/up +). */
+export function useDragOffset() {
+  const [value] = useState(() => new Animated.Value(0));
+  return value;
+}

--- a/apps/mobile/src/screens/meter-screen.tsx
+++ b/apps/mobile/src/screens/meter-screen.tsx
@@ -28,8 +28,9 @@ import {
 } from '@/components/meter/metering-icons';
 import { PermissionFallback } from '@/components/meter/permission-fallback';
 import { RETICLE_SIZE, Reticle } from '@/components/meter/reticle';
-import { ScrubOverlay, useDragOffset } from '@/components/meter/scrub-overlay';
+import { ScrubOverlay } from '@/components/meter/scrub-overlay';
 import { SegmentedPill } from '@/components/meter/segmented-pill';
+import { useDragOffset } from '@/components/meter/use-drag-offset';
 import { useCalibration } from '@/hooks/use-calibration';
 import { useCameraMeter } from '@/hooks/use-camera-meter';
 import { useMeterCapture } from '@/hooks/use-meter-capture';

--- a/packages/ui/src/__tests__/components/toast.test.tsx
+++ b/packages/ui/src/__tests__/components/toast.test.tsx
@@ -1,12 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  Toast,
-  ToastProvider,
-  useOptionalToast,
-  useToast,
-} from '../../components/toast';
+import { Toast, ToastProvider } from '../../components/toast';
+import { useOptionalToast, useToast } from '../../components/toast-context';
 
 // Mock timers for testing animations and auto-dismiss
 beforeEach(() => {

--- a/packages/ui/src/components/border-calculator/border-calculator-context.tsx
+++ b/packages/ui/src/components/border-calculator/border-calculator-context.tsx
@@ -6,7 +6,7 @@ import type {
   SelectItem,
   useGeometryCalculations,
 } from '@dorkroom/logic';
-import { createContext, type ReactNode, use } from 'react';
+import { createContext, use } from 'react';
 import type { FormInstance } from '../../forms/utils/form-api-types';
 
 type GeometryCalculationResult = ReturnType<
@@ -87,23 +87,9 @@ export interface BorderCalculatorContextValue {
   currentSettings: BorderPresetSettings;
 }
 
-const BorderCalculatorContext = createContext<
+export const BorderCalculatorContext = createContext<
   BorderCalculatorContextValue | undefined
 >(undefined);
-
-interface BorderCalculatorProviderProps {
-  value: BorderCalculatorContextValue;
-  children: ReactNode;
-}
-
-export function BorderCalculatorProvider({
-  value,
-  children,
-}: BorderCalculatorProviderProps) {
-  return (
-    <BorderCalculatorContext value={value}>{children}</BorderCalculatorContext>
-  );
-}
 
 export function useBorderCalculator(): BorderCalculatorContextValue {
   const context = use(BorderCalculatorContext);

--- a/packages/ui/src/components/border-calculator/border-calculator-provider.tsx
+++ b/packages/ui/src/components/border-calculator/border-calculator-provider.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+import {
+  BorderCalculatorContext,
+  type BorderCalculatorContextValue,
+} from './border-calculator-context';
+
+interface BorderCalculatorProviderProps {
+  value: BorderCalculatorContextValue;
+  children: ReactNode;
+}
+
+export function BorderCalculatorProvider({
+  value,
+  children,
+}: BorderCalculatorProviderProps) {
+  return (
+    <BorderCalculatorContext value={value}>{children}</BorderCalculatorContext>
+  );
+}

--- a/packages/ui/src/components/border-calculator/index.ts
+++ b/packages/ui/src/components/border-calculator/index.ts
@@ -5,10 +5,8 @@ export { BladeReadingsSection } from './blade-readings-section';
 export { BladeResultsDisplay } from './blade-results-display';
 export { BladeVisualizationSection } from './blade-visualization-section';
 export type { BorderCalculatorContextValue } from './border-calculator-context';
-export {
-  BorderCalculatorProvider,
-  useBorderCalculator,
-} from './border-calculator-context';
+export { useBorderCalculator } from './border-calculator-context';
+export { BorderCalculatorProvider } from './border-calculator-provider';
 export { BorderInfoSection } from './border-info-section';
 export { BordersOffsetsSection } from './borders-offsets-section';
 export { MobileBorderCalculator } from './mobile-border-calculator';

--- a/packages/ui/src/components/border-calculator/mobile-border-calculator.tsx
+++ b/packages/ui/src/components/border-calculator/mobile-border-calculator.tsx
@@ -42,10 +42,8 @@ import { useMeasurementFormatter } from '../../hooks/use-measurement-conversion'
 import { AnimatedPreview } from './animated-preview';
 // Components
 import { BladeResultsDisplay } from './blade-results-display';
-import {
-  type BorderCalculatorContextValue,
-  BorderCalculatorProvider,
-} from './border-calculator-context';
+import type { BorderCalculatorContextValue } from './border-calculator-context';
+import { BorderCalculatorProvider } from './border-calculator-provider';
 // Sections
 import { BorderSizeSection } from './sections/border-size-section';
 import { PaperSizeSection } from './sections/paper-size-section';

--- a/packages/ui/src/components/share-button.tsx
+++ b/packages/ui/src/components/share-button.tsx
@@ -3,7 +3,7 @@ import { Loader2, Share2 } from 'lucide-react';
 import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { cn } from '../lib/cn';
-import { useOptionalToast } from './toast';
+import { useOptionalToast } from './toast-context';
 
 /**
  * Result returned from ShareButton's onClick callback to control toast display

--- a/packages/ui/src/components/toast-context.ts
+++ b/packages/ui/src/components/toast-context.ts
@@ -1,0 +1,21 @@
+import { createContext, use } from 'react';
+
+export type ToastType = 'success' | 'error' | 'info';
+
+export interface ToastContextValue {
+  showToast: (message: string, type?: ToastType) => void;
+}
+
+export const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function useOptionalToast(): ToastContextValue | null {
+  return use(ToastContext);
+}
+
+export function useToast(): ToastContextValue {
+  const context = use(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+}

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -1,18 +1,17 @@
 import { Check, X } from 'lucide-react';
 import {
-  createContext,
   type ReactNode,
-  use,
   useCallback,
   useEffect,
   useMemo,
   useState,
 } from 'react';
 import { cn } from '../lib/cn';
+import { ToastContext, type ToastType } from './toast-context';
 
 export interface ToastProps {
   message: string;
-  type?: 'success' | 'error' | 'info';
+  type?: ToastType;
   duration?: number;
   onClose?: () => void;
   isVisible?: boolean;
@@ -118,15 +117,6 @@ export interface ToastProviderProps {
   children: ReactNode;
 }
 
-export interface ToastContextValue {
-  showToast: (message: string, type?: ToastProps['type']) => void;
-}
-
-const ToastContext = createContext<ToastContextValue | null>(null);
-export function useOptionalToast(): ToastContextValue | null {
-  return use(ToastContext);
-}
-
 export function ToastProvider({ children }: ToastProviderProps) {
   const [toast, setToast] = useState<{
     message: string;
@@ -167,12 +157,4 @@ export function ToastProvider({ children }: ToastProviderProps) {
       )}
     </ToastContext>
   );
-}
-
-export function useToast(): ToastContextValue {
-  const context = use(ToastContext);
-  if (!context) {
-    throw new Error('useToast must be used within a ToastProvider');
-  }
-  return context;
 }

--- a/packages/ui/src/contexts/theme-context.tsx
+++ b/packages/ui/src/contexts/theme-context.tsx
@@ -1,15 +1,7 @@
-import {
-  createContext,
-  type ReactNode,
-  use,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { createContext, use } from 'react';
 import type { Theme } from '../lib/themes';
-import { resolveTheme } from '../lib/themes';
 
-interface ThemeContextValue {
+export interface ThemeContextValue {
   theme: Theme;
   resolvedTheme: 'light' | 'dark' | 'darkroom' | 'high-contrast';
   setTheme: (theme: Theme) => void;
@@ -17,133 +9,9 @@ interface ThemeContextValue {
   setAnimationsEnabled: (enabled: boolean) => void;
 }
 
-const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
-
-interface ThemeProviderProps {
-  children: ReactNode;
-}
-
-const STORAGE_KEY = 'dorkroom-theme';
-const ANIMATIONS_STORAGE_KEY = 'dorkroom-animations-enabled';
-
-// Read the persisted theme on first render. On the server (no localStorage) or
-// for a first-time visitor, default to 'system' and persist that default.
-function getInitialTheme(): Theme {
-  if (typeof localStorage === 'undefined') {
-    return 'system';
-  }
-  const saved = localStorage.getItem(STORAGE_KEY);
-  if (
-    saved === 'light' ||
-    saved === 'dark' ||
-    saved === 'darkroom' ||
-    saved === 'high-contrast' ||
-    saved === 'system'
-  ) {
-    return saved;
-  }
-  // First time visitor - default to system preference and save it
-  localStorage.setItem(STORAGE_KEY, 'system');
-  return 'system';
-}
-
-// Read the persisted animations preference on first render, defaulting to true.
-function getInitialAnimationsEnabled(): boolean {
-  if (typeof localStorage === 'undefined') {
-    return true;
-  }
-  const savedAnimations = localStorage.getItem(ANIMATIONS_STORAGE_KEY);
-  if (savedAnimations === 'true' || savedAnimations === 'false') {
-    return savedAnimations === 'true';
-  }
-  localStorage.setItem(ANIMATIONS_STORAGE_KEY, 'true');
-  return true;
-}
-
-export function ThemeProvider({ children }: ThemeProviderProps) {
-  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
-  const [resolvedTheme, setResolvedTheme] = useState<
-    'light' | 'dark' | 'darkroom' | 'high-contrast'
-  >('dark');
-  const [animationsEnabled, setAnimationsEnabledState] = useState(
-    getInitialAnimationsEnabled
-  );
-
-  // Update resolved theme when theme changes or system preference changes
-  useEffect(() => {
-    const updateResolvedTheme = () => {
-      const resolved = resolveTheme(theme);
-      setResolvedTheme(resolved);
-
-      // Apply theme to document
-      if (typeof document !== 'undefined') {
-        document.documentElement.setAttribute('data-theme', resolved);
-        // Always disable animations for darkroom and high-contrast themes
-        const shouldDisableAnimations =
-          resolved === 'darkroom' ||
-          resolved === 'high-contrast' ||
-          !animationsEnabled;
-        document.documentElement.setAttribute(
-          'data-animations-disabled',
-          shouldDisableAnimations ? 'true' : 'false'
-        );
-
-        // Sync iOS Safari's browser-chrome color (status bar + toolbar
-        // background-extension bands) to the active theme's background. The
-        // static meta in index.html is near-black (#09090b); without this it
-        // shows as a black band in light/high-contrast themes — most visibly
-        // at the top and behind the bottom toolbar while the mobile menu is
-        // open (the page is dimmed, so the chrome bands stand out).
-        const themeColorMeta = document.querySelector<HTMLMetaElement>(
-          'meta[name="theme-color"]'
-        );
-        if (themeColorMeta) {
-          const background = getComputedStyle(document.documentElement)
-            .getPropertyValue('--color-background')
-            .trim();
-          if (background) {
-            themeColorMeta.setAttribute('content', background);
-          }
-        }
-      }
-    };
-
-    updateResolvedTheme();
-
-    // Listen for system theme changes when using 'system'
-    if (theme === 'system') {
-      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-      const handleChange = () => updateResolvedTheme();
-
-      mediaQuery.addEventListener('change', handleChange);
-      return () => mediaQuery.removeEventListener('change', handleChange);
-    }
-
-    return undefined;
-  }, [theme, animationsEnabled]);
-
-  const contextValue = useMemo<ThemeContextValue>(() => {
-    const setTheme = (newTheme: Theme) => {
-      setThemeState(newTheme);
-      localStorage.setItem(STORAGE_KEY, newTheme);
-    };
-
-    const setAnimationsEnabled = (enabled: boolean) => {
-      setAnimationsEnabledState(enabled);
-      localStorage.setItem(ANIMATIONS_STORAGE_KEY, String(enabled));
-    };
-
-    return {
-      theme,
-      resolvedTheme,
-      setTheme,
-      animationsEnabled,
-      setAnimationsEnabled,
-    };
-  }, [theme, resolvedTheme, animationsEnabled]);
-
-  return <ThemeContext value={contextValue}>{children}</ThemeContext>;
-}
+export const ThemeContext = createContext<ThemeContextValue | undefined>(
+  undefined
+);
 
 export function useTheme() {
   const context = use(ThemeContext);

--- a/packages/ui/src/contexts/theme-provider.tsx
+++ b/packages/ui/src/contexts/theme-provider.tsx
@@ -1,0 +1,130 @@
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import type { Theme } from '../lib/themes';
+import { resolveTheme } from '../lib/themes';
+import { ThemeContext, type ThemeContextValue } from './theme-context';
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+const STORAGE_KEY = 'dorkroom-theme';
+const ANIMATIONS_STORAGE_KEY = 'dorkroom-animations-enabled';
+
+// Read the persisted theme on first render. On the server (no localStorage) or
+// for a first-time visitor, default to 'system' and persist that default.
+function getInitialTheme(): Theme {
+  if (typeof localStorage === 'undefined') {
+    return 'system';
+  }
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (
+    saved === 'light' ||
+    saved === 'dark' ||
+    saved === 'darkroom' ||
+    saved === 'high-contrast' ||
+    saved === 'system'
+  ) {
+    return saved;
+  }
+  // First time visitor - default to system preference and save it
+  localStorage.setItem(STORAGE_KEY, 'system');
+  return 'system';
+}
+
+// Read the persisted animations preference on first render, defaulting to true.
+function getInitialAnimationsEnabled(): boolean {
+  if (typeof localStorage === 'undefined') {
+    return true;
+  }
+  const savedAnimations = localStorage.getItem(ANIMATIONS_STORAGE_KEY);
+  if (savedAnimations === 'true' || savedAnimations === 'false') {
+    return savedAnimations === 'true';
+  }
+  localStorage.setItem(ANIMATIONS_STORAGE_KEY, 'true');
+  return true;
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+  const [resolvedTheme, setResolvedTheme] = useState<
+    'light' | 'dark' | 'darkroom' | 'high-contrast'
+  >('dark');
+  const [animationsEnabled, setAnimationsEnabledState] = useState(
+    getInitialAnimationsEnabled
+  );
+
+  // Update resolved theme when theme changes or system preference changes
+  useEffect(() => {
+    const updateResolvedTheme = () => {
+      const resolved = resolveTheme(theme);
+      setResolvedTheme(resolved);
+
+      // Apply theme to document
+      if (typeof document !== 'undefined') {
+        document.documentElement.setAttribute('data-theme', resolved);
+        // Always disable animations for darkroom and high-contrast themes
+        const shouldDisableAnimations =
+          resolved === 'darkroom' ||
+          resolved === 'high-contrast' ||
+          !animationsEnabled;
+        document.documentElement.setAttribute(
+          'data-animations-disabled',
+          shouldDisableAnimations ? 'true' : 'false'
+        );
+
+        // Sync iOS Safari's browser-chrome color (status bar + toolbar
+        // background-extension bands) to the active theme's background. The
+        // static meta in index.html is near-black (#09090b); without this it
+        // shows as a black band in light/high-contrast themes — most visibly
+        // at the top and behind the bottom toolbar while the mobile menu is
+        // open (the page is dimmed, so the chrome bands stand out).
+        const themeColorMeta = document.querySelector<HTMLMetaElement>(
+          'meta[name="theme-color"]'
+        );
+        if (themeColorMeta) {
+          const background = getComputedStyle(document.documentElement)
+            .getPropertyValue('--color-background')
+            .trim();
+          if (background) {
+            themeColorMeta.setAttribute('content', background);
+          }
+        }
+      }
+    };
+
+    updateResolvedTheme();
+
+    // Listen for system theme changes when using 'system'
+    if (theme === 'system') {
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      const handleChange = () => updateResolvedTheme();
+
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }
+
+    return undefined;
+  }, [theme, animationsEnabled]);
+
+  const contextValue = useMemo<ThemeContextValue>(() => {
+    const setTheme = (newTheme: Theme) => {
+      setThemeState(newTheme);
+      localStorage.setItem(STORAGE_KEY, newTheme);
+    };
+
+    const setAnimationsEnabled = (enabled: boolean) => {
+      setAnimationsEnabledState(enabled);
+      localStorage.setItem(ANIMATIONS_STORAGE_KEY, String(enabled));
+    };
+
+    return {
+      theme,
+      resolvedTheme,
+      setTheme,
+      animationsEnabled,
+      setAnimationsEnabled,
+    };
+  }, [theme, resolvedTheme, animationsEnabled]);
+
+  return <ThemeContext value={contextValue}>{children}</ThemeContext>;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -68,12 +68,9 @@ export { TextInput } from './components/text-input';
 export type { ThemeToggleProps } from './components/theme-toggle';
 export { ThemeToggle } from './components/theme-toggle';
 export type { ToastProps } from './components/toast';
-export {
-  Toast,
-  ToastProvider,
-  useOptionalToast,
-  useToast,
-} from './components/toast';
+export { Toast, ToastProvider } from './components/toast';
+export type { ToastContextValue, ToastType } from './components/toast-context';
+export { useOptionalToast, useToast } from './components/toast-context';
 export { ToggleSwitch } from './components/toggle-switch';
 export type { TooltipProps } from './components/tooltip';
 export { Tooltip } from './components/tooltip';
@@ -101,7 +98,8 @@ export {
   useTemperature,
 } from './contexts/temperature-context';
 // Theme
-export { ThemeProvider, useTheme } from './contexts/theme-context';
+export { useTheme } from './contexts/theme-context';
+export { ThemeProvider } from './contexts/theme-provider';
 // Volume
 export { useVolume, VolumeProvider } from './contexts/volume-context';
 // Forms (utilities only — components and schemas via @dorkroom/ui/forms)


### PR DESCRIPTION
## Why

react-doctor **0.7.8** re-weighted `only-export-components`, which knocked the scores down on current `main`:

| project | before | after |
| --- | --- | --- |
| `@dorkroom/source` | 97 | **100** |
| `@dorkroom/mobile` | 97 | **100** |
| `@dorkroom/logic` | 100 | **100** |
| `@dorkroom/ui` | 96 | **100** |

Every finding was the same shape: a context module exporting its Provider *component* next to its hooks/contexts, so Fast Refresh can't preserve state on edit.

## What

Split the component out of each flagged module so a file exports either components or non-components, never both:

- `packages/ui/src/contexts/theme-provider.tsx` (new) — `ThemeProvider`
- `packages/ui/src/components/border-calculator/border-calculator-provider.tsx` (new) — `BorderCalculatorProvider`
- `packages/ui/src/components/toast-context.ts` (new) — `ToastContext`, `useToast`, `useOptionalToast`
- `apps/dorkroom/.../context/recipe-provider.tsx` (new) — `RecipeProvider`
- `apps/mobile/src/components/meter/use-drag-offset.ts` (new) — `useDragOffset`

Public API is unchanged — the barrels (`@dorkroom/ui`, `border-calculator`, the recipes `context/index.ts`) re-export exactly the same names from the new paths.

This also **removes** the four existing `only-export-components` suppressions in `recipe-context.tsx` rather than adding four more.

## Verification

- `bun run test` — 20/20 turbo tasks, 88 test files, 1766 tests, 0 lint errors
- `npx react-doctor@latest` — 100/100 on all four projects

> Note: the Vercel check is currently failing repo-wide on an unrelated platform-side error (`Failed to load Builders after installing them: @vercel/node (peer-version-mismatch)`), which also reproduces when redeploying an untouched 4-day-old build.
