### PR TITLE
chore(deps): add Renovate to cover the typescript-7 alias

### DIFF
--- a/.claude/skills/toolchain/SKILL.md
+++ b/.claude/skills/toolchain/SKILL.md
@@ -38,14 +38,24 @@ description: Dorkroom's lint/format/typecheck/dependency toolchain — oxlint, B
   `.github/dependabot.yml` ignores `typescript` majors so the 6→7 bump stops being re-proposed;
   lift the hold and collapse the two packages once 7.1 restores the API (Microsoft's stated window
   is 3–4 months from the 7.0 RC, so roughly Q4 2026).
-- **Nothing watches `typescript-7` — bump it by hand.** Dependabot silently skips aliased packages
-  in the `bun` ecosystem
+- **Renovate watches `typescript-7`; Dependabot cannot see it.** Dependabot silently skips aliased
+  packages in the `bun` ecosystem
   ([dependabot-core#15847](https://github.com/dependabot/dependabot-core/issues/15847)): the alias
   is misparsed as a subdependency, so no update is proposed and no warning is emitted. That is why
-  the pin sat on the moving `rc` dist-tag from #133 until it was caught manually. Until that issue
-  closes, `typescript-7` is the one dependency with no automated coverage — check it whenever you
-  touch the toolchain (`bun pm view typescript` for the current 7.x release, then
-  `bun update typescript-7`).
+  the pin sat on the moving `rc` dist-tag from #133 until it was caught manually. `renovate.json`
+  exists solely to close that one gap — **every other dependency is disabled in it**, so the two
+  bots never race. Two things about that config are load-bearing:
+  - It matches on **`matchDepNames: ["typescript-7"]`, not `matchPackageNames`.** The alias resolves
+    to `packageName: "typescript"`, so a `matchPackageNames` rule would also match the 6.x
+    compiler-API pin and propose exactly the 6→7 bump that breaks the Vercel build.
+  - It sets **`rangeStrategy: "bump"`.** The dep is a caret range (`^7.0.2`), so under the default
+    `replace` strategy an in-range release like 7.1.0 would satisfy it and produce **no PR** — and
+    7.1 is precisely the release we are waiting for. `bump` moves the floor, so 7.1 arrives as a
+    visible PR.
+  - `minimumReleaseAge: "7 days"` mirrors the `bunfig.toml` soak gate, so Renovate never proposes a
+    version `bun install` would refuse.
+  - Renovate requires the GitHub App to be installed on the repo; the config file alone does
+    nothing. If `typescript-7` ever goes quiet for a long stretch, check that first.
 - **Don't reach for the `@typescript/typescript6` compat wrapper** that the announcement recommends
   (`typescript@npm:@typescript/typescript6`). Under bun 1.3.11 it self-destructs: the wrapper's
   `@typescript/old` → `npm:typescript@^6` dependency dedupes against the `typescript` alias key and

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
       # subdependency and no update is ever proposed, with no warning:
       # https://github.com/dependabot/dependabot-core/issues/15847
       # That is why the alias sat on the `rc` dist-tag from #133 until it was
-      # caught by hand. Bump `typescript-7` manually until that issue closes.
+      # caught by hand. Renovate covers that one dependency instead — see
+      # `renovate.json`, which disables everything else so the two bots do not
+      # race. Once #15847 ships, this repo could drop back to Dependabot alone.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,8 @@ Lint with `oxlint`, format with Biome. Typecheck/build run on **stable
 TypeScript 7** via the `typescript-7` npm alias; `typescript` is deliberately
 held on **6.x** because TS 7.0 ships no programmatic API and `@vercel/node`
 resolves `typescript` from the project to build `api/**/*.ts` — do not collapse
-the two. Nothing automated watches the `typescript-7` alias; bump it by hand.
+the two. Dependabot is blind to the `typescript-7` alias, so **Renovate** covers
+that one dependency (`renovate.json`) — do not let Renovate manage anything else.
 Type-aware rules run separately via `bun run lint:types` and are not yet in the
 CI gate. Dependency pinning is two-tier, backstopped by the `bunfig.toml`
 `minimumReleaseAge` gate. See the `toolchain` skill (`.claude/skills/toolchain/`)

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":semanticCommitTypeAll(chore)"],
+  "timezone": "America/Los_Angeles",
+  "schedule": ["before 9am on monday"],
+  "labels": ["dependencies"],
+  "dependencyDashboard": false,
+  "vulnerabilityAlerts": { "enabled": false },
+  "osvVulnerabilityAlerts": false,
+  "packageRules": [
+    {
+      "description": "Dependabot owns every dependency in this repo. Renovate is here for the single dependency Dependabot cannot see, so disable everything by default and let the allow-rule below opt one dep back in. Without this the two bots race and open duplicate PRs.",
+      "matchPackageNames": ["*"],
+      "enabled": false
+    },
+    {
+      "description": "The TypeScript 7 compiler is installed as an npm alias (typescript-7 = npm:typescript@^7.0.2). Dependabot silently skips aliased packages in the bun ecosystem (dependabot-core#15847) - no PR, no warning - which is how this pin sat on the moving `rc` dist-tag unnoticed. Renovate covers it. Match on depName, NOT packageName: the alias resolves to packageName `typescript`, which would also match the 6.x compiler-API pin that must stay on 6 until TS 7.1 restores the API.",
+      "matchDepNames": ["typescript-7"],
+      "enabled": true,
+      "rangeStrategy": "bump",
+      "minimumReleaseAge": "7 days",
+      "commitMessageTopic": "the TypeScript 7 compiler (`typescript-7` alias)"
+    }
+  ]
+}


