### PR TITLE
fix(vercel): bump pinned @vercel/node runtime to 5.8.26

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
   "framework": null,
   "functions": {
     "api/**/*.ts": {
-      "runtime": "@vercel/node@5.6.3"
+      "runtime": "@vercel/node@5.8.26"
     }
   },
   "env": {


### PR DESCRIPTION
## The failure

Every deployment — preview **and production** — has been failing for ~3.5 hours:

```
Installing Builder: @vercel/node@5.8.26
Error: Failed to load Builders after installing them:
@vercel/node@5.6.3 (version-mismatch). Retry the build.
```

## Why

The `5.6.3` in that error is **our own pin**, in `vercel.json`:

```json
"functions": { "api/**/*.ts": { "runtime": "@vercel/node@5.6.3" } }
```

Vercel rolled out CLI **56.5.0** today, which installs `@vercel/node@5.8.26` as its builder. That no longer satisfies the peer range of the pinned `5.6.3`, so the build dies before it even starts.

This looked platform-side at first — redeploying an *untouched* 4-day-old build failed identically — but that's simply because the old commits carry the same pin. Nothing about the recent merges caused it; the trigger was the CLI rollout, and the fix is on our side.

## The fix

Pin to the version the platform now installs.

## Verification

Preview-deployed straight off this commit (`vercel deploy` from a clean checkout of `main` + this one-line change):

- status **● Ready** (vs. Error on every build since the rollout)
- all five functions emitted: `api/combinations`, `api/developers`, `api/docs`, `api/filmdev`, `api/films`

## Follow-up

This class of breakage recurs whenever Vercel bumps its bundled builder. Worth considering dropping the explicit `runtime` pin so Vercel uses its default — deliberately not done here to keep the unblock surgical.
