### PR TITLE
chore(ci): stop Dependabot bumping Expo SDK-managed native modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,61 @@ updates:
       # letting Renovate own it — Renovate reads each manifest separately and
       # keeps the two majors independent. See `renovate.json`.
       - dependency-name: "tailwindcss"
+      # ---------------------------------------------------------------------
+      # Expo SDK-managed native modules.
+      #
+      # `expo install` owns the versions of these packages: each Expo SDK
+      # release pins an exact compatible set (node_modules/expo/
+      # bundledNativeModules.json), and `npx expo install --fix` is the only
+      # correct way to change them. Dependabot does not know that matrix, so
+      # it proposes versions the SDK does not support — and nothing catches
+      # it, because the mobile `build` script is a no-op and no CI job builds
+      # the native app. The failure only appears at `eas build` or at runtime
+      # on a device.
+      #
+      # This is not hypothetical. Before the SDK 57 upgrade, Dependabot had
+      # pushed four native modules PAST what the SDK supported, and
+      # `expo install --fix` had to move them back DOWN:
+      #     react-native-gesture-handler   3.1.0  -> 2.32.0
+      #     react-native-worklets         0.11.3  -> 0.10.1
+      #     @shopify/react-native-skia     2.6.9  -> 2.6.2
+      #     react-native-svg             15.15.5  -> 15.15.4
+      # It had also bumped individual expo-* packages across an SDK boundary
+      # (expo-blur, expo-glass-effect, expo-image, expo-keep-awake to 57.x
+      # while `expo` itself stayed on ^56), which left duplicate native
+      # modules installed and expo-doctor failing 3 checks.
+      #
+      # To upgrade: bump the SDK deliberately with
+      #   cd apps/mobile && npx expo install expo@^<next> --fix
+      # then run `npx expo-doctor` and build to a device.
+      #
+      # NOT listed here on purpose:
+      #   * `react` / `react-dom` — Expo pins these too, but they are shared
+      #     with the web app at the repo root. Dependabot unifies a version
+      #     across every manifest (see the tailwindcss note above), so
+      #     ignoring them here would freeze the WEB app's React. The mobile
+      #     app instead deviates from Expo's pin via `expo.install.exclude`
+      #     in apps/mobile/package.json.
+      #   * react-native-vision-camera, react-native-mmkv,
+      #     react-native-nitro-modules, react-native-reorderable-list,
+      #     nativewind — native, but NOT in Expo's bundled list, so Expo does
+      #     not own their versions and Dependabot may legitimately bump them.
+      #     They still deserve a device build before merging.
+      #
+      # `expo-*` / `@expo/*` are wildcarded. That also catches
+      # `expo-quick-actions`, which is third-party and not SDK-pinned; it is
+      # a native module whose compatibility tracks the SDK anyway, so bump it
+      # alongside the SDK rather than on its own.
+      - dependency-name: "expo"
+      - dependency-name: "expo-*"
+      - dependency-name: "@expo/*"
+      - dependency-name: "babel-preset-expo"
+      - dependency-name: "react-native"
+      - dependency-name: "react-native-gesture-handler"
+      - dependency-name: "react-native-reanimated"
+      - dependency-name: "react-native-safe-area-context"
+      - dependency-name: "react-native-screens"
+      - dependency-name: "react-native-svg"
+      - dependency-name: "react-native-worklets"
+      - dependency-name: "@shopify/react-native-skia"
+      - dependency-name: "@react-native-community/slider"


### PR DESCRIPTION
Follow-up to #203. Closes the loop on a recurring failure mode.

## Why

`expo install` owns the versions of these packages. Each Expo SDK release pins an exact compatible set in `node_modules/expo/bundledNativeModules.json`, and `npx expo install --fix` is the only correct way to change them. Dependabot doesn't know that matrix, so it proposes versions the SDK doesn't support.

Nothing catches it. The mobile `build` script is literally `echo 'no-op: native app builds run via expo/EAS, not turbo'`, and no CI job builds the native app — so a bad bump sails through green CI and only surfaces at `eas build` or at runtime on a device.

**This already happened.** Before the SDK 57 upgrade, Dependabot had pushed four native modules *past* what the SDK supported, and `expo install --fix` had to move them back **down**:

| Package | Dependabot had | SDK 57 wants |
| --- | --- | --- |
| `react-native-gesture-handler` | 3.1.0 | **2.32.0** |
| `react-native-worklets` | 0.11.3 | **0.10.1** |
| `@shopify/react-native-skia` | 2.6.9 | **2.6.2** |
| `react-native-svg` | 15.15.5 | **15.15.4** |

It had also bumped individual `expo-*` packages across an SDK boundary (`expo-blur`, `expo-glass-effect`, `expo-image`, `expo-keep-awake` to 57.x while `expo` itself stayed on `^56`), which left **duplicate native modules** installed and `expo-doctor` failing 3 checks.

## Deliberately NOT ignored

**`react` / `react-dom`.** Expo pins these too, but they're shared with the web app at the repo root. Dependabot unifies a version across every manifest — the exact behaviour that turned a "tailwindcss 4.3.0 → 4.3.3" patch into a v3→v4 major for `apps/mobile` in #187, fixed in #202. Ignoring them here would freeze the **web app's** React. The mobile app instead deviates from Expo's pin via `expo.install.exclude` in `apps/mobile/package.json`.

**`react-native-vision-camera`, `react-native-mmkv`, `react-native-nitro-modules`, `react-native-reorderable-list`, `nativewind`.** Native modules, but *not* in Expo's bundled list, so Expo doesn't own their versions and Dependabot may legitimately bump them. They still deserve a device build before merging — that's a review-discipline problem, not a config one.

This is also why `react-native-*` is **not** wildcarded: it would have swept up all of the above.

## Verification

Cross-checked the patterns against `bundledNativeModules.json` intersected with what `apps/mobile` actually declares:

- **29 Expo-managed packages, 0 unguarded gaps**
- **0 community modules wrongly caught** by the `expo-*` / `@expo/*` wildcards
- YAML parses cleanly

One knowing exception: the `expo-*` wildcard also catches `expo-quick-actions`, which is third-party and not SDK-pinned. It's a native module whose compatibility tracks the SDK anyway, so bumping it alongside the SDK is the safer default. Documented inline.

## How to upgrade from now on

```
cd apps/mobile && npx expo install expo@^<next> --fix
npx expo-doctor
```
…then build to a device. #203 is the worked example.

## Screenshots

None — CI configuration only, no rendered output.