### PR DESCRIPTION
Closes the one gap in this repo's dependency automation.

## Why

`typescript-7` (`npm:typescript@^7.0.2`) is the compiler every `build`/`typecheck` script actually invokes, and **nothing watches it.** Dependabot silently skips aliased packages in the `bun` ecosystem — the alias is misparsed as a subdependency, so no PR is opened and no warning is emitted ([dependabot-core#15847](https://github.com/dependabot/dependabot-core/issues/15847), opened 2026-08-10). The repo's own history bears this out: Dependabot has bumped `typescript` twice (#87, #177) and `typescript-7` **zero** times since the alias landed in #133. That is exactly how the pin sat on the moving `rc` dist-tag until it was caught by hand in #186.

## What this does

Renovate is scoped to that single dependency. Every other package is disabled in `renovate.json`, so it never races Dependabot, and security alerts stay off so Dependabot remains the only source of those.

Two settings are load-bearing and easy to get wrong:

| Setting | Why |
| --- | --- |
| `matchDepNames: ["typescript-7"]` | The alias resolves to `packageName: "typescript"`. A `matchPackageNames` rule would **also** match the 6.x compiler-API pin and re-propose the 6→7 bump that breaks the Vercel build (the #177 failure). `matchDepNames` is the only selector that separates them. |
| `rangeStrategy: "bump"` | The dep is a caret range. Under Renovate's default `replace` strategy, an in-range release like **7.1.0 would satisfy `^7.0.2` and produce no PR at all** — and 7.1 is the release we're waiting on to collapse the 6/7 split. `bump` moves the floor so it arrives as a visible PR. |

`minimumReleaseAge: "7 days"` mirrors the `bunfig.toml` soak gate, so Renovate never proposes a version `bun install --frozen-lockfile` would then refuse.

## Verification

Ran Renovate locally against this repo — `renovate --platform=local --dry-run=lookup` on 44.7.2:

- **Extraction confirms the alias is seen correctly:** `depName: typescript-7`, `packageName: typescript`, `npmPackageAlias: true`, `currentValue: ^7.0.2`, under the **bun** manager (so it maintains `bun.lock` — important, since CI runs `bun install --frozen-lockfile`).
- **Unconfigured**, Renovate wanted to open ~40 branches, including the dangerous plain-`typescript` 6→7 bump.
- **With this config**, zero branches (correct — 7.0.2 is the newest stable 7.x).
- **Positive test:** with the alias temporarily downgraded to `^6.0.0`, the *only* branches proposed were `renovate/typescript-7-6.x` and `renovate/typescript-7-7.x`. Everything else stayed disabled, and the plain `typescript` dep produced no branch — confirming the `matchDepNames` targeting works.
- `renovate-config-validator`: passes.
- `bun run test`: 20/20 tasks.

## Required manual step

**The Renovate GitHub App must be installed on this repo** — the config file alone does nothing, and the app has never run here. Free for public repos: https://github.com/apps/renovate

I'd recommend the App over a self-hosted Actions workflow here specifically because PRs created with `GITHUB_TOKEN` do not trigger other workflows, so a self-hosted runner's PRs would never run `build-and-test` — which is the check that matters most for a lockfile change.

Docs updated in the same commit (`CLAUDE.md`, the `toolchain` skill, and the `dependabot.yml` comment), since all three previously said `typescript-7` had to be bumped by hand.

## Screenshots

None — config and docs only, no rendered output.