### PR TITLE
fix(mobile): restore Tailwind v3, guard the v3/v4 workspace split

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,21 @@ updates:
       # race. Once #15847 ships, this repo could drop back to Dependabot alone.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # `tailwindcss` is intentionally at two different MAJORS in this repo:
+      # the web app is on v4, and apps/mobile is held on v3 because NativeWind
+      # v4 hard-requires Tailwind v3 (apps/mobile/scripts/link-nativewind-
+      # tailwind.mjs exists solely to symlink v3 into NativeWind).
+      #
+      # Dependabot cannot express that. It treats the workspace as one version
+      # domain and unifies the constraint across every manifest, so PR #187 —
+      # labelled "tailwindcss 4.3.0 to 4.3.3" — silently rewrote apps/mobile
+      # from ^3.4.17 to ^4.3.3, a v3->v4 major that breaks NativeWind. CI did
+      # not catch it: the mobile `build` script is a no-op and nothing in CI
+      # builds the native app.
+      #
+      # Note an `update-types: [semver-major]` ignore would NOT have stopped
+      # that, because from Dependabot's point of view it was a *patch* bump.
+      # The only reliable guard is ignoring the package outright here and
+      # letting Renovate own it — Renovate reads each manifest separately and
+      # keeps the two majors independent. See `renovate.json`.
+      - dependency-name: "tailwindcss"

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -63,7 +63,7 @@
     "@types/react": "~19.2.14",
     "lucide-static": "^1.18.0",
     "sharp": "^0.35.3",
-    "tailwindcss": "^4.3.3",
+    "tailwindcss": "^3.4.17",
     "typescript": "~6.0.3",
     "vitest": "4.1.10"
   },

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,18 @@
       "rangeStrategy": "bump",
       "minimumReleaseAge": "7 days",
       "commitMessageTopic": "the TypeScript 7 compiler (`typescript-7` alias)"
+    },
+    {
+      "description": "Tailwind is at two different majors on purpose: v4 for the web app, v3 for apps/mobile (NativeWind v4 hard-requires v3). Dependabot treats the workspace as one version domain and unified them, which is how PR #187 rewrote apps/mobile from ^3.4.17 to ^4.3.3 while calling itself a patch bump. Renovate reads each manifest separately, so it is the tool that can hold the two apart. Dependabot now ignores tailwindcss entirely.",
+      "matchDepNames": ["tailwindcss"],
+      "enabled": true,
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Hard ceiling: apps/mobile must never be offered Tailwind v4. NativeWind v4 refuses to run against it ('NativeWind only supports Tailwind CSS v3'), and nothing in CI would catch the break because the mobile build script is a no-op.",
+      "matchDepNames": ["tailwindcss"],
+      "matchFileNames": ["apps/mobile/package.json"],
+      "allowedVersions": "<4"
     }
   ]
 }


### PR DESCRIPTION
**Fixes a regression introduced today by #187.** Main is currently broken for mobile development.

## What happened

#187 was titled "bump tailwindcss from 4.3.0 to 4.3.3". For the root web app that is exactly what it was. For `apps/mobile` it rewrote `^3.4.17` → `^4.3.3` — **a v3→v4 major**. Dependabot treats the bun workspace as a single version domain and unifies the constraint across every manifest, so the major was hidden inside a patch-labelled PR.

`apps/mobile` is held on Tailwind v3 deliberately: NativeWind v4 hard-requires it and refuses to run against v4 (`NativeWind only supports Tailwind CSS v3`). That is the entire reason `apps/mobile/scripts/link-nativewind-tailwind.mjs` exists — it symlinks the nested v3 into NativeWind's own `node_modules`. With mobile declaring v4, the script no-ops and NativeWind resolves the root's v4.

**Why nothing caught it:** the mobile `build` script is literally `echo 'no-op: native app builds run via expo/EAS, not turbo'`, no CI job builds the native app, and stale `node_modules` kept a working v3 on disk locally. It only surfaced after a clean reinstall.

## The guard

Ignoring `tailwindcss` majors in Dependabot **would not have prevented this** — from Dependabot's point of view it *was* a patch bump. The only reliable fix is to take the package away from Dependabot entirely and give it to Renovate, which reads each manifest separately and can hold two majors apart. `apps/mobile` also gets a hard `allowedVersions: "<4"` ceiling.

`tailwindcss` is the only package in the repo declared at different majors across manifests, so this is a targeted guard, not a general policy change.

## Verification

`renovate --platform=local --dry-run=lookup` on 44.7.2:

- Renovate extracts `tailwindcss` **twice, with independent constraints**: root `4.3.3` and mobile `^3.4.17`. Dependabot could not represent this.
- Steady state: no updates proposed (correct — both are current).
- **Positive test:** with mobile forced to `^2.0.0`, Renovate proposes `newVersion: 3.4.19` — stopping at v3 instead of jumping to v4 — and leaves the root v4 pin untouched.
- `renovate-config-validator`: passes.

Separately confirmed on the SDK 57 branch that reverting to `^3.4.17` makes the link script find v3 again (`[link-nw] NativeWind already resolves Tailwind v3 — ok`) and takes `expo-doctor` to 20/20.

## Screenshots

None — dependency and CI config only, no rendered output. The web app's Tailwind v4 is unchanged.