### PR TITLE
fix(vercel): bump pinned @vercel/node runtime to 5.9.0

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
   "framework": null,
   "functions": {
     "api/**/*.ts": {
-      "runtime": "@vercel/node@5.8.26"
+      "runtime": "@vercel/node@5.9.0"
     }
   },
   "env": {


### PR DESCRIPTION
Every deploy has failed for the last ~4 days. It is not the platform — it's the stale runtime pin in `vercel.json`.

```
> Installing Builder: @vercel/node@5.9.0
Error: Failed to load Builders after installing them:
       @vercel/node@5.8.26 (version-mismatch)
```

Vercel's build CLI (58.1.0) now installs `@vercel/node@5.9.0`, but `vercel.json` pins `5.8.26`, and the mismatch aborts the build ~10s in — at builder install, before the app is compiled. Because it fails so early and identically on every branch, it reads as a platform outage.

### Evidence it's repo-wide, not PR-specific

The two most recent deploys (both `● Error`) are #173 and #174, two unrelated PRs — one docs-only, one a lockfile bump. The last successful deploys are 4 days old. Anything pushed right now fails the same way, `main` included.

### Why 5.9.0 and not 5.9.3

npm's current `@vercel/node` is 5.9.3, but the pin has to match **what the platform actually installs**, which the build log shows is 5.9.0. Pinning ahead of it would reproduce the same mismatch in the other direction.

### Recurrence

Same failure and same fix as 43bfa3f (`fix(vercel): bump pinned @vercel/node runtime to 5.8.26`). This pin goes stale every time Vercel moves its bundled builder, and there's no local signal — it only shows up as a red check. Worth considering whether the pin earns its keep, or whether dropping it (letting Vercel track its own builder) is better than re-fixing this periodically.

### Screenshots

None — build configuration only, no rendered output.

https://claude.ai/code/session_01LMPpC3CWyxxsG2m6RtGgXW
