### PR TITLE
fix: clear react-doctor 0.9.11 findings across web app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The iOS app has its own changelog: [`apps/mobile/CHANGELOG.md`](apps/mobile/CHAN
 
 This project uses [CalVer](https://calver.org/) date-based versioning: `YYYY.MM.DD`.
 
+## [2026.08.09]
+
+### Fixed
+
+- The bot meta endpoint (`api/meta.ts`) now checks the origin response status before rewriting it: because `fetch()` resolves (rather than rejects) on HTTP 4xx/5xx, a failing origin request could previously have its error page rewritten and served as a valid share card. It now returns a 502 instead.
+
+### Changed
+
+- The films / development-recipes filter sidebar memoizes its context value and collapse toggle, so consumers no longer re-render on every parent render. Collapse/expand transitions now name the property they animate (`transition-[width]`) instead of `transition-all`, and the hero preview and skip link use the curated `transition` utility, avoiding animation of unrelated properties.
+
 ## [2026.07.13]
 
 ### Changed

--- a/api/meta.ts
+++ b/api/meta.ts
@@ -179,6 +179,15 @@ export default async function handler(
   const originResponse = await fetch('https://dorkroom.art/', {
     headers: { 'x-bypass-meta': '1' },
   });
+
+  // fetch() resolves (does not reject) on HTTP 4xx/5xx. Injecting meta tags
+  // into an origin error payload would emit a broken card, so fail fast with a
+  // bad-gateway instead of rewriting an error page as if it were the document.
+  if (!originResponse.ok) {
+    res.status(502).send('Failed to fetch origin document');
+    return;
+  }
+
   let html = await originResponse.text();
 
   // Replace <title>. A function replacer is used for every substitution

--- a/apps/dorkroom/src/app/pages/development-recipes/components/recipe-results-section.tsx
+++ b/apps/dorkroom/src/app/pages/development-recipes/components/recipe-results-section.tsx
@@ -60,7 +60,7 @@ export const RecipeResultsSection: FC<RecipeResultsSectionProps> = (props) => {
   } = props;
 
   return (
-    <div className="transition-all duration-500 ease-in-out">
+    <div className="transition duration-500 ease-in-out">
       {(isLoading || isRefreshingData) && (
         <div className="space-y-4 animate-slide-fade-top">
           <div

--- a/apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
+++ b/apps/dorkroom/src/app/pages/development-recipes/development-recipes-page.tsx
@@ -567,7 +567,7 @@ export default function DevelopmentRecipesPage() {
         ) : (
           <div className="flex gap-4">
             <aside
-              className="flex-shrink-0 transition-all duration-300"
+              className="flex-shrink-0 transition-[width] duration-300"
               style={{ width: isFiltersSidebarCollapsed ? '64px' : '304px' }}
             >
               <FiltersSidebar

--- a/apps/dorkroom/src/app/pages/films/films-page.tsx
+++ b/apps/dorkroom/src/app/pages/films/films-page.tsx
@@ -102,7 +102,7 @@ function FilmsDesktopLayout({
 }) {
   return (
     <div className="mt-6 flex gap-6">
-      <aside className="flex-shrink-0 transition-all duration-300">
+      <aside className="flex-shrink-0 transition-[width] duration-300">
         <FilmFiltersPanel
           onCollapsedChange={onCollapsedChange}
           searchQuery={db.searchQuery}
@@ -357,7 +357,7 @@ export default function FilmsPage() {
       {/* Skip link for accessibility */}
       <a
         href="#film-results"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-lg focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 transition-all"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-lg focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 transition"
         style={{
           backgroundColor: 'var(--color-primary)',
           color: 'white',

--- a/apps/dorkroom/src/app/pages/home-hero-preview.tsx
+++ b/apps/dorkroom/src/app/pages/home-hero-preview.tsx
@@ -146,7 +146,7 @@ export function HomeHeroPreview() {
     >
       {/* The paper, with the print area and four easel blades */}
       <div
-        className="hero-preview-paper relative w-full overflow-hidden rounded-sm shadow-subtle transition-all group-hover/hero:-translate-y-0.5 group-hover/hero:shadow-lg"
+        className="hero-preview-paper relative w-full overflow-hidden rounded-sm shadow-subtle transition group-hover/hero:-translate-y-0.5 group-hover/hero:shadow-lg"
         style={{
           aspectRatio: `${PAPER.width} / ${PAPER.height}`,
           backgroundColor: 'var(--color-paper-background)',

--- a/packages/logic/src/hooks/development-recipes/use-recipe-url-state.ts
+++ b/packages/logic/src/hooks/development-recipes/use-recipe-url-state.ts
@@ -458,6 +458,7 @@ export const useRecipeUrlState = (
   useEffect(() => {
     if (initialUrlState.fromUrl) {
       isInitializedRef.current = true;
+      // eslint-disable-next-line react-doctor/no-adjust-state-on-prop-change -- this is a one-time init gate flipped after the URL-derived state commits (see comment above), not a per-change adjustment users would see go stale; it synchronizes with the external URL, a valid effect use
       setIsInitialized(true);
     }
   }, [initialUrlState]);

--- a/packages/logic/src/hooks/use-url-preset-loader.ts
+++ b/packages/logic/src/hooks/use-url-preset-loader.ts
@@ -1,3 +1,4 @@
+/* eslint-disable react-doctor/no-adjust-state-on-prop-change -- this hook synchronizes React state with an external system (the URL `?preset=`/`#preset` params plus `hashchange` events), a documented valid effect use, not "adjusting state when a prop changes." No prop is tracked; the rule's heuristic misfires on every setter transitively reachable from the load effects. */
 import { useCallback, useEffect, useState } from 'react';
 import type { BorderPresetSettings } from '../types/border-calculator';
 import { decodePreset, isValidEncodedPreset } from '../utils/preset-sharing';

--- a/packages/logic/src/hooks/use-window-dimensions.ts
+++ b/packages/logic/src/hooks/use-window-dimensions.ts
@@ -31,6 +31,7 @@ export function useWindowDimensions() {
     height: isBrowser() ? window.innerHeight : DEFAULT_HEIGHT,
   });
 
+  // eslint-disable-next-line react-doctor/effect-needs-cleanup -- the debounce timer handle is held in effect scope and cleared in the returned cleanup (and before each re-arm); the setTimeout inside handleResize is fully owned, the analyzer just can't trace the handle through the nested function
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
 

--- a/packages/ui/src/components/calculator/info-card.tsx
+++ b/packages/ui/src/components/calculator/info-card.tsx
@@ -123,6 +123,7 @@ export function InfoCardList({
   return (
     <ul className={cn('space-y-3', className)}>
       {normalizedItems.map((item, index) => (
+        // eslint-disable-next-line react-doctor/no-array-index-as-key -- static, read-only info list that never reorders or filters; the index fallback only applies to items with an empty title, so there is no stable id to key on and no data-mismatch risk
         <InfoCard key={item.title || index} item={item} variant={variant} />
       ))}
     </ul>

--- a/packages/ui/src/components/drawer.tsx
+++ b/packages/ui/src/components/drawer.tsx
@@ -57,6 +57,7 @@ export function Drawer({
 
   const runCloseTransition = useCallback(() => {
     setTransition((prev) => ({ ...prev, animateOpen: false }));
+    // eslint-disable-next-line react-doctor/effect-needs-cleanup -- the timer handle is captured and released by the returned `() => clearTimeout(timer)` cleanup, which the effect below wires up; the analyzer can't trace the handle out through this useCallback return
     const timer = setTimeout(
       () => setTransition((prev) => ({ ...prev, showContent: false })),
       300

--- a/packages/ui/src/components/filters/filter-panel-container.tsx
+++ b/packages/ui/src/components/filters/filter-panel-container.tsx
@@ -1,5 +1,5 @@
 import { ChevronRight, Filter } from 'lucide-react';
-import { type FC, type ReactNode, useState } from 'react';
+import { type FC, type ReactNode, useCallback, useMemo, useState } from 'react';
 import { cn } from '../../lib/cn';
 import { setStyles } from '../../lib/dom';
 import { FilterPanelContext } from './filter-panel-context';
@@ -40,20 +40,24 @@ export const FilterPanelContainer: FC<FilterPanelContainerProps> = ({
   const isControlled = collapsed !== undefined;
   const isCollapsed = isControlled ? collapsed : internalCollapsed;
 
-  const toggle = () => {
+  const toggle = useCallback(() => {
     const newCollapsed = !isCollapsed;
     if (!isControlled) {
       setInternalCollapsed(newCollapsed);
     }
     onCollapsedChange?.(newCollapsed);
-  };
+  }, [isCollapsed, isControlled, onCollapsedChange]);
 
-  const contextValue = {
-    isCollapsed,
-    toggle,
-    activeFilterCount,
-    hasActiveFilters,
-  };
+  // Memoize so consumers don't redraw on every render of this container.
+  const contextValue = useMemo(
+    () => ({
+      isCollapsed,
+      toggle,
+      activeFilterCount,
+      hasActiveFilters,
+    }),
+    [isCollapsed, toggle, activeFilterCount, hasActiveFilters]
+  );
 
   // Collapsed state - show only toggle button and filter badge
   if (isCollapsed) {


### PR DESCRIPTION
## Summary

React Doctor's unpinned `@latest` moved from **0.7.7** (the version noted in `CLAUDE.md`) to **0.9.11**, and its expanded ruleset surfaced **20 findings on code that hasn't changed** (last real edits to the flagged files were ~2026-07-14). This PR takes the score back to **no issues found** by fixing the genuine problems and suppressing the false positives with justifying comments (matching the repo's existing `eslint-disable-next-line react-doctor/...` pattern).

> Note: React Doctor's numeric score API is unreachable from the CI/agent environment (the host is blocked by egress policy → `403`), so `react-doctor` prints "Score unavailable". The full local scan reporting **"No issues found!"** is the reliable signal here.

## Related Issues

<!-- none -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Data addition (film, developer, or recipe entries)

## Changes Made

**Genuine fixes**

- `api/meta.ts` — check `originResponse.ok` before rewriting the fetched document. `fetch()` resolves (does not reject) on HTTP 4xx/5xx, so an origin error page could previously be meta-injected and served as a valid share card; now returns `502`. (`no-fetch-response-used-without-status-check`)
- `filter-panel-container.tsx` — memoize the context value (`useMemo`) and the collapse `toggle` (`useCallback`) so filter consumers no longer re-render on every parent render. (`context-provider-value-from-unmemoized-local-literal`)
- `transition-all` → named properties, behavior-preserving: `transition-[width]` on the two collapsible sidebars (width is the only thing that changes), curated `transition` on the hero preview (transform + shadow), results section, and skip link. (`no-transition-all`)

**False positives suppressed with justification**

- `effect-needs-cleanup` (2, reported as errors) — timers are fully cleaned up, just through indirection the analyzer can't trace: `use-window-dimensions.ts` (handle in effect scope, cleared in the returned cleanup) and `drawer.tsx` (handle released by the `useCallback`'s returned `() => clearTimeout(...)` that the effect wires up).
- `no-adjust-state-on-prop-change` (9) — `use-url-preset-loader.ts` (8) and `use-recipe-url-state.ts` (1) synchronize React state with an **external system** (URL `?preset=`/`#preset` params, `hashchange` events, one-time init gate). No prop is tracked; this is a documented valid effect use.
- `no-array-index-as-key` (1) — `info-card.tsx` is a static, read-only info list that never reorders or filters; the index fallback only applies to empty-title items, so there is no stable id and no data-mismatch risk.

## Testing

- [x] I have run `bun run test` and all checks pass (20/20 turbo tasks, 1766 tests)
- [ ] I have added tests that prove my fix/feature works
- [ ] I have tested manually in the development environment

`npx react-doctor@latest --verbose` → **No issues found!** across all four projects.

## Checklist

- [x] My code follows the project's code style
- [x] I have formatted my code with `bun run format`
- [x] I have made corresponding changes to documentation (if applicable) — `CHANGELOG.md`
- [x] My changes generate no new warnings
- [x] I have checked that there are no circular dependencies between packages

## Screenshots

No meaningful rendered-output change. The `transition-all` → named-property swaps are behavior-preserving (the properties that actually animate are the same; only `transition-all`'s coverage of unchanging properties is dropped), and the context-value memoization / lint suppressions produce no visual difference. Animation timing isn't captured by static screenshots.

## Additional Notes

The flagged code was unchanged — these findings are purely from the react-doctor version bump. Worth re-checking on the next react-doctor upgrade (per the `CLAUDE.md` health-score notes), and dropping any suppression whose upstream heuristic gets fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jy3j7G4SMfF2bmdeL3dxrJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jy3j7G4SMfF2bmdeL3dxrJ)_