### PR TITLE
chore(ui): restore react-doctor 100/100 — suppress no-multi-component-file on colocated cell renderers

### DIFF
--- a/packages/ui/src/components/development-recipes/table-columns.tsx
+++ b/packages/ui/src/components/development-recipes/table-columns.tsx
@@ -188,7 +188,7 @@ const formatDilution = (row: DevelopmentCombinationView): string => {
  * Temperature cell renderer component - uses hook to get current temperature unit
  * Color coding: yellow (warning) + AlertTriangle for higher temps, blue (info) + Snowflake for lower temps
  */
-// eslint-disable-next-line react-doctor/no-multi-comp, react-doctor/only-export-components -- cell-renderer colocated with createTableColumns; the column factory references it directly and extracting fragments a cohesive module
+// eslint-disable-next-line react-doctor/no-multi-comp, react-doctor/no-multi-component-file, react-doctor/only-export-components -- cell-renderer colocated with createTableColumns; the column factory references it directly and extracting fragments a cohesive module
 function TemperatureCellRenderer({
   cellContext,
 }: {
@@ -237,7 +237,7 @@ function TemperatureCellRenderer({
  * For custom recipes, calculates pushPull from film.isoSpeed and shootingIso
  * to ensure accurate display regardless of the stored pushPull value.
  */
-// eslint-disable-next-line react-doctor/no-multi-comp, react-doctor/only-export-components -- cell-renderer colocated with createTableColumns; the column factory references it directly and extracting fragments a cohesive module
+// eslint-disable-next-line react-doctor/no-multi-comp, react-doctor/no-multi-component-file, react-doctor/only-export-components -- cell-renderer colocated with createTableColumns; the column factory references it directly and extracting fragments a cohesive module
 function IsoCellRenderer({
   cellContext,
 }: {
@@ -290,7 +290,7 @@ function IsoCellRenderer({
  * container so it isn't exposed as an interactive element itself; the child
  * (a real button) remains the focusable control.
  */
-// eslint-disable-next-line react-doctor/no-multi-comp, react-doctor/only-export-components -- cell-renderer colocated with createTableColumns; the column factory references it directly and extracting fragments a cohesive module
+// eslint-disable-next-line react-doctor/no-multi-comp, react-doctor/no-multi-component-file, react-doctor/only-export-components -- cell-renderer colocated with createTableColumns; the column factory references it directly and extracting fragments a cohesive module
 function StopPropagationWrapper({ children }: { children: React.ReactNode }) {
   return (
     <div
@@ -308,7 +308,7 @@ function StopPropagationWrapper({ children }: { children: React.ReactNode }) {
  * Extracted into a component so the handlers passed to the memoized
  * ActionIconButton can be stabilized with useCallback.
  */
-// eslint-disable-next-line react-doctor/no-multi-comp, react-doctor/only-export-components -- cell-renderer colocated with createTableColumns; the column factory references it directly and extracting fragments a cohesive module
+// eslint-disable-next-line react-doctor/no-multi-comp, react-doctor/no-multi-component-file, react-doctor/only-export-components -- cell-renderer colocated with createTableColumns; the column factory references it directly and extracting fragments a cohesive module
 function ActionsCell({
   view,
   context,


### PR DESCRIPTION
## Summary

react-doctor's latest ruleset (`react-doctor@0.9.12`) adds a **native** rule, `react-doctor/no-multi-component-file` ("Crowded component file"), distinct from the pre-existing external `react-doctor/no-multi-comp` rule. It fires on the four cell-renderer components colocated in `packages/ui/src/components/development-recipes/table-columns.tsx` that were already suppressed under `no-multi-comp`. Because the existing `eslint-disable` directives didn't include the new rule id, each renderer produced a fresh Maintainability warning (4 total), regressing the health score below 100/100.

This extends each of the four existing disable directives to also cover `react-doctor/no-multi-component-file`, honoring the same documented decision behind the original suppressions: these renderers are intentionally colocated with `createTableColumns` (the column factory references them directly; extracting them fragments a cohesive module). After the change, a full scan reports **zero findings** across all four projects.

This is the "re-check suppressions on each react-doctor upgrade" case the `react-doctor` skill explicitly calls out — no product code changed, only the ruleset did.

## Related Issues

<!-- none -->

## Type of Change

- [x] Refactoring (no functional changes)

## Changes Made

- Added `react-doctor/no-multi-component-file` to the four `eslint-disable-next-line` directives on `TemperatureCellRenderer`, `IsoCellRenderer`, `StopPropagationWrapper`, and `ActionsCell` in `table-columns.tsx`.

## Testing

- [x] I have run `bun run test` and all checks pass (20/20 turbo tasks successful, 1766 tests passing)
- [x] Verified `npx react-doctor@latest --verbose` reports **No issues found** after the change (before: 4 `no-multi-component-file` warnings)

Note: The react-doctor Score API and docs host are unreachable from this environment (blocked by the network egress proxy, HTTP 403), so the numeric score prints as "unavailable"; the pass criterion used here is react-doctor's zero-findings result.

## Checklist

- [x] My code follows the project's code style
- [x] I have formatted my code with `bun run format`
- [x] My changes generate no new warnings
- [x] I have checked that there are no circular dependencies between packages

## Screenshots

No rendered output changes — this is a comment-only change to lint-suppression directives; no route, shared component, theme token, or calculator result is affected.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Ppgfx2cpgftcPCTdcR8MU

---
_Generated by [Claude Code](https://claude.ai/code/session_013Ppgfx2cpgftcPCTdcR8MU)